### PR TITLE
Add 66wz support, partially fix #637

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Fork me on GitHub: <https://github.com/soimort/you-get>
 * Twitter <http://twitter.com>
 * Youku (优酷) <http://www.youku.com>
 * YouTube <http://www.youtube.com>
+* 66wz (温州宽带影视网)<http://tv.66wz.com>
 * AcFun <http://www.acfun.tv>
 * Alive.in.th <http://alive.in.th>
 * Baidu Music (百度音乐) <http://music.baidu.com>

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -940,7 +940,7 @@ def script_main(script_name, download, download_playlist = None):
             sys.exit(1)
 
 def url_to_module(url):
-    from .extractors import netease, w56, acfun, baidu, baomihua, bilibili, blip, catfun, cntv, cbs, coursera, dailymotion, dongting, douban, douyutv, ehow, facebook, freesound, funshion, google, sina, ifeng, alive, instagram, iqiyi, joy, jpopsuki, khan, ku6, kugou, kuwo, letv, lizhi, magisto, metacafe, miaopai, miomio, mixcloud, mtv81, nicovideo, pptv, qianmo, qq, sohu, songtaste, soundcloud, ted, theplatform, tudou, tucao, tumblr, twitter, vid48, videobam, vidto, vimeo, vine, vk, xiami, yinyuetai, youku, youtube, zhanqi
+    from .extractors import netease, w56, acfun, baidu, baomihua, bilibili, blip, catfun, cntv, cbs, coursera, dailymotion, dongting, douban, douyutv, ehow, facebook, freesound, funshion, google, sina, ifeng, alive, instagram, iqiyi, joy, jpopsuki, khan, ku6, kugou, kuwo, letv, lizhi, magisto, metacafe, miaopai, miomio, mixcloud, mtv81, nicovideo, pptv, qianmo, qq, sohu, songtaste, soundcloud, ted, theplatform, tudou, tucao, tumblr, tv66wz, twitter, vid48, videobam, vidto, vimeo, vine, vk, xiami, yinyuetai, youku, youtube, zhanqi
 
     video_host = r1(r'https?://([^/]+)/', url)
     video_url = r1(r'https?://[^/]+(.*)', url)
@@ -1007,6 +1007,7 @@ def url_to_module(url):
         'tudou': tudou,
         'tumblr': tumblr,
         'twitter': twitter,
+        '66wz': tv66wz,
         'vid48': vid48,
         'videobam': videobam,
         'vidto': vidto,

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -46,6 +46,7 @@ from .theplatform import *
 from .tucao import *
 from .tudou import *
 from .tumblr import *
+from .tv66wz import *
 from .twitter import *
 from .vid48 import *
 from .videobam import *

--- a/src/you_get/extractors/tv66wz.py
+++ b/src/you_get/extractors/tv66wz.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+__all__ = ['tv66wz_download']
+# Attention: It is not possible to name the function as 66wz, so I've put "tv" in front of the names.
+
+from ..common import *
+import re
+
+#----------------------------------------------------------------------
+def tv66wz_download(url, output_dir = '.', merge = False, info_only = False):
+    """str, blahblah->None
+    Call the API function"""
+    if re.match(r'http://tv.66wz.com/\w+', url):
+        
+        p = re.compile(r"g_arrVideo\[\d+\] = new videoInfo\((\d+),\d,\'(.+)\',\'")
+        
+        url_list = []
+        
+        html = get_content(url)
+        
+        for m in p.finditer(html):
+            url_list.append((m.group(1), m.group(2)))
+            #1: id 2: title
+        
+        for i in url_list:
+            tv66wz_download_by_id(i[0], i[1], output_dir='.', merge=False, 
+                                 info_only=False)
+
+#----------------------------------------------------------------------
+def tv66wz_download_by_id(id, title, output_dir = '.', merge = False, info_only = False):
+    """
+    str,str, blahblah...-> None
+    Attention: title comes from previous function, arguments not exactly the same
+    as other extractors"""
+    url_httppplay = 'http://60.190.99.171:8080/forcetech/cms/flvhttpplay.jsp?id={id}&type=0&documentID=0&columnID=0'.format(id = id)
+    
+    html = get_content(url_httppplay)
+    
+    p = re.compile(r'.+filevalue=(.+)&amp;copyvalue')
+    for m in p.finditer(html):
+        url = m.group(1)
+        break
+    
+    #print(url)
+    
+    print('This will take very very long...')
+    
+    type_, ext, size = url_info(url)
+    print_info('66wz', title, 'flv', 0)
+    if not info_only:
+        download_urls([url], title, 'flv', total_size=None, output_dir=output_dir, merge=merge)
+
+site_info = "66wz"
+download = tv66wz_download
+download_playlist = playlist_not_supported('66wz')


### PR DESCRIPTION
As in #637 ,  ```url_info``` is not able to deal with malformed 301 redirect.

I've thrown here a helper function to follow the header.

Please consider putting this helper function in ```commons.py```.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/638)
<!-- Reviewable:end -->
