### PR TITLE
fix duplicate url bug for bilibili

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -121,7 +121,7 @@ def bilibili_download(url, output_dir='.', merge=True, info_only=False):
     id = id.split('&')[0]
     if t == 'cid':
         # Multi-P
-        cids = [id]
+        cids = []
         p = re.findall('<option value=\'([^\']*)\'>', html)
         if not p:
             bilibili_download_by_cid(id, title, output_dir=output_dir, merge=merge, info_only=info_only)


### PR DESCRIPTION
当有多 P 时，会错误的将 1P 的 id 重复加入 list。

测试地址：
http://www.bilibili.com/video/av824538/
http://www.bilibili.com/video/av2772797/

fix #497

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/610)
<!-- Reviewable:end -->
