### PR TITLE
[ffmpeg] use subprocess.check_call

### DIFF
--- a/src/you_get/processor/ffmpeg.py
+++ b/src/you_get/processor/ffmpeg.py
@@ -109,11 +109,9 @@ def ffmpeg_concat_flv_to_mp4(files, output='output.mp4'):
         params.append(output + '.txt')
         params += ['-c', 'copy', output]
 
-        if subprocess.call(params) == 0:
-            os.remove(output + '.txt')
-            return True
-        else:
-            raise
+        subprocess.check_call(params)
+        os.remove(output + '.txt')
+        return True
 
     for file in files:
         if os.path.isfile(file):


### PR DESCRIPTION
This fixes `RuntimeError: No active exception to reraise`. Raising a `CalledProcessError` is more useful for debugging and manual fixing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/678)
<!-- Reviewable:end -->
