### PR TITLE
Some bilibili has duplicate url

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -88,6 +88,12 @@ def bilibili_download_by_cids(cids, title, output_dir='.', merge=True, info_only
     else:
         type = 'flv'
 
+    ret = []
+    for u in urls:
+        if u not in ret:    # remove duplicate, keep url order
+            ret.append(u)
+    urls = ret
+
     size = 0
     for url in urls:
         _, _, temp = url_info(url)


### PR DESCRIPTION
Such as http://www.bilibili.com/video/av2020012/

Before patch, I got:

Video Site: bilibili.com
Title:      【科幻】黑夜传说四部合集（720P修复版）（2003-2012）（双语字幕）
Type:       Flash video (video/x-flv)
Size:       6527.82 MiB (6844915737 Bytes)

Real URLs:
['http://nl-amsterdam.acgvideo.com/c/ac/3124235-1.flv?expires=1424949600&ssig=-kFTiFPQImuQ_2pYh3ibMA&o=1179620804&rate=0', 'http://nl-amsterdam.acgvideo.com/c/ac/3124235-1.flv?expires=1424949600&ssig=-kFTiFPQImuQ_2pYh3ibMA&o=1179620804&rate=0', 'http://ws.acgvideo.com/5/70/3124236-1.flv', 'http://ws.acgvideo.com/2/6f/3124237-1.flv', 'http://ws.acgvideo.com/0/31/3124238-1.flv']

First two urls are same, which waste bandwidth

After patch:

Title:      【科幻】黑夜传说四部合集（720P修复版）（2003-2012）（双语字幕）
Type:       Flash video (video/x-flv)
Size:       4962.75 MiB (5203818377 Bytes)

Real URLs:
['http://nl-amsterdam.acgvideo.com/c/ac/3124235-1.flv?expires=1424951400&ssig=n8baoSz5LQtuGh7BAlxGig&o=1179620804&rate=0', 'http://ws.acgvideo.com/5/70/3124236-1.flv', 'http://ws.acgvideo.com/2/6f/3124237-1.flv', 'http://ws.acgvideo.com/0/31/3124238-1.flv']


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/497)
<!-- Reviewable:end -->
