### PR TITLE
[Bilibili] Use default header

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -14,13 +14,6 @@ import re
 # API key provided by cnbeining
 appkey='85eb6835b0a1034e';
 secretkey = '2ad42749773c441109bdc0191257a664'
-client = {
-    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-    'Accept-Charset': 'UTF-8,*;q=0.5',
-    'Accept-Encoding': 'gzip,deflate,sdch',
-    'Accept-Language': 'en-US,en;q=0.8',
-    'User-Agent': 'Biligrab /0.8 (cnbeining@gmail.com)'
-}
 
 def get_srt_xml(id):
     url = 'http://comment.bilibili.com/%s.xml' % id
@@ -76,7 +69,7 @@ def bilibili_download_by_cids(cids, title, output_dir='.', merge=True, info_only
         urls += [i
                 if not re.match(r'.*\.qqvideo\.tc\.qq\.com', i)
                 else re.sub(r'.*\.qqvideo\.tc\.qq\.com', 'http://vsrc.store.qq.com', i)
-                for i in parse_cid_playurl(get_content(url, headers=client))]
+                for i in parse_cid_playurl(get_content(url, headers=fake_headers))]
 
     if re.search(r'\.(flv|hlv)\b', urls[0]):
         type = 'flv'
@@ -102,7 +95,7 @@ def bilibili_download_by_cid(id, title, output_dir='.', merge=True, info_only=Fa
     urls = [i
             if not re.match(r'.*\.qqvideo\.tc\.qq\.com', i)
             else re.sub(r'.*\.qqvideo\.tc\.qq\.com', 'http://vsrc.store.qq.com', i)
-            for i in parse_cid_playurl(get_content(url, headers=client))]
+            for i in parse_cid_playurl(get_content(url, headers=fake_headers))]
 
     if re.search(r'\.(flv|hlv)\b', urls[0]):
         type = 'flv'


### PR DESCRIPTION
It seems Bilibili is blocking requests with our old header, default Python header, or no header - now every request is redirected to a creepy video http://static.hdslb.com/error.mp4
We are switching to the default browser's header now, unless we have a better one.

cc. @cnbeining
