### PR TITLE
Load Mozilla cookies.sqlite

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -936,18 +936,23 @@ def script_main(script_name, download, download_playlist = None):
                 cookies = cookiejar.MozillaCookieJar()
                 con = sqlite3.connect(a)
                 cur = con.cursor()
-                cur.execute("SELECT host, path, isSecure, expiry, name, value FROM moz_cookies")
-                for item in cur.fetchall():
-                    c = cookiejar.Cookie(0, item[4], item[5],
-                                         None, False,
-                                         item[0],
-                                         item[0].startswith('.'),
-                                         item[0].startswith('.'),
-                                         item[1], False,
-                                         item[2],
-                                         item[3], item[3]=="",
-                                         None, None, {})
-                    cookies.set_cookie(c)
+                try:
+                    cur.execute("SELECT host, path, isSecure, expiry, name, value FROM moz_cookies")
+                    for item in cur.fetchall():
+                        c = cookiejar.Cookie(0, item[4], item[5],
+                                             None, False,
+                                             item[0],
+                                             item[0].startswith('.'),
+                                             item[0].startswith('.'),
+                                             item[1], False,
+                                             item[2],
+                                             item[3], item[3]=="",
+                                             None, None, {})
+                        cookies.set_cookie(c)
+                except: pass
+                # TODO: Chromium Cookies
+                # SELECT host_key, path, secure, expires_utc, name, encrypted_value FROM cookies
+                # http://n8henrie.com/2013/11/use-chromes-cookies-for-easier-downloading-with-python-requests/
 
         elif o in ('-l', '--playlist'):
             playlist = True

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -108,10 +108,7 @@ def bilibili_download_by_cid(cid, title, output_dir='.', merge=True, info_only=F
         download_urls(urls, title, type_, total_size=None, output_dir=output_dir, merge=merge)
 
 def bilibili_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
-    opener = request.build_opener(request.HTTPCookieProcessor(cookies))
-    request.install_opener(opener)
-
-    html = get_html(url)
+    html = get_content(url)
 
     title = r1_of([r'<meta name="description" content="(.+)"',
                    r'<meta name="title" content="([^<>]{1,999})" />',

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -108,6 +108,9 @@ def bilibili_download_by_cid(cid, title, output_dir='.', merge=True, info_only=F
         download_urls(urls, title, type_, total_size=None, output_dir=output_dir, merge=merge)
 
 def bilibili_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
+    opener = request.build_opener(request.HTTPCookieProcessor(cookies))
+    request.install_opener(opener)
+
     html = get_html(url)
 
     title = r1_of([r'<meta name="description" content="(.+)"',


### PR DESCRIPTION
The old-fashioned Netscape `cookies.txt` is nowhere to be seen in modern browsers. We should really move on to a modern format (e.g. Mozilla's SQLite-based cookies), so there will be no need for one to manually export `cookies.txt` anymore.

Also, this will allow for easier downloads of Bilibili's member-only videos, just grab a cookie file from your Firefox:

```
$ you-get -i -c ~/.mozilla/firefox/gggfz9xl.default/cookies.sqlite \
  http://www.bilibili.com/video/av2987444
```

Bilibili uses CAPTCHA verification as part of its login process, so there is no way to automatize this like we do in Niconico. Preloading existed cookies is a must in such occasions.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/686)
<!-- Reviewable:end -->
