### PR TITLE
fix 404 of "%s/%s.html" in qq.py

### DIFF
--- a/src/you_get/extractor/qq.py
+++ b/src/you_get/extractor/qq.py
@@ -33,6 +33,11 @@ def qq_download(url, output_dir = '.', merge = True, info_only = False):
         vid = r1(r'http://static.video.qq.com/.*vid=(\w+)', url)
         url = "http://v.qq.com/page/%s.html" % vid
 
+    if re.match(r'http://v.qq.com/cover/.*\.html', url):
+        html = get_html(url)
+        vid = r1(r'vid:"([^"]+)"', html)
+        url = 'http://sns.video.qq.com/tvideo/fcgi-bin/video?vid=%s' % vid
+
     html = get_html(url)
 
     title = match1(html, r'<title>(.+?)</title>', r'title:"([^"]+)"')[0].strip()
@@ -40,7 +45,10 @@ def qq_download(url, output_dir = '.', merge = True, info_only = False):
     title = unescape_html(title)
     title = escape_file_path(title)
 
-    id = vid
+    try:
+        id = vid
+    except:
+        id = r1(r'vid:"([^"]+)"', html)
 
     qq_download_by_id(id, title, output_dir = output_dir, merge = merge, info_only = info_only)
 


### PR DESCRIPTION
Happy new year 抖Mort, long time no PR for the project.

I've tested this fix in

```
http://v.qq.com/cover/j/j873qv1h7x54oqb.html?vid=i00139tqu0r&start=155
http://y.qq.com/y/static/mv/mv_play.html?vid=g0013ztbsf2
http://static.video.qq.com/TPout.swf?auto=1&vid=q0111msw4jo
```

It's not quiet easy for me to fix this, I'm very happy when found the video title hidden in http://sns.video.qq.com/tvideo/fcgi-bin/video?vid= in wireshark(seems easier than searching in dev console), so I hope that you could write sth. like your [post before](http://www.soimort.org/posts/149) about grabbing videos , thanks a lot for the project.

I've also removed some spaces, they are not nice in vim with vividchalk color scheme. It would be great if you could remove them through the project.
