### PR TITLE
Fix for youtube.py - no longer works for VEVO / encrypted sig

### DIFF
--- a/src/you_get/extractor/youtube.py
+++ b/src/you_get/extractor/youtube.py
@@ -45,7 +45,7 @@ def decipher(js, s):
         code = re.sub(r'(\w+).split\(""\)', r'list(\1)', code)
         return code
     
-    f1 = match1(js, r'g.sig\|\|(\w+)\(g.s\)')
+    f1 = match1(js, r'\w+\.sig\|\|(\w+)\(\w+\.\w+\)')
     f1def = match1(js, r'(function %s\(\w+\)\{[^\{]+\})' % f1)
     code = tr_js(f1def)
     f2 = match1(f1def, r'(\w+)\(\w+,\d+\)')


### PR DESCRIPTION
No longer works on VEVO encoded videos such as http://www.youtube.com/watch?v=3O1_3zBUKM8
This more general regular expression fixes it.
