### PR TITLE
Print URLs one per line instead of as a list when the --url option is specified

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -478,7 +478,7 @@ class DummyProgressBar:
 def download_urls(urls, title, ext, total_size, output_dir='.', refer=None, merge=True, faker=False):
     assert urls
     if dry_run:
-        print('Real URLs:\n%s\n' % urls)
+        print('Real URLs:\n%s' % '\n'.join(urls))
         return
 
     if player:


### PR DESCRIPTION
This PR converts the output of, for instance,

    you-get -u http://v.youku.com/v_show/id_XNzIwOTA1OTI4.html

from

```
site:                优酷 (Youku)
title:               Apple Special Event, WWDC 2014 Keynote
stream:
    - format:        flv
      container:     flv
      video-profile: 标清
      size:          267.4 MiB (280408659 bytes)
    # download-with: you-get --format=flv [URL]

Real URLs:
['http://112.25.17.177/6776355EA734E795D43212134/0300021500538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.51.42/6979500DA693C773493E166B4/0300021501538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.47.45/6576355E6763D7752E82D4F67/0300021502538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.47.23/6779500D7DC3C7733A3805A4D/0300021503538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://111.1.52.233/657847288A93B71A5B5906848/0300021504538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.50.140/6579500D6003E7772F56A656D/0300021505538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.51.45/697E7C8685246786D389A5F41/0300021506538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.37.14/677D73A18EC357656DD0E4868/0300021507538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.61.175/677E7C86B9F4B790C94324C5F/0300021508538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.17.143/698119735C9C3976CF6F335908/0300021509538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.50.208/678108E506573C77347F232337/030002150A538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://117.135.153.74/69813A8FF5DC3281B1D7C183B4B/030002150B538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.50.236/67812A01A42B3075BD5D674E1D/030002150C538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://111.1.52.241/69815BAC98AB4E722FDD612958/030002150D538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.47.45/65812A01A9F4347639ABBF6056/030002150E538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://111.1.52.178/67815BAC9BF44171D147D628D3/030002150F538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.45.51/67816C3AEFAD3976D57B135310/0300021510538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.50.102/69819DE5DA3637769818942869/0300021511538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://111.1.16.203/6981AE742B614671EBF4303A7B/0300021512538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://111.1.16.142/67819DE5D9003D71ABBAE9205E/0300021513538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv', 'http://112.25.47.106/6981CF90C6E74277EF35AD37BD/0300021514538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv']

```

to

```
site:                优酷 (Youku)
title:               Apple Special Event, WWDC 2014 Keynote
stream:
    - format:        flv
      container:     flv
      video-profile: 标清
      size:          267.4 MiB (280408659 bytes)
    # download-with: you-get --format=flv [URL]

Real URLs:
http://112.25.17.177/6776355EF88457845100E5FC2/0300021500538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.51.42/67773E4349A3876B7858362D7/0300021501538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.47.45/67784728EC233761A6C2467A4/0300021502538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.47.23/697B61D74E04A78E91CBC3738/0300021503538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://111.1.52.233/697C6ABC7834271D89AEB6707/0300021504538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.50.140/677B61D799E4E796724FE21C3/0300021505538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.51.45/697E7C86CAE3E77731BC66554/0300021506538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.37.14/697F856BBDA4E796316184B10/0300021507538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.61.175/698108E504933D77564EA44D73/0300021508538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.17.143/6981197355D94E795D38E52C18/0300021509538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.50.208/678108E5055E43780F55D0431E/030002150A538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://117.135.153.74/657F856B8854382485C1442DF8/030002150B538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.50.236/67812A01A6D24D7947FE855260/030002150C538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://111.1.52.241/658119735A964E722FDD5F3067/030002150D538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.47.45/69816C3AE50C4277EF262F662D/030002150E538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://111.1.52.178/67815BAC9AB23B71A5A91924D1/030002150F538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.45.51/67816C3AE9E03175DB8E1044B0/0300021510538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.50.102/65815BAC958A4277EFF7A84822/0300021511538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://111.1.16.203/67818D5787A34871FA369F37DA/0300021512538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://111.1.16.142/65817CC934864571E4C2C22C3C/0300021513538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
http://112.25.47.106/65818D578D473B771476C94C90/0300021514538D0AE76B4201AD1C894E56C696-E608-436D-E978-2C85541FFAAA.flv
```

This way the output is easier to parse, e.g. with

    you-get -u http://v.youku.com/v_show/id_XNzIwOTA1OTI4.html | sed '1,/Real URLs:/d'

The original output was rather annoying to parse even with Python, unless we use `eval`, which is usually not recommended.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/516)
<!-- Reviewable:end -->
