### PR TITLE
Accept vimeo https urls

### DIFF
--- a/src/you_get/extractors/vimeo.py
+++ b/src/you_get/extractors/vimeo.py
@@ -21,7 +21,7 @@ def vimeo_download_by_id(id, title = None, output_dir = '.', merge = True, info_
         download_urls([url], title, ext, size, output_dir, merge = merge, faker = True)
 
 def vimeo_download(url, output_dir = '.', merge = True, info_only = False):
-    id = r1(r'http://[\w.]*vimeo.com[/\w]*/(\d+)$', url)
+    id = r1(r'http[s]://[\w.]*vimeo.com[/\w]*/(\d+)$', url)
     assert id
     
     vimeo_download_by_id(id, None, output_dir = output_dir, merge = merge, info_only = info_only)


### PR DESCRIPTION
It is possible that a vimeo URL starts is secured with https. It would be awesome if it would be supported.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/462)
<!-- Reviewable:end -->
