### PR TITLE
Add Veoh support, fix #79

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Fork me on GitHub: <https://github.com/soimort/you-get>
 * TED <http://www.ted.com>
 * Tudou (土豆) <http://www.tudou.com>
 * Tumblr <http://www.tumblr.com>
+* Veoh <http://www.veoh.com>
 * VID48 <http://vid48.com>
 * VideoBam <http://videobam.com>
 * VK <http://vk.com>

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -68,6 +68,7 @@ SITES = {
     'vidto'      : 'vidto',
     'vimeo'      : 'vimeo',
     'weibo'      : 'miaopai',
+    'veoh'       : 'veoh',
     'vine'       : 'vine',
     'vk'         : 'vk',
     'xiami'      : 'xiami',

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -55,6 +55,7 @@ from .tucao import *
 from .tudou import *
 from .tumblr import *
 from .twitter import *
+from .veoh import *
 from .vid48 import *
 from .videobam import *
 from .vimeo import *

--- a/src/you_get/extractors/veoh.py
+++ b/src/you_get/extractors/veoh.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+__all__ = ['veoh_download']
+
+from ..common import *
+import urllib.error
+
+def veoh_download(url, output_dir = '.', merge = False, info_only = False, **kwargs):
+    '''Get item_id'''
+    if re.match(r'http://www.veoh.com/watch/\w+', url):
+        item_id = match1(url, r'http://www.veoh.com/watch/(\w+)')
+    elif re.match(r'http://www.veoh.com/m/watch.php\?v=\.*', url):
+        item_id = match1(url, r'http://www.veoh.com/m/watch.php\?v=(\w+)')
+    else:
+        raise NotImplementedError('Cannot find item ID')
+    veoh_download_by_id(item_id, output_dir = '.', merge = False, info_only = False, **kwargs)
+
+#----------------------------------------------------------------------
+def veoh_download_by_id(item_id, output_dir = '.', merge = False, info_only = False, **kwargs):
+    """Source: Android mobile"""
+    webpage_url = 'http://www.veoh.com/m/watch.php?v={item_id}&quality=1'.format(item_id = item_id)
+    
+    #grab download URL
+    a = get_content(webpage_url, decoded=True)
+    url = match1(a, r'<source src="(.*?)\"\W')
+    
+    #grab title
+    title = match1(a, r'<meta property="og:title" content="([^"]*)"')
+
+    type_, ext, size = url_info(url)
+    print_info(site_info, title, type_, size)
+    if not info_only:
+        download_urls([url], title, ext, total_size=None, output_dir=output_dir, merge=merge)
+
+
+site_info = "Veoh"
+download = veoh_download
+download_playlist = playlist_not_supported('veoh')


### PR DESCRIPTION
```
python3 you-get http://www.veoh.com/watch/v31095531C9r4dFkG
Site:       Veoh
Title:      Japan all-girl group ad 'encourages homosexuality'
Type:       MPEG-4 video (video/mp4)
Size:       1.22 MiB (1276115 Bytes)

Downloading Japan all-girl group ad 'encourages homosexuality'.mp4 ...
```

```
python3 you-get --json http://www.veoh.com/m/watch.php?v=v31095531C9r4dFkG&quality=1
 {
    "site": "Veoh",
    "streams": {
        "__default__": {
            "container": "mp4",
            "size": null,
            "src": [
                "http://content.veoh.com/flash/p/2/v31095531C9r4dFkG/h31095531.mp4?ct=aa63fcf606b2374b41765e4b8e75759310e70cece41fc6f2"
            ],
            "video_profile": "__default__"
        }
    },
    "title": "Japan all-girl group ad 'encourages homosexuality'",
    "url": null
}
```

百合啊百合（

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/729)
<!-- Reviewable:end -->
