### PR TITLE
Fix bug on MioMio Extractor

### DIFF
--- a/src/you_get/extractors/miomio.py
+++ b/src/you_get/extractors/miomio.py
@@ -21,6 +21,7 @@ def miomio_download(url, output_dir = '.', merge = True, info_only = False, **kw
     elif t == 'tudou':
         tudou_download_by_id(id, title, output_dir=output_dir, merge=merge, info_only=info_only)
     elif t == 'sina' or t == 'video':
+        fake_headers['Referer'] = url
         url = "http://www.miomio.tv/mioplayer/mioplayerconfigfiles/sina.php?vid=" + id
         xml_data = get_content(url, headers=fake_headers, decoded=True)
         url_list = sina_xml_to_url_list(xml_data)


### PR DESCRIPTION
Hi! When I try to download a video from miomio, get the following output.

```
INSERT ❯ you-get --debug http://www.miomio.tv/watch/cc247040/
you-get: version 0.4.125, a tiny downloader that scrapes the web.
you-get: ['http://www.miomio.tv/watch/cc247040/']
Traceback (most recent call last):
  File "/usr/local/opt/pyenv/versions/3.4.2/bin/you-get", line 11, in <module>
    sys.exit(main())
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/site-packages/you_get/common.py", line 1213, in main
    script_main('you-get', any_download, any_download_playlist, **kwargs)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/site-packages/you_get/common.py", line 1134, in script_main
    download_main(download, download_playlist, args, playlist, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/site-packages/you_get/common.py", line 987, in download_main
    download(url, **kwargs)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/site-packages/you_get/common.py", line 1206, in any_download
    m.download(url, **kwargs)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/site-packages/you_get/extractors/miomio.py", line 24, in miomio_download
    xml_data = get_content(url, headers=fake_headers, decoded=True)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/site-packages/you_get/common.py", line 289, in get_content
    response = request.urlopen(req)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/urllib/request.py", line 153, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/urllib/request.py", line 461, in open
    response = meth(req, response)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/urllib/request.py", line 571, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/urllib/request.py", line 493, in error
    result = self._call_chain(*args)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/urllib/request.py", line 433, in _call_chain
    result = func(*args)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/urllib/request.py", line 676, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/urllib/request.py", line 461, in open
    response = meth(req, response)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/urllib/request.py", line 571, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/urllib/request.py", line 499, in error
    return self._call_chain(*args)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/urllib/request.py", line 433, in _call_chain
    result = func(*args)
  File "/usr/local/opt/pyenv/versions/3.4.2/lib/python3.4/urllib/request.py", line 579, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
```
I found some missing header elements from real request below, and I can download video with adding 'Referer' to `fake_headers`.

<img width="1440" alt="2015-11-07 19 54 41" src="https://cloud.githubusercontent.com/assets/3055271/11014802/9942f3f8-8589-11e5-8749-ee18abac84b5.png">

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/752)
<!-- Reviewable:end -->
