### PR TITLE
New option: --no-caption

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -1023,6 +1023,8 @@ def script_main(script_name, download, download_playlist, **kwargs):
     \n'''
     help += '''Download options:
     -n | --no-merge                     Do not merge video parts.
+         --no-caption                   Do not download captions.
+                                        (subtitles, lyrics, danmaku, ...)
     -f | --force                        Force overwriting existed files.
     -F | --format <STREAM_ID>           Set video format to STREAM_ID.
     -O | --output-filename <FILE>       Set output filename.
@@ -1036,7 +1038,7 @@ def script_main(script_name, download, download_playlist, **kwargs):
     '''
 
     short_opts = 'Vhfiuc:ndF:O:o:p:x:y:'
-    opts = ['version', 'help', 'force', 'info', 'url', 'cookies', 'no-merge', 'no-proxy', 'debug', 'json', 'format=', 'stream=', 'itag=', 'output-filename=', 'output-dir=', 'player=', 'http-proxy=', 'extractor-proxy=', 'lang=']
+    opts = ['version', 'help', 'force', 'info', 'url', 'cookies', 'no-caption', 'no-merge', 'no-proxy', 'debug', 'json', 'format=', 'stream=', 'itag=', 'output-filename=', 'output-dir=', 'player=', 'http-proxy=', 'extractor-proxy=', 'lang=']
     if download_playlist:
         short_opts = 'l' + short_opts
         opts = ['playlist'] + opts
@@ -1058,6 +1060,7 @@ def script_main(script_name, download, download_playlist, **kwargs):
 
     info_only = False
     playlist = False
+    caption = True
     merge = True
     stream_id = None
     lang = None
@@ -1113,6 +1116,8 @@ def script_main(script_name, download, download_playlist, **kwargs):
 
         elif o in ('-l', '--playlist'):
             playlist = True
+        elif o in ('--no-caption'):
+            caption = False
         elif o in ('-n', '--no-merge'):
             merge = False
         elif o in ('--no-proxy',):
@@ -1145,14 +1150,14 @@ def script_main(script_name, download, download_playlist, **kwargs):
     try:
         if stream_id:
             if not extractor_proxy:
-                download_main(download, download_playlist, args, playlist, stream_id=stream_id, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output)
+                download_main(download, download_playlist, args, playlist, stream_id=stream_id, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output, caption=caption)
             else:
-                download_main(download, download_playlist, args, playlist, stream_id=stream_id, extractor_proxy=extractor_proxy, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output)
+                download_main(download, download_playlist, args, playlist, stream_id=stream_id, extractor_proxy=extractor_proxy, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output, caption=caption)
         else:
             if not extractor_proxy:
-                download_main(download, download_playlist, args, playlist, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output)
+                download_main(download, download_playlist, args, playlist, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output, caption=caption)
             else:
-                download_main(download, download_playlist, args, playlist, extractor_proxy=extractor_proxy, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output)
+                download_main(download, download_playlist, args, playlist, extractor_proxy=extractor_proxy, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output, caption=caption)
     except KeyboardInterrupt:
         if traceback:
             raise

--- a/src/you_get/extractor.py
+++ b/src/you_get/extractor.py
@@ -203,6 +203,9 @@ class VideoExtractor():
                           output_dir=kwargs['output_dir'],
                           merge=kwargs['merge'],
                           av=stream_id in self.dash_streams)
+            if not kwargs['caption']:
+                print('Skipping captions.')
+                return
             for lang in self.caption_tracks:
                 filename = '%s.%s.srt' % (get_filename(self.title), lang)
                 print('Saving %s ... ' % filename, end="", flush=True)

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -154,6 +154,9 @@ def bilibili_download(url, output_dir='.', merge=True, info_only=False, **kwargs
         raise NotImplementedError(flashvars)
 
     if not info_only and not dry_run:
+        if not kwargs['caption']:
+            print('Skipping danmaku.')
+            return
         title = get_filename(title)
         print('Downloading %s ...\n' % (title + '.cmt.xml'))
         xml = get_srt_xml(cid)

--- a/src/you_get/extractors/netease.py
+++ b/src/you_get/extractors/netease.py
@@ -19,7 +19,7 @@ def netease_hymn():
     errr oh! fuck ohhh!!!!
     """
 
-def netease_cloud_music_download(url, output_dir='.', merge=True, info_only=False):
+def netease_cloud_music_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
     rid = match1(url, r'id=(.*)')
     if rid is None:
         rid = match1(url, r'/(\d+)/?$')
@@ -38,6 +38,7 @@ def netease_cloud_music_download(url, output_dir='.', merge=True, info_only=Fals
         for i in j['album']['songs']:
             netease_song_download(i, output_dir=new_dir, info_only=info_only)
             try: # download lyrics
+                assert kwargs['caption']
                 l = loads(get_content("http://music.163.com/api/song/lyric/?id=%s&lv=-1&csrf_token=" % i['id'], headers={"Referer": "http://music.163.com/"}))
                 netease_lyric_download(i, l["lrc"]["lyric"], output_dir=new_dir, info_only=info_only)
             except: pass
@@ -55,6 +56,7 @@ def netease_cloud_music_download(url, output_dir='.', merge=True, info_only=Fals
         for i in j['result']['tracks']:
             netease_song_download(i, output_dir=new_dir, info_only=info_only)
             try: # download lyrics
+                assert kwargs['caption']
                 l = loads(get_content("http://music.163.com/api/song/lyric/?id=%s&lv=-1&csrf_token=" % i['id'], headers={"Referer": "http://music.163.com/"}))
                 netease_lyric_download(i, l["lrc"]["lyric"], output_dir=new_dir, info_only=info_only)
             except: pass
@@ -63,6 +65,7 @@ def netease_cloud_music_download(url, output_dir='.', merge=True, info_only=Fals
         j = loads(get_content("http://music.163.com/api/song/detail/?id=%s&ids=[%s]&csrf_token=" % (rid, rid), headers={"Referer": "http://music.163.com/"}))
         netease_song_download(j["songs"][0], output_dir=output_dir, info_only=info_only)
         try: # download lyrics
+            assert kwargs['caption']
             l = loads(get_content("http://music.163.com/api/song/lyric/?id=%s&lv=-1&csrf_token=" % rid, headers={"Referer": "http://music.163.com/"}))
             netease_lyric_download(j["songs"][0], l["lrc"]["lyric"], output_dir=output_dir, info_only=info_only)
         except: pass
@@ -113,7 +116,7 @@ def netease_download(url, output_dir = '.', merge = True, info_only = False, **k
     if "163.fm" in url:
         url = get_location(url)
     if "music.163.com" in url:
-        netease_cloud_music_download(url,output_dir,merge,info_only)
+        netease_cloud_music_download(url, output_dir, merge, info_only, **kwargs)
     else:
         html = get_decoded_html(url)
 


### PR DESCRIPTION
Fix #861.

The `--no-caption` option suppresses the download of captions (danmaku, lyrics, subtitles) from

* Bilibili
* music.163.com
* YouTube (see also <https://github.com/soimort/you-get/pull/705#issuecomment-159485291>)

Example:

````console
$ you-get http://www.bilibili.com/video/av3535049/
Site:       bilibili.com
Title:      义薄云天！小女孩为了救自己的朋友，捐肝脏死于手术台
Type:       Flash video (video/x-flv)
Size:       113.04 MiB (118531404 Bytes)

Skipping ./义薄云天！小女孩为了救自己的朋友，捐肝脏死于手术台.mp4: file already exists

Downloading 义薄云天！小女孩为了救自己的朋友，捐肝脏死于手术台.cmt.xml ...
```

```console
$ you-get --no-caption http://www.bilibili.com/video/av3535049/
Site:       bilibili.com
Title:      义薄云天！小女孩为了救自己的朋友，捐肝脏死于手术台
Type:       Flash video (video/x-flv)
Size:       113.04 MiB (118531404 Bytes)

Skipping ./义薄云天！小女孩为了救自己的朋友，捐肝脏死于手术台.mp4: file already exists

Skipping danmaku.
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/864)
<!-- Reviewable:end -->
