### PR TITLE
fix album name replaces colon to placeholder

### DIFF
--- a/src/you_get/downloader/xiami.py
+++ b/src/you_get/downloader/xiami.py
@@ -67,6 +67,7 @@ def xiami_download_showcollect(cid, output_dir = '.', merge = True, info_only = 
 
     xml = get_html('http://www.xiami.com/song/playlist/id/%s/type/3' % cid, faker = True)
     doc = parseString(xml)
+    album_name = album_name.replace(':', ' ')
     output_dir =  output_dir + "/" + "[" + collect_name + "]"
     tracks = doc.getElementsByTagName("track")
     track_nr = 1


### PR DESCRIPTION
http://www.xiami.com/album/55568
the album name with a colon.

because the colon is not in file or directory name on windows OS.
replace the colon to placholder(blank charator).
