### PR TITLE
[YouTube] Fix for unable to download videos with encrypted sig (eg VEVO)

### DIFF
--- a/src/you_get/extractor/youtube.py
+++ b/src/you_get/extractor/youtube.py
@@ -31,7 +31,7 @@ yt_codecs = [
     {'itag': 36, 'container': '3GP', 'video_resolution': '240p', 'video_encoding': 'MPEG-4 Visual', 'video_profile': 'Simple', 'video_bitrate': '0.17', 'audio_encoding': 'AAC', 'audio_bitrate': '38'},
     {'itag': 17, 'container': '3GP', 'video_resolution': '144p', 'video_encoding': 'MPEG-4 Visual', 'video_profile': 'Simple', 'video_bitrate': '0.05', 'audio_encoding': 'AAC', 'audio_bitrate': '24'},
 ]
-##
+
 def decipher(js, s):
     def tr_js(code):
         code = re.sub(r'function', r'def', code)


### PR DESCRIPTION
No longer works on VEVO encoded videos such as http://www.youtube.com/watch?v=3O1_3zBUKM8
This more general regular expression fixes it.
