### PR TITLE
Encodings

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -148,12 +148,17 @@ def undeflate(data):
     decompressobj = zlib.decompressobj(-zlib.MAX_WBITS)
     return decompressobj.decompress(data)+decompressobj.flush()
 
+
 # DEPRECATED in favor of get_content()
-def get_response(url, faker = False):
+def get_response(url, faker=False):
     if faker:
-        response = request.urlopen(request.Request(url, headers = fake_headers), None)
+        response = request.urlopen(request.Request(url, headers=fake_headers), None)
     else:
-        response = request.urlopen(url)
+        try:
+            response = request.urlopen(url)
+        except UnicodeEncodeError:
+            url = url.encode('ascii', 'ignore').decode('ascii')
+            response = request.urlopen(url)
 
     data = response.read()
     if response.info().get('Content-Encoding') == 'gzip':


### PR DESCRIPTION
Using **you-get** to make downloading of some videos from [instagram.com][5], i get the following output of <kbd>python3 you-get https://instagram.com/p/5FOKHvyvSl/⁠⁠⁠⁠</kbd>:
```shell
Traceback (most recent call last):
  File "you-get", line 19, in <module>
    you_get.main(repo_path=_filepath)
  File "/home/falcucci/you-get/src/you_get/__main__.py", line 91, in main
    main()
  File "/home/falcucci/you-get/src/you_get/common.py", line 1158, in main
    script_main('you-get', any_download, any_download_playlist)
  File "/home/falcucci/you-get/src/you_get/common.py", line 972, in script_main
    download_main(download, download_playlist, args, playlist, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output)
  File "/home/falcucci/you-get/src/you_get/common.py", line 857, in download_main
    download(url, **kwargs)
  File "/home/falcucci/you-get/src/you_get/common.py", line 1151, in any_download
    m.download(url, **kwargs)
  File "/home/falcucci/you-get/src/you_get/extractors/instagram.py", line 8, in instagram_download
    html = get_html(url)
  File "/home/falcucci/you-get/src/you_get/common.py", line 174, in get_html
    content = get_response(url, faker).data
  File "/home/falcucci/you-get/src/you_get/common.py", line 157, in get_response
    response = request.urlopen(url)
  File "/usr/lib/python3.4/urllib/request.py", line 153, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.4/urllib/request.py", line 455, in open
    response = self._open(req, data)
  File "/usr/lib/python3.4/urllib/request.py", line 473, in _open
    '_open', req)
  File "/usr/lib/python3.4/urllib/request.py", line 433, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.4/urllib/request.py", line 1258, in http_open
    return self.do_open(http.client.HTTPConnection, req)
  File "/usr/lib/python3.4/urllib/request.py", line 1232, in do_open
    h.request(req.get_method(), req.selector, req.data, headers)
  File "/usr/lib/python3.4/http/client.py", line 1065, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python3.4/http/client.py", line 1093, in _send_request
    self.putrequest(method, url, **skips)
  File "/usr/lib/python3.4/http/client.py", line 957, in putrequest
    self._output(request.encode('ascii'))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 18-21: ordinal not in range(128)
```

For now, it has only happened once. Certainly it can happens one more time (or many times). :sweat_smile:

Try it yourself. thx!

[5]: https://instagram.com/

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/684)
<!-- Reviewable:end -->
