### PR TITLE
[ZhanQi]temporary fix using RTMP url, bypass to fix #809

### DIFF
--- a/src/you_get/extractors/zhanqi.py
+++ b/src/you_get/extractors/zhanqi.py
@@ -19,15 +19,17 @@ def zhanqi_download(url, output_dir = '.', merge = True, info_only = False, **kw
     title = unescape_html(title)
     rtmp_base = "http://wshdl.load.cdn.zhanqi.tv/zqlive"
     vod_base = "http://dlvod.cdn.zhanqi.tv"
+    rtmp_real_base = "rtmp://dlrtmp.cdn.zhanqi.tv/zqlive/"
     
     if video_type == "LIVE":
         rtmp_id = match1(html, rtmp_id_patt).replace('\\/','/')
-        request_url = rtmp_base+'/'+rtmp_id+'.flv?get_url=1'
-        real_url = get_html(request_url)
+        #request_url = rtmp_base+'/'+rtmp_id+'.flv?get_url=1'
+        #real_url = get_html(request_url)
+        real_url = rtmp_real_base + '/' + rtmp_id
         print_info(site_info, title, 'flv', float('inf'))
         if not info_only:
-            #download_rtmp_url(real_url, title, 'flv', {}, output_dir, merge = merge)
-            download_urls([real_url], title, 'flv', None, output_dir, merge = merge)
+            download_rtmp_url(real_url, title, 'flv', {}, output_dir, merge = merge)
+            #download_urls([real_url], title, 'flv', None, output_dir, merge = merge)
     elif video_type == "VOD":
         vod_m3u8_request = vod_base + match1(html, vod_m3u8_id_patt).replace('\\/','/')
         vod_m3u8 = get_html(vod_m3u8_request)
@@ -47,6 +49,7 @@ def zhanqi_download(url, output_dir = '.', merge = True, info_only = False, **kw
             download_urls(real_url, title, type_ or 'ts', size, output_dir, merge = merge)
     else:
         NotImplementedError('Unknown_video_type')
+
 site_info = "zhanqi.tv"
 download = zhanqi_download
 download_playlist = playlist_not_supported('zhanqi')


### PR DESCRIPTION
Also some PEP8.

I am willing to see some REAL fix of WsSecret. Should we can find this algorithm, this would be useful to other sites including Bilibili, maybe Sina...


```
python3 you-get --debug http://www.zhanqi.tv/heroesofthestorm
Site:       zhanqi.tv
Title:      黄金风暴联赛胜者组EDG vs ESTAR
Type:       Flash video (video/x-flv)
Size:       inf MiB (inf Bytes)

Call rtmpdump:
rtmpdump -r rtmp://dlrtmp.cdn.zhanqi.tv/zqlive//8855_uUA6t -o ./黄金风暴联赛胜者组EDG vs ESTAR.flv

RTMPDump v2.4
(c) 2010 Andrej Stepanchuk, Howard Chu, The Flvstreamer Team; license: GPL
Connecting ...
INFO: Connected...
Starting download at: 0.000 kB
INFO: Metadata:
INFO:   Server                NGINX RTMP (github.com/arut/nginx-rtmp-module)
INFO:   width                 1280.00
INFO:   height                720.00
INFO:   displayWidth          1280.00
INFO:   displayHeight         720.00
INFO:   duration              0.00
INFO:   framerate             30.00
INFO:   fps                   30.00
INFO:   videodatarate         1464.00
INFO:   videocodecid          7.00
INFO:   audiodatarate         0.00
INFO:   audiocodecid          10.00
INFO:   profile               ???????????????????????????????
INFO:   level                 ???????????????????????????????
INFO:   publishedtime         1450107247.00
INFO:   currenttime           1450126561.00
330.173 kB / 1.77 sec^C
Caught signal: 2, cleaning up, just a second...
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/811)
<!-- Reviewable:end -->
