### PR TITLE
force override when concat files through ffmpeg

### DIFF
--- a/src/you_get/processor/ffmpeg.py
+++ b/src/you_get/processor/ffmpeg.py
@@ -26,7 +26,7 @@ def has_ffmpeg_installed():
 def ffmpeg_convert_ts_to_mkv(files, output='output.mkv'):
     for file in files:
         if os.path.isfile(file):
-            params = [FFMPEG, '-i']
+            params = [FFMPEG, '-y', '-i']
             params.append(file)
             params.append(output)
             subprocess.call(params)
@@ -42,7 +42,7 @@ def ffmpeg_concat_mp4_to_mpg(files, output='output.mpg'):
                 concat_list.write("file '%s'\n" % file)
         concat_list.close()
 
-        params = [FFMPEG, '-f', 'concat', '-i']
+        params = [FFMPEG, '-f', 'concat', '-y', '-i']
         params.append(output + '.txt')
         params += ['-c', 'copy', output]
 
@@ -54,7 +54,7 @@ def ffmpeg_concat_mp4_to_mpg(files, output='output.mpg'):
 
     for file in files:
         if os.path.isfile(file):
-            params = [FFMPEG, '-i']
+            params = [FFMPEG, '-y', '-i']
             params.append(file)
             params.append(file + '.mpg')
             subprocess.call(params)
@@ -64,7 +64,7 @@ def ffmpeg_concat_mp4_to_mpg(files, output='output.mpg'):
         for input in inputs:
             o.write(input.read())
 
-    params = [FFMPEG, '-i']
+    params = [FFMPEG, '-y', '-i']
     params.append(output + '.mpg')
     params += ['-vcodec', 'copy', '-acodec', 'copy']
     params.append(output)
@@ -79,7 +79,7 @@ def ffmpeg_concat_mp4_to_mpg(files, output='output.mpg'):
         raise
 
 def ffmpeg_concat_ts_to_mkv(files, output='output.mkv'):
-    params = [FFMPEG, '-isync', '-i']
+    params = [FFMPEG, '-isync', '-y', '-i']
     params.append('concat:')
     for file in files:
         if os.path.isfile(file):
@@ -103,7 +103,7 @@ def ffmpeg_concat_flv_to_mp4(files, output='output.mp4'):
                 concat_list.write("file '%s'\n" % file)
         concat_list.close()
 
-        params = [FFMPEG, '-f', 'concat', '-i']
+        params = [FFMPEG, '-f', 'concat', '-y', '-i']
         params.append(output + '.txt')
         params += ['-c', 'copy', output]
 
@@ -115,14 +115,14 @@ def ffmpeg_concat_flv_to_mp4(files, output='output.mp4'):
 
     for file in files:
         if os.path.isfile(file):
-            params = [FFMPEG, '-i']
+            params = [FFMPEG, '-y', '-i']
             params.append(file)
             params += ['-map', '0', '-c', 'copy', '-f', 'mpegts', '-bsf:v', 'h264_mp4toannexb']
             params.append(file + '.ts')
 
             subprocess.call(params)
 
-    params = [FFMPEG, '-i']
+    params = [FFMPEG, '-y', '-i']
     params.append('concat:')
     for file in files:
         f = file + '.ts'
@@ -149,7 +149,7 @@ def ffmpeg_concat_mp4_to_mp4(files, output='output.mp4'):
                 concat_list.write("file '%s'\n" % file)
         concat_list.close()
 
-        params = [FFMPEG, '-f', 'concat', '-i']
+        params = [FFMPEG, '-f', 'concat', '-y', '-i']
         params.append(output + '.txt')
         params += ['-c', 'copy', output]
 
@@ -161,14 +161,14 @@ def ffmpeg_concat_mp4_to_mp4(files, output='output.mp4'):
 
     for file in files:
         if os.path.isfile(file):
-            params = [FFMPEG, '-i']
+            params = [FFMPEG, '-y', '-i']
             params.append(file)
             params += ['-c', 'copy', '-f', 'mpegts', '-bsf:v', 'h264_mp4toannexb']
             params.append(file + '.ts')
 
             subprocess.call(params)
 
-    params = [FFMPEG, '-i']
+    params = [FFMPEG, '-y', '-i']
     params.append('concat:')
     for file in files:
         f = file + '.ts'


### PR DESCRIPTION
In some unknown circumstances, you-get will download same file again even if it exists, and ffmpeg will wait for use confirmation for overriding existing file and times out.

Added -y option to ffmpeg to resolve. File already downloaded again, why not overrides the original one?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/457)

<!-- Reviewable:end -->
