### PR TITLE
get encoding from response date

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -210,7 +210,8 @@ def get_content(url, headers={}, decoded=True):
 
     # Decode the response body
     if decoded:
-        charset = match1(response.getheader('Content-Type'), r'charset=([\w-]+)')
+        charset = match1(response.getheader('Content-Type'), r'charset=([\w-]+)') or \
+                  match1(str(data), r'charset=([\w-]+)')
         if charset is not None:
             data = data.decode(charset)
         else:


### PR DESCRIPTION
fix #622

Signed-off-by: Zhang Ning <zhangn1985@gmail.com>

many sites don't have charset in response header.
eg. sohu, letv,

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/641)
<!-- Reviewable:end -->
