### PR TITLE
minor fix: b64decode takes only bytes not str

### DIFF
--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -44,6 +44,8 @@ class Youku(VideoExtractor):
 
             return result
 
+        ep = ep.encode('ascii') if isinstance(ep, str) else ep
+
         e_code = trans_e(f_code_1, base64.b64decode(ep))
         sid, token = e_code.split('_')
         new_ep = trans_e(f_code_2, '%s_%s_%s' % (sid, vid, token))


### PR DESCRIPTION
Found this issue when downloading a video from youku. The issue there is that self.ep could be a string instead of bytes. A very minor fix. 
