### PR TITLE
fix ffmpeg version error

### DIFF
--- a/src/you_get/processor/ffmpeg.py
+++ b/src/you_get/processor/ffmpeg.py
@@ -18,11 +18,7 @@ def get_usable_ffmpeg(cmd):
     except:
         return None
 
-get_usable_ffmpeg_result = get_usable_ffmpeg('ffmpeg') or get_usable_ffmpeg('avconv')
-if get_usable_ffmpeg_result:
-    FFMPEG, FFMPEG_VERSION = get_usable_ffmpeg_result
-else:
-    FFMPEG, FFMPEG_VERSION = None, None
+FFMPEG, FFMPEG_VERSION = get_usable_ffmpeg('ffmpeg') or get_usable_ffmpeg('avconv') or (None, None)
 
 def has_ffmpeg_installed():
     return FFMPEG is not None


### PR DESCRIPTION
修复ffmpeg版本非数字时出错

Fix ffmpeg version error if it's not numerical.

For example: `N-45175-gd6711ee-`
