### PR TITLE
Remove global in subclass of VideoExtractor()

### DIFF
--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -163,9 +163,19 @@ class Youku(VideoExtractor):
             if not self.streams[stream_id]['src'] and self.password_protected:
                 log.e('[Failed] Wrong password.')
 
-site = Youku()
-download = site.download_by_url
-download_playlist = site.download_playlist_by_url
+def my_download_by_url(*args, **kwargs):
+    site = Youku()
+    return site.download_by_url(*args, **kwargs)
 
-youku_download_by_vid = site.download_by_vid
+def my_download_playlist_by_url(*args, **kwargs):
+    site = Youku()
+    return site.download_playlist_by_url(*args, **kwargs)
+
+# youku_download_by_vid = site.download_by_vid
 # Used by: acfun.py bilibili.py miomio.py tudou.py
+def youku_download_by_vid(*args, **kwargs):
+    site = Youku()
+    return site.download_by_vid(*args, **kwargs)
+
+download = my_download_by_url
+download_playlist = my_download_playlist_by_url

--- a/src/you_get/extractors/youtube.py
+++ b/src/you_get/extractors/youtube.py
@@ -205,6 +205,13 @@ class YouTube(VideoExtractor):
         self.streams[stream_id]['src'] = [src]
         self.streams[stream_id]['size'] = urls_size(self.streams[stream_id]['src'])
 
-site = YouTube()
-download = site.download_by_url
-download_playlist = site.download_playlist_by_url
+def my_download_by_url(*args, **kwargs):
+    site = YouTube()
+    return site.download_by_url(*args, **kwargs)
+
+def my_download_playlist_by_url(*args, **kwargs):
+    site = YouTube()
+    return site.download_playlist_by_url(*args, **kwargs)
+
+download = my_download_by_url
+download_playlist = my_download_playlist_by_url


### PR DESCRIPTION
Using `site = Youku()` as global variable will prevent the extractor
from getting different video links simutaneously. Each extractor
should create its own Youku() instance in order to avoid interference
under multithreading.