### PR TITLE
Fix iqiyi (20150710)

### DIFF
--- a/src/you_get/extractors/iqiyi.py
+++ b/src/you_get/extractors/iqiyi.py
@@ -12,6 +12,8 @@ import hashlib
 
 '''
 Changelog:
+-> http://www.iqiyi.com/common/flashplayer/20150710/MainPlayer_5_2_25_c3_3_5_1.swf
+
 -> http://www.iqiyi.com/common/flashplayer/20150703/MainPlayer_5_2_24_1_c3_3_3.swf
     SingletonClass.ekam
 
@@ -41,7 +43,7 @@ bid meaning for quality
 
 def mix(tvid):
     enc = []
-    enc.append('754f3a28fee047ad9b654420056b400b')
+    enc.append('341c0055ad1d4e798c2b784d9dbed29f')
     tm = str(randint(2000,4000))
     src = 'hsalf'
     enc.append(str(tm))

--- a/src/you_get/extractors/iqiyi.py
+++ b/src/you_get/extractors/iqiyi.py
@@ -21,7 +21,7 @@ Changelog:
     In this version Z7elzzup.cexe,just use node.js to run this code(with some modification) and get innerkey.
 
 -> http://www.iqiyi.com/common/flashplayer/20150612/MainPlayer_5_2_23_1_c3_2_6_5.swf
-    In this version do not directly use enc key 
+    In this version do not directly use enc key
     gen enc key (so called sc ) in DMEmagelzzup.mix(tvid) -> (tm->getTimer(),src='hsalf',sc)
     encrypy alogrithm is md5(DMEmagelzzup.mix.genInnerKey +tm+tvid)
     how to gen genInnerKey ,can see first 3 lin in mix function in this file
@@ -74,10 +74,10 @@ def getVrsEncodeCode(vlink):
 def getVMS(tvid,vid,uid):
     #tm ->the flash run time for md5 usage
     #um -> vip 1 normal 0
-    #authkey -> for password protected video ,replace '' with your password 
+    #authkey -> for password protected video ,replace '' with your password
     #puid user.passportid may empty?
     #TODO: support password protected video
-    tm,sc,src = mix(tvid) 
+    tm,sc,src = mix(tvid)
     vmsreq='http://cache.video.qiyi.com/vms?key=fvip&src=1702633101b340d8917a69cf8a4b8c7' +\
                 "&tvId="+tvid+"&vid="+vid+"&vinfo=1&tm="+tm+\
                 "&enc="+sc+\
@@ -96,15 +96,15 @@ def iqiyi_download(url, output_dir = '.', merge = True, info_only = False):
     gen_uid=uuid4().hex
 
     html = get_html(url)
-    
-    tvid = r1(r'data-player-tvid="([^"]+)"', html)
-    videoid = r1(r'data-player-videoid="([^"]+)"', html)
-    
+
+    tvid = r1(r'data-player-tvid="([^"]+)"', html) or r1(r'tvid=([^&]+)', url)
+    videoid = r1(r'data-player-videoid="([^"]+)"', html) or r1(r'vid=([^&]+)', url)
+
     assert tvid
     assert videoid
 
     info = getVMS(tvid, videoid, gen_uid)
-    
+
     assert info["code"] == "A000000"
 
     title = info["data"]["vi"]["vn"]
@@ -127,13 +127,13 @@ def iqiyi_download(url, output_dir = '.', merge = True, info_only = False):
     for i in info["data"]["vp"]["tkl"][0]["vs"]:
         if int(i["bid"])<=10 and int(i["bid"])>=bid:
             bid=int(i["bid"])
-           
+
             video_links=i["fs"] #now in i["flvs"] not in i["fs"]
             if not i["fs"][0]["l"].startswith("/"):
                 tmp = getVrsEncodeCode(i["fs"][0]["l"])
                 if tmp.endswith('mp4'):
                      video_links = i["flvs"]
-            
+
 
     urls=[]
     size=0


### PR DESCRIPTION
- Fix #569 for new player:
   - http://www.iqiyi.com/common/flashplayer/20150710/MainPlayer_5_2_25_c3_3_5_1.swf
- Extract `tvid` and `vid` from embeded URLs such as:
    - http://www.iqiyi.com/common/qplay.html?cnid=5&tvid=4087092609&vid=049fe2ee97bf72f4ef7c30b85ae2c251

We need a way to automatically extract keys from its player...

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/570)
<!-- Reviewable:end -->
