### PR TITLE
Add Vimeo Channel support, fix #121

### DIFF
--- a/src/you_get/extractors/vimeo.py
+++ b/src/you_get/extractors/vimeo.py
@@ -11,7 +11,7 @@ def vimeo_download_by_channel(url, output_dir = '.', merge = False, info_only = 
     """str->None"""
     # https://vimeo.com/channels/464686
     channel_id = match1(url, r'http://vimeo.com/channels/(\w+)')
-    vimeo_download_by_channel_id(channel_id, output_dir = '.', merge = False, info_only = False)
+    vimeo_download_by_channel_id(channel_id, output_dir, merge, info_only)
 
 #----------------------------------------------------------------------
 def vimeo_download_by_channel_id(channel_id, output_dir = '.', merge = False, info_only = False):
@@ -25,7 +25,7 @@ def vimeo_download_by_channel_id(channel_id, output_dir = '.', merge = False, in
         id_list.append(match1(i['uri'], r'/videos/(\w+)'))
         
     for id in id_list:
-        vimeo_download_by_id(id)
+        vimeo_download_by_id(id, None, output_dir, merge, info_only)
 
 def vimeo_download_by_id(id, title = None, output_dir = '.', merge = True, info_only = False):
     video_page = get_content('http://player.vimeo.com/video/%s' % id, headers=fake_headers)
@@ -45,7 +45,7 @@ def vimeo_download_by_id(id, title = None, output_dir = '.', merge = True, info_
 
 def vimeo_download(url, output_dir = '.', merge = True, info_only = False):
     if re.match(r'http://vimeo.com/channels/\w+', url):
-        vimeo_download_by_channel(url, output_dir='.', merge=False, info_only=False)
+        vimeo_download_by_channel(url, output_dir, merge, info_only)
     else:
         id = r1(r'http://[\w.]*vimeo.com[/\w]*/(\d+)$', url)
         assert id

--- a/src/you_get/extractors/vimeo.py
+++ b/src/you_get/extractors/vimeo.py
@@ -1,8 +1,31 @@
 #!/usr/bin/env python
 
-__all__ = ['vimeo_download', 'vimeo_download_by_id']
+__all__ = ['vimeo_download', 'vimeo_download_by_id', 'vimeo_download_by_channel', 'vimeo_download_by_channel_id']
 
 from ..common import *
+from json import loads
+access_token = 'f6785418277b72c7c87d3132c79eec24'  #By Beining
+
+#----------------------------------------------------------------------
+def vimeo_download_by_channel(url, output_dir = '.', merge = False, info_only = False):
+    """str->None"""
+    # https://vimeo.com/channels/464686
+    channel_id = match1(url, r'http://vimeo.com/channels/(\w+)')
+    vimeo_download_by_channel_id(channel_id, output_dir = '.', merge = False, info_only = False)
+
+#----------------------------------------------------------------------
+def vimeo_download_by_channel_id(channel_id, output_dir = '.', merge = False, info_only = False):
+    """str/int->None"""
+    html = get_content('https://api.vimeo.com/channels/{channel_id}/videos?access_token={access_token}'.format(channel_id = channel_id, access_token = access_token))
+    data = loads(html)
+    id_list = []
+    
+    #print(data)
+    for i in data['data']:
+        id_list.append(match1(i['uri'], r'/videos/(\w+)'))
+        
+    for id in id_list:
+        vimeo_download_by_id(id)
 
 def vimeo_download_by_id(id, title = None, output_dir = '.', merge = True, info_only = False):
     video_page = get_content('http://player.vimeo.com/video/%s' % id, headers=fake_headers)
@@ -21,11 +44,14 @@ def vimeo_download_by_id(id, title = None, output_dir = '.', merge = True, info_
         download_urls([url], title, ext, size, output_dir, merge = merge, faker = True)
 
 def vimeo_download(url, output_dir = '.', merge = True, info_only = False):
-    id = r1(r'http://[\w.]*vimeo.com[/\w]*/(\d+)$', url)
-    assert id
+    if re.match(r'http://vimeo.com/channels/\w+', url):
+        vimeo_download_by_channel(url, output_dir='.', merge=False, info_only=False)
+    else:
+        id = r1(r'http://[\w.]*vimeo.com[/\w]*/(\d+)$', url)
+        assert id
     
-    vimeo_download_by_id(id, None, output_dir = output_dir, merge = merge, info_only = info_only)
+        vimeo_download_by_id(id, None, output_dir = output_dir, merge = merge, info_only = info_only)
 
 site_info = "Vimeo.com"
 download = vimeo_download
-download_playlist = playlist_not_supported('vimeo')
+download_playlist = vimeo_download_by_channel


### PR DESCRIPTION
Note the rate limit of the API key.

```
python3 you-get https://vimeo.com/channels/464686
Video Site: Vimeo.com
Title:      8.4 Recursion with Transformations (The Nature of Code) from shiffman on Vimeo
Type:       MPEG-4 video (video/mp4)
Size:       130.77 MiB (137121450 Bytes)

Downloading 8.4 Recursion with Transformations (The Nature of Code) from shiffman on Vimeo.mp4 ...
```

There are too many videos to test, but according to the API everyone should be working.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/634)
<!-- Reviewable:end -->
