### PR TITLE
修正爱奇艺同一个节目的不同选集默认下载第一个选集的bug

### DIFF
--- a/src/you_get/extractors/iqiyi.py
+++ b/src/you_get/extractors/iqiyi.py
@@ -122,8 +122,11 @@ class Iqiyi(VideoExtractor):
 
         if self.url and not self.vid:
             html = get_html(self.url)
-            tvid = r1(r'data-player-tvid="([^"]+)"', html) or r1(r'tvid=([^&]+)', self.url)
-            videoid = r1(r'data-player-videoid="([^"]+)"', html) or r1(r'vid=([^&]+)', self.url)
+            tvid = r1(r'#curid=(.+)_', self.url)
+            videoid = r1(r'#curid=.+_(.*)$', self.url)  #修正同一个节目的不同选集默认下载第一个选集的bug,前提是选不同选集时网址会变
+            if not tvid and not videoid:
+                tvid = r1(r'data-player-tvid="([^"]+)"', html) or r1(r'tvid=([^&]+)', self.url)
+                videoid = r1(r'data-player-videoid="([^"]+)"', html) or r1(r'vid=([^&]+)', self.url)
             self.vid = (tvid, videoid)
 
         self.gen_uid=uuid4().hex

--- a/src/you_get/extractors/iqiyi.py
+++ b/src/you_get/extractors/iqiyi.py
@@ -123,7 +123,7 @@ class Iqiyi(VideoExtractor):
         if self.url and not self.vid:
             html = get_html(self.url)
             tvid = r1(r'#curid=(.+)_', self.url)
-            videoid = r1(r'#curid=.+_(.*)$', self.url)  #修正同一个节目的不同选集默认下载第一个选集的bug,前提是选不同选集时网址会变
+            videoid = r1(r'#curid=.+_(.*)$', self.url)
             if not tvid and not videoid:
                 tvid = r1(r'data-player-tvid="([^"]+)"', html) or r1(r'tvid=([^&]+)', self.url)
                 videoid = r1(r'data-player-videoid="([^"]+)"', html) or r1(r'vid=([^&]+)', self.url)


### PR DESCRIPTION
例如下载爱奇艺以下网页中的视频时, html中包含该页面下不同节目的所有tvid信息,  但原程序会默认下载第一个, 因为即使我点了第二个视频html源代码也不会变, 但此时url会在后面加一个#curid=418102300_5580ace7adb766582c36cdbbc20047ab的字段, 分别对应tvid和video_id,所以可以在原程序执行前先判断url中是否自带tvid和video_id来解决下载统一节目不同期时默认下载第一期的bug
http://www.iqiyi.com/v_19rrkp18q8.html?list=19rroek15u
http://www.iqiyi.com/v_19rrkp18q8.html?list=19rroek15u#curid=417925900_f0ed29fab6d700bd4969eb39eb3becc6

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/766)
<!-- Reviewable:end -->
