### PR TITLE
fix xiami bug

### DIFF
--- a/src/you_get/__main__.py
+++ b/src/you_get/__main__.py
@@ -58,7 +58,6 @@ def url_to_module(url):
         'youku': youku,
         'youtu': youtube,
         'youtube': youtube,
-        'songtaste':songtaste,
         #TODO
     }
     if k in downloads:

--- a/src/you_get/downloader/__init__.py
+++ b/src/you_get/downloader/__init__.py
@@ -36,4 +36,3 @@ from .xiami import *
 from .yinyuetai import *
 from .youku import *
 from .youtube import *
-from .songtaste import *


### PR DESCRIPTION
**the bug is string encode proplem. maybe it can not reproducing in other OS except windows.**
# environment

**win7**
**Python 3.2.1 (default, Jul 10 2011, 21:51:15) [MSC v.1500 32 bit (Intel)] on win32**
# setup

D:\mine\githubox>c:\Python32\python.exe you-get\you-get http://www.xiami.com/album/3332
# result

  File "D:\mine\githubox\you-get\src\you_get\downloader\xiami.py", line 34, in x
iami_download_lyric
    x.write(lrc)
UnicodeEncodeError: 'gbk' codec can't encode character '\ufffd' in position 142:
 illegal multibyte sequence
