### PR TITLE
Don't download duplicated URLs in embed.py

### DIFF
--- a/src/you_get/extractors/embed.py
+++ b/src/you_get/extractors/embed.py
@@ -34,12 +34,12 @@ def embed_download(url, output_dir = '.', merge = True, info_only = False ,**kwa
     found = False
     title = match1(content, '<title>([^<>]+)</title>')
     vids = matchall(content, youku_embed_patterns)
-    for vid in vids:
+    for vid in set(vids):
         found = True
         youku_download_by_vid(vid, title=title, output_dir=output_dir, merge=merge, info_only=info_only)
 
     vids = matchall(content, tudou_embed_patterns)
-    for vid in vids:
+    for vid in set(vids):
         found = True
         tudou_download_by_id(vid, title=title, output_dir=output_dir, merge=merge, info_only=info_only)
 


### PR DESCRIPTION
For some pages such like http://www.pideo.net/video/youku/8cbc48e546ea657a/, a single embedded pattern appears in the page multiple times. Should only download each URL once.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/711)
<!-- Reviewable:end -->
