### PR TITLE
Add Letvcloud support, as in #422

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -898,7 +898,7 @@ def script_main(script_name, download, download_playlist = None):
             sys.exit(1)
 
 def url_to_module(url):
-    from .extractors import netease, w56, acfun, baidu, bilibili, blip, catfun, cntv, cbs, coursera, dailymotion, dongting, douban, ehow, facebook, freesound, google, sina, ifeng, alive, instagram, iqiyi, joy, jpopsuki, khan, ku6, kugou, kuwo, letv, magisto, miomio, mixcloud, mtv81, nicovideo, pptv, qq, sohu, songtaste, soundcloud, ted, theplatform, tudou, tucao, tumblr, vid48, videobam, vimeo, vine, vk, xiami, yinyuetai, youku, youtube
+    from .extractors import netease, w56, acfun, baidu, bilibili, blip, catfun, cntv, cbs, coursera, dailymotion, dongting, douban, ehow, facebook, freesound, google, sina, ifeng, alive, instagram, iqiyi, joy, jpopsuki, khan, ku6, kugou, kuwo, letv, letvcloud, magisto, miomio, mixcloud, mtv81, nicovideo, pptv, qq, sohu, songtaste, soundcloud, ted, theplatform, tudou, tucao, tumblr, vid48, videobam, vimeo, vine, vk, xiami, yinyuetai, youku, youtube
 
     video_host = r1(r'https?://([^/]+)/', url)
     video_url = r1(r'https?://[^/]+(.*)', url)
@@ -941,6 +941,7 @@ def url_to_module(url):
         'kugou': kugou,
         'kuwo': kuwo,
         'letv': letv,
+        'letvcloud': letvcloud,
         'magisto': magisto,
         'miomio': miomio,
         'mixcloud': mixcloud,

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -24,6 +24,7 @@ from .ku6 import *
 from .kugou import *
 from .kuwo import *
 from .letv import *
+from .letvcloud import *
 from .magisto import *
 from .miomio import *
 from .mixcloud import *

--- a/src/you_get/extractors/letvcloud.py
+++ b/src/you_get/extractors/letvcloud.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+__all__ = ['letvcloud_download', 'letvcloud_download_by_vu']
+
+from ..common import *
+import urllib.request
+import json
+import hashlib
+
+
+def letvcloud_download_by_vu(vu, title = None, output_dir = '.', merge = True, info_only = False):
+    str2Hash = 'cfflashformatjsonran0.7214574650861323uu2d8c027396ver2.1vu' + vu + 'bie^#@(%27eib58'
+    sign = hashlib.md5(str2Hash.encode('utf-8')).hexdigest()
+    request_info = urllib.request.Request('http://api.letvcloud.com/gpc.php?&sign='+sign+'&cf=flash&vu='+vu+'&ver=2.1&ran=0.7214574650861323&qr=2&format=json&uu=2d8c027396')
+    try:
+        response = urllib.request.urlopen(request_info)
+        data = response.read()
+        info = json.loads(data.decode('utf-8'))
+        if info['code'] == 0:
+            for i in info['data']['video_info']['media']:
+                type_available.append({'video_url': info['data']['video_info']['media'][i]['play_url']['main_url'], 'video_quality': int(info['data']['video_info']['media'][i]['play_url']['vtype'])})
+            url = [b64decode(sorted(type_available ,key = lambda x:x['video_quality'])[-1]['video_url'])]
+        else:
+            raise ValueError('Cannot get URL!')
+    except:
+        print('ERROR: Cannot get video URL!')
+    download_urls([url], title, ext, size, output_dir, merge = merge)
+
+
+def letvcloud_download(url, output_dir = '.', merge = True, info_only = False):
+    for i in url.split('&'):
+        if 'vu=' in i:
+            vu = i[3:]
+    if len(vu) == 0:
+        raise ValueError('Cannot get vu!')
+    letvcloud_download_by_vu(vu, title, output_dir, merge = merge, info_only = info_only)
+
+site_info = "Letvcloud"
+download = letvcloud_download
+download_playlist = playlist_not_supported('letvcloud')


### PR DESCRIPTION
There's one problem with the extractor:

The main extractor is failing to send `yuntv.ltev.com` to the right extractor, `letvcloud`.

I am feeling that fixing this problem is over my ability, so I 've finished everything else, hoping someone else would like to fix it up.

Now you can call `letvcloud_download_by_vu` to download Letvcloud's video.

P.S: I have to set the file permission to 755 in order to edit them. And I am sure you would need to re-edit them later, since the bug with the main extractor is left untouched. I would not say it is not working, but the effect is lower than my expectation.
