### PR TITLE
Fix problems with videos that do not have 720p mode

### DIFF
--- a/src/you_get/extractors/dailymotion.py
+++ b/src/you_get/extractors/dailymotion.py
@@ -13,9 +13,12 @@ def dailymotion_download(url, output_dir = '.', merge = True, info_only = False)
     title = match1(html, r'"title"\s*:\s*"(.+?)",')
 
     for quality in ['720','480','380','240','auto']:
-        real_url = info[quality][0]["url"]
-        if real_url:
-            break
+        try:
+            real_url = info[quality][0]["url"]
+            if real_url:
+                break
+        except KeyError:
+            pass
 
     type, ext, size = url_info(real_url)
 


### PR DESCRIPTION
Some videos that use lower resolutions do not work for me.
Here is an example: www.dailymotion.com/video/x2mzuat

The fix is quite simple (arguably, using get() instead of [] inside try-catch might be better).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/618)
<!-- Reviewable:end -->
