### PR TITLE
Support load cookies.txt

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -18,6 +18,7 @@ force = False
 player = None
 sogou_proxy = None
 sogou_env = None
+cookies_txt = None
 
 fake_headers = {
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',


### PR DESCRIPTION
Support load cookies.txt  

I need to download some private videos shared with me. This should be useful.

BTW, here's [a snippet](https://gist.github.com/hupili/9825148) to export cookies.txt from Chrome.
