### PR TITLE
[ffmpeg] more check_call replacing wrong 'raise's

### DIFF
--- a/src/you_get/processor/ffmpeg.py
+++ b/src/you_get/processor/ffmpeg.py
@@ -170,11 +170,9 @@ def ffmpeg_concat_mp4_to_mp4(files, output='output.mp4'):
         params.append(output + '.txt')
         params += ['-c', 'copy', output]
 
-        if subprocess.call(params) == 0:
-            os.remove(output + '.txt')
-            return True
-        else:
-            raise
+        subprocess.check_call(params)
+        os.remove(output + '.txt')
+        return True
 
     for file in files:
         if os.path.isfile(file):
@@ -196,9 +194,7 @@ def ffmpeg_concat_mp4_to_mp4(files, output='output.mp4'):
     else:
         params += ['-c', 'copy', '-absf', 'aac_adtstoasc', output]
 
-    if subprocess.call(params) == 0:
-        for file in files:
-            os.remove(file + '.ts')
-        return True
-    else:
-        raise
+    subprocess.check_call(params)
+    for file in files:
+        os.remove(file + '.ts')
+    return True


### PR DESCRIPTION
I also met this error message from ffmpeg:
```
[mp4 @ 0x562afd33f380] Malformed AAC bitstream detected: use the audio bitstream filter 'aac_adtstoasc' to fix it ('-bsf:a aac_adtstoasc' option with ffmpeg)
```

Adding the mentioned option fixes the conversion. But I don't know whether we should add this option into you-get.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/899)
<!-- Reviewable:end -->
