### PR TITLE
Fixed miomio download of sina video

### DIFF
--- a/src/you_get/extractor/miomio.py
+++ b/src/you_get/extractor/miomio.py
@@ -4,7 +4,7 @@ __all__ = ['miomio_download']
 
 from ..common import *
 
-from .sina import sina_download_by_vid
+from .sina import sina_download_by_xml
 from .tudou import tudou_download_by_id
 from .youku import youku_download_by_vid
 
@@ -21,7 +21,9 @@ def miomio_download(url, output_dir = '.', merge = True, info_only = False):
     elif t == 'tudou':
         tudou_download_by_id(id, title, output_dir=output_dir, merge=merge, info_only=info_only)
     elif t == 'sina':
-        sina_download_by_vid(id, title, output_dir=output_dir, merge=merge, info_only=info_only)
+        url = "http://www.miomio.tv/mioplayer/mioplayerconfigfiles/sina.php?vid=" + id
+        xml = get_content (url, headers=fake_headers, decoded=True)
+        sina_download_by_xml(xml, title, output_dir=output_dir, merge=merge, info_only=info_only)
     else:
         raise NotImplementedError(flashvars)
 

--- a/src/you_get/extractor/sina.py
+++ b/src/you_get/extractor/sina.py
@@ -12,11 +12,13 @@ def get_k(vid, rand):
     t = str(int('{0:b}'.format(int(time()))[:-6], 2))
     return md5((vid + 'Z6prk18aWxP278cVAH' + t + rand).encode('utf-8')).hexdigest()[:16] + t
 
-def video_info(vid):
+def video_info_xml(vid):
     rand = "0.{0}{1}".format(randint(10000, 10000000), randint(10000, 10000000))
     url = 'http://v.iask.com/v_play.php?vid={0}&ran={1}&p=i&k={2}'.format(vid, rand, get_k(vid, rand))
     xml = get_content(url, headers=fake_headers, decoded=True)
+    return xml
 
+def video_info(xml):
     urls = re.findall(r'<url>(?:<!\[CDATA\[)?(.*?)(?:\]\]>)?</url>', xml)
     name = match1(xml, r'<vname>(?:<!\[CDATA\[)?(.+?)(?:\]\]>)?</vname>')
     vstr = match1(xml, r'<vstr>(?:<!\[CDATA\[)?(.+?)(?:\]\]>)?</vstr>')
@@ -27,11 +29,17 @@ def sina_download_by_vid(vid, title=None, output_dir='.', merge=True, info_only=
     http://video.sina.com.cn/
     """
 
-    urls, name, vstr = video_info(vid)
+    xml = video_info_xml(vid)
+    sina_download_by_urls(xml, title, output_dir, merge, info_only)
+
+
+def sina_download_by_xml(xml, title, output_dir, merge, info_only):
+    urls, name, vstr = video_info(xml)
     title = title or name
     assert title
     size = 0
     for url in urls:
+        print (url)
         _, _, temp = url_info(url)
         size += temp
 


### PR DESCRIPTION
Thanks for the useful program.  

When I tried to get a sina video from a miomio address, the current version `0.3.30dev-48cdcde` does not work.   Further analysis shows that miomio seems to be returning its own id for a video in sina.com, and its player calls an API: `http://www.miomio.tv/mioplayer/mioplayerconfigfiles/sina.php?vid=[vid returned by miomio]` to get the xml which should have been returned by http://v.iask.com previously. 

Hence the following patch, which I found to be working at least for me.
