### PR TITLE
[YouTube] Download subtitles / closed captions in SRT format

### DIFF
--- a/src/you_get/extractor.py
+++ b/src/you_get/extractor.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from .common import match1, download_urls, parse_host, set_proxy, unset_proxy
+from .common import match1, download_urls, get_filename, parse_host, set_proxy, unset_proxy
 from .util import log
 from . import json_output
+import os
 
 class Extractor():
     def __init__(self, *args):
@@ -25,6 +26,7 @@ class VideoExtractor():
         self.audiolang = None
         self.password_protected = False
         self.dash_streams = {}
+        self.caption_tracks = {}
 
         if args:
             self.url = args[0]
@@ -195,6 +197,15 @@ class VideoExtractor():
                           output_dir=kwargs['output_dir'],
                           merge=kwargs['merge'],
                           av=stream_id in self.dash_streams)
+            for lang in self.caption_tracks:
+                filename = '%s.%s.srt' % (get_filename(self.title), lang)
+                print('Saving %s ...' % filename, end="", flush=True)
+                srt = self.caption_tracks[lang]
+                with open(os.path.join(kwargs['output_dir'], filename),
+                          'w', encoding='utf-8') as x:
+                    x.write(srt)
+                print('Done.')
+
             # For main_dev()
             #download_urls(urls, self.title, self.streams[stream_id]['container'], self.streams[stream_id]['size'])
 


### PR DESCRIPTION
Download YouTube videos together with subtitles / closed captions.

Since YouTube (also Google Video) uses its own non-standard XML format for storing timed text, and that is hardly ever supported by any media player, all downloaded captions will be converted to [SRT subtitle format](http://www.matroska.org/technical/specs/subtitles/srt.html) automatically.

(Fix #36, #235)

Example:
```
λ  you-get-develop [youtube-caption-tracks] you-get --itag=137 youtu.be/8r7SGQ4c4fQ
site:                YouTube
title:               【MV】Green Flash / AKB48[公式]
stream:
    - itag:          137
      container:     mp4
      quality:       1920 x 1080
      size:          86.6 MiB (90798818 bytes)
    # download-with: you-get --itag=137 [URL]

Downloading 【MV】Green Flash - AKB48[公式].mp4 ...
100.0% ( 86.6/86.6 MB) [========================================] 2/2
Merging video parts... Done.

Saving 【MV】Green Flash - AKB48[公式].ja.srt ...Done.
Saving 【MV】Green Flash - AKB48[公式].ko.srt ...Done.
Saving 【MV】Green Flash - AKB48[公式].zh-CN.srt ...Done.
Saving 【MV】Green Flash - AKB48[公式].en.srt ...Done.
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/705)
<!-- Reviewable:end -->
