### PR TITLE
Fix acfun

### DIFF
--- a/src/you_get/extractors/acfun.py
+++ b/src/you_get/extractors/acfun.py
@@ -21,25 +21,87 @@ def get_srt_lock_json(id):
     url = 'http://comment.acfun.tv/%s_lock.json' % id
     return get_html(url)
 
-def acfun_download_by_vid(vid, title=None, output_dir='.', merge=True, info_only=False):
-    info = json.loads(get_html('http://www.acfun.tv/video/getVideo.aspx?id=' + vid))
-    sourceType = info['sourceType']
-    sourceId = info['sourceId']
-    # danmakuId = info['danmakuId']
-    if sourceType == 'sina':
-        sina_download_by_vid(sourceId, title, output_dir=output_dir, merge=merge, info_only=info_only)
-    elif sourceType == 'youku':
-        youku_download_by_vid(sourceId, title=title, output_dir=output_dir, merge=merge, info_only=info_only)
-    elif sourceType == 'tudou':
-        tudou_download_by_iid(sourceId, title, output_dir=output_dir, merge=merge, info_only=info_only)
-    elif sourceType == 'qq':
-        qq_download_by_id(sourceId, title, output_dir=output_dir, merge=merge, info_only=info_only)
-    elif sourceType == 'letv':
-        letvcloud_download_by_vu(sourceId, title, output_dir=output_dir, merge=merge, info_only=info_only)
+# def acfun_download_by_vid(vid, title=None, output_dir='.', merge=True, info_only=False):
+#     info = json.loads(get_html('http://www.acfun.tv/video/getVideo.aspx?id=' + vid))
+#     sourceType = info['sourceType']
+#     sourceId = info['sourceId']
+#     # danmakuId = info['danmakuId']
+#     if sourceType == 'sina':
+#         sina_download_by_vid(sourceId, title, output_dir=output_dir, merge=merge, info_only=info_only)
+#     elif sourceType == 'youku':
+#         youku_download_by_vid(sourceId, title=title, output_dir=output_dir, merge=merge, info_only=info_only)
+#     elif sourceType == 'tudou':
+#         tudou_download_by_iid(sourceId, title, output_dir=output_dir, merge=merge, info_only=info_only)
+#     elif sourceType == 'qq':
+#         qq_download_by_id(sourceId, title, output_dir=output_dir, merge=merge, info_only=info_only)
+#     elif sourceType == 'letv':
+#         letvcloud_download_by_vu(sourceId, title, output_dir=output_dir, merge=merge, info_only=info_only)
+#     else:
+#         raise NotImplementedError(sourceType)
+
+#     if not info_only:
+#         title = get_filename(title)
+#         try:
+#             print('Downloading %s ...\n' % (title + '.cmt.json'))
+#             cmt = get_srt_json(vid)
+#             with open(os.path.join(output_dir, title + '.cmt.json'), 'w') as x:
+#                 x.write(cmt)
+#             # print('Downloading %s ...\n' % (title + '.cmt_lock.json'))
+#             # cmt = get_srt_lock_json(danmakuId)
+#             # with open(os.path.join(output_dir, title + '.cmt_lock.json'), 'w') as x:
+#             #     x.write(cmt)
+#         except:
+#             pass
+
+
+
+# decompile from player swf
+# protected static const VIDEO_PARSE_API:String = "http://jiexi.acfun.info/index.php?vid=";
+# protected static var VIDEO_RATES_CODE:Array = ["C40","C30","C20","C10"];
+# public static var VIDEO_RATES_STRING:Array = ["原画","超清","高清","流畅"];
+
+# Sometimes may find C80 but size smaller than C30 
+stream_types     = ["C40","C30","C20","C10"]
+stream_types_map = {"C10":"流畅","C20":"高清","C30":"超清","C40":"原画"}
+
+def acfun_download_by_vid(vid, title=None, output_dir='.', merge=True, info_only=False ,**kwargs):
+    #api example http://jiexi.acfun.info/index.php?vid=1122870
+    info = json.loads(get_content("http://jiexi.acfun.info/index.php?vid={}".format(vid)))
+    assert info["code"] == 200
+    assert info["success"] == True
+
+    support_types = sorted(info["result"].keys(),key= lambda i: int(i[1:]))
+
+    stream_id = None
+    if "stream_id" in kwargs and kwargs["stream_id"] in support_types:
+        stream_id = kwargs["stream_id"]
     else:
-        raise NotImplementedError(sourceType)
+        print("Current Video Supports:")
+        for i in support_types:
+            if info["result"][i]["totalbytes"] != 0:
+                print("\t--foramt",i,"<URL>:",info["result"][i]["quality"],"size:","%.2f"% (info["result"][i]["totalbytes"] / 1024.0 /1024.0),"MB")
+            else:
+                print("\t--foramt",i,"<URL>:",info["result"][i]["quality"])
+        #because C80 is not the best
+        if "C80" not in support_types:
+            stream_id = support_types[-1]
+        else:
+            stream_id = support_types[-2]
+
+    urls = [None] * len(info["result"][stream_id]["files"])
+    for i in info["result"][stream_id]["files"]:
+        urls[i["no"]] = i["url"]
+    ext = info["result"][stream_id]["files"][0]["type"]
+    size = 0
+    for i in urls:
+        _, _, tmp =url_info(i)
+        size +=tmp
+    print_info(site_info, title, ext, size)
+    print("Format:    ",stream_id)
+    print()
 
     if not info_only:
+        download_urls(urls, title, ext, size, output_dir = output_dir, merge = merge)
         title = get_filename(title)
         try:
             print('Downloading %s ...\n' % (title + '.cmt.json'))
@@ -52,8 +114,7 @@ def acfun_download_by_vid(vid, title=None, output_dir='.', merge=True, info_only
             #     x.write(cmt)
         except:
             pass
-
-def acfun_download(url, output_dir = '.', merge = True, info_only = False):
+def acfun_download(url, output_dir = '.', merge = True, info_only = False ,**kwargs):
     assert re.match(r'http://[^\.]+.acfun.[^\.]+/\D/\D\D(\d+)', url)
     html = get_html(url)
 
@@ -67,7 +128,7 @@ def acfun_download(url, output_dir = '.', merge = True, info_only = False):
         for video in videos:
             p_vid = video[0]
             p_title = title + " - " + video[1]
-            acfun_download_by_vid(p_vid, p_title, output_dir=output_dir, merge=merge, info_only=info_only)
+            acfun_download_by_vid(p_vid, p_title, output_dir=output_dir, merge=merge, info_only=info_only ,**kwargs)
     else:
         # Useless - to be removed?
         id = r1(r"src=\"/newflvplayer/player.*id=(\d+)", html)

--- a/src/you_get/extractors/acfun.py
+++ b/src/you_get/extractors/acfun.py
@@ -77,9 +77,9 @@ def acfun_download_by_vid(vid, title=None, output_dir='.', merge=True, info_only
         print("Current Video Supports:")
         for i in support_types:
             if info["result"][i]["totalbytes"] != 0:
-                print("\t--foramt",i,"<URL>:",info["result"][i]["quality"],"size:","%.2f"% (info["result"][i]["totalbytes"] / 1024.0 /1024.0),"MB")
+                print("\t--format",i,"<URL>:",info["result"][i]["quality"],"size:","%.2f"% (info["result"][i]["totalbytes"] / 1024.0 /1024.0),"MB")
             else:
-                print("\t--foramt",i,"<URL>:",info["result"][i]["quality"])
+                print("\t--format",i,"<URL>:",info["result"][i]["quality"])
         #because C80 is not the best
         if "C80" not in support_types:
             stream_id = support_types[-1]

--- a/src/you_get/extractors/acfun.py
+++ b/src/you_get/extractors/acfun.py
@@ -59,10 +59,8 @@ def get_srt_lock_json(id):
 # protected static const VIDEO_PARSE_API:String = "http://jiexi.acfun.info/index.php?vid=";
 # protected static var VIDEO_RATES_CODE:Array = ["C40","C30","C20","C10"];
 # public static var VIDEO_RATES_STRING:Array = ["原画","超清","高清","流畅"];
-
 # Sometimes may find C80 but size smaller than C30 
-stream_types     = ["C40","C30","C20","C10"]
-stream_types_map = {"C10":"流畅","C20":"高清","C30":"超清","C40":"原画"}
+
 
 def acfun_download_by_vid(vid, title=None, output_dir='.', merge=True, info_only=False ,**kwargs):
     #api example http://jiexi.acfun.info/index.php?vid=1122870
@@ -108,12 +106,9 @@ def acfun_download_by_vid(vid, title=None, output_dir='.', merge=True, info_only
             cmt = get_srt_json(vid)
             with open(os.path.join(output_dir, title + '.cmt.json'), 'w') as x:
                 x.write(cmt)
-            # print('Downloading %s ...\n' % (title + '.cmt_lock.json'))
-            # cmt = get_srt_lock_json(danmakuId)
-            # with open(os.path.join(output_dir, title + '.cmt_lock.json'), 'w') as x:
-            #     x.write(cmt)
         except:
             pass
+
 def acfun_download(url, output_dir = '.', merge = True, info_only = False ,**kwargs):
     assert re.match(r'http://[^\.]+.acfun.[^\.]+/\D/\D\D(\d+)', url)
     html = get_html(url)


### PR DESCRIPTION
introuce new api for acfun 
add support for choose different format of acfun's own definition
default format is C40 if exists
see example:

```
$ python3  you-get http://www.acfun.tv/v/ab1470184_2  
Current Video Supports:
	--foramt C00 <URL>: 单段_原画_MP4
	--foramt C10 <URL>: 单段_标清_MP4
	--foramt C20 <URL>: 单段_高清_MP4
	--foramt C30 <URL>: 单段_超清_MP4
	--foramt C40 <URL>: 单段_原画_MP4
	--foramt C80 <URL>: 单段_原画_MP4
Video Site: AcFun.tv
Title:      马路须加学园4 - 马路须加学园4
Type:       MPEG-4 video (video/mp4)
Size:       273.26 MiB (286538532 Bytes)

Format:     C40

Downloading 马路须加学园4 - 马路须加学园4.mp4 ...

```
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/480)
<!-- Reviewable:end -->
