### PR TITLE
Fixed a bug. Videos with unicode characters in the title can now be down...

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -124,7 +124,18 @@ def filenameable(text):
             ord('['): '(',
             ord(']'): ')',
         })
+    # check for non-ascii characters in the videoname
+    text_asciiOnly = ''
+    for char in text:
+        if ord(char) < 128:
+            text_asciiOnly += char
+    # if the videoname has no ascii characters at all, set to 'unnamed'
+    if text_asciiOnly == '':
+        text = 'unnamed'
+    else:
+        text = text_asciiOnly
     return text
+    
 
 def unescape_html(html):
     from html import parser


### PR DESCRIPTION
Bug fixed: https://github.com/soimort/you-get/issues/217
and other unicode related bugs.

Characters of the video name that can't be represented as ascii-characters will be remoded from the to be generated filename.
If the video name consists of only not-convertable unicode characters, the filename will be set to unnamed.ext
