### PR TITLE
bilibili: 如果标题包含非法文件名字符，保存评论时会报异常

### DIFF
--- a/src/you_get/extractor/bilibili.py
+++ b/src/you_get/extractor/bilibili.py
@@ -99,6 +99,7 @@ def bilibili_download(url, output_dir = '.', merge = True, info_only = False):
         raise NotImplementedError(flashvars)
     
     if not info_only:
+        title = legitimize(title)
         print('Downloading %s ...' % (title + '.cmt.xml'))
         xml = get_srt_xml(id)
         with open(os.path.join(output_dir, title + '.cmt.xml'), 'w', encoding='utf-8') as x:


### PR DESCRIPTION
if the video title contains invalid filename character, IOError(code=22)
is thrown when saving *.cmt.xml.

只有一行的小 patch，献丑了 :)
