### PR TITLE
[youku] gracefully handle single failure when downloading playlist

### DIFF
--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -6,6 +6,7 @@ from ..extractor import VideoExtractor
 
 import base64
 import time
+import traceback
 
 class Youku(VideoExtractor):
     name = "优酷 (Youku)"
@@ -83,7 +84,11 @@ class Youku(VideoExtractor):
         self.p_playlist()
         for video in videos:
             index = parse_query_param(video, 'f')
-            self.__class__().download_by_url(video, index=index, **kwargs)
+            try:
+                self.__class__().download_by_url(video, index=index, **kwargs)
+            except:
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                traceback.print_exception(exc_type, exc_value, exc_traceback)
 
     def prepare(self, **kwargs):
         assert self.url or self.vid

--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -86,6 +86,8 @@ class Youku(VideoExtractor):
             index = parse_query_param(video, 'f')
             try:
                 self.__class__().download_by_url(video, index=index, **kwargs)
+            except KeyboardInterrupt:
+                raise
             except:
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 traceback.print_exception(exc_type, exc_value, exc_traceback)


### PR DESCRIPTION
TL;DR: When downloading a playlist, a single failure shouldn't terminate the whole process.

Youku playlist can have broken video links. I believe this happens really rare, but I have one sample here: http://www.youku.com/playlist_show/id_21492543.html
This playlist contains a broken video link: http://v.youku.com/v_show/id_XNjUxNzQyNzEy.html

Since python set is unordered, when downloading this playlist, we can hit this video at a random point of the whole process, and crash.

This diff is just a rough idea. I'm open for opinions. I have several in my mind actually:
Should we have a flag guarding this feature?
Should we apply this feature to all extractors? If yes is there a better way to do that other than changing every extractor that support playlist?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/651)
<!-- Reviewable:end -->
