### PR TITLE
fix m5.music.126.net return 404

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -348,6 +348,7 @@ def url_info(url, faker = False, headers = {}):
     headers = response.headers
 
     type = headers['content-type']
+    if type == 'image/jpg; charset=UTF-8' or type == 'image/jpg' : type = 'audio/mpeg'    #fix for netease
     mapping = {
         'video/3gpp': '3gp',
         'video/f4v': 'flv',

--- a/src/you_get/extractors/netease.py
+++ b/src/you_get/extractors/netease.py
@@ -94,13 +94,14 @@ def netease_video_download(vinfo, output_dir='.', info_only=False):
 
 def netease_song_download(song, output_dir='.', info_only=False):
     title = "%s. %s" % (song['position'], song['name'])
+    songNet = 'p' + song['mp3Url'].split('/')[2][1:]
 
     if 'hMusic' in song and song['hMusic'] != None:
-        url_best = make_url(song['hMusic']['dfsId'])
+        url_best = make_url(songNet, song['hMusic']['dfsId'])
     elif 'mp3Url' in song:
         url_best = song['mp3Url']
     elif 'bMusic' in song:
-        url_best = make_url(song['bMusic']['dfsId'])
+        url_best = make_url(songNet, song['bMusic']['dfsId'])
 
     netease_download_common(title, url_best,
                             output_dir=output_dir, info_only=info_only)
@@ -165,9 +166,9 @@ def encrypted_id(dfsId):
     return result
 
 
-def make_url(dfsId):
+def make_url(songNet, dfsId):
     encId = encrypted_id(dfsId)
-    mp3_url = "http://m5.music.126.net/%s/%s.mp3" % (encId, dfsId)
+    mp3_url = "http://%s/%s/%s.mp3" % (songNet, encId, dfsId)
     return mp3_url
 
 


### PR DESCRIPTION
网易云音乐的cdn一直在升级，先前提交的pll https://github.com/soimort/you-get/pull/908  已经失效（返回 timeout），但是可以通过修改m为p的方法获取 `headers` 和下载，但是获取的 `headers` 是不存在的 `image/jpg; charset=UTF-8'` ，所以对文件类型做了些修改。

* 使用 m5.music.126.net 解析：
```py
you-get: version 0.4.266, a tiny downloader that scrapes the web.
you-get: ['http://music.163.com/#/song?id=190449']
Traceback (most recent call last):
  File "D:\Documents\GitHub\you-get\you-get", line 11, in <module>
    you_get.main(repo_path=_filepath)
  File "D:\Documents\GitHub\you-get\src\you_get\__main__.py", line 92, in main
    main(**kwargs)
  File "D:\Documents\GitHub\you-get\src\you_get\common.py", line 1244, in main
    script_main('you-get', any_download, any_download_playlist, **kwargs)
  File "D:\Documents\GitHub\you-get\src\you_get\common.py", line 1165, in script_main
    download_main(download, download_playlist, args, playlist, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output, caption=caption)
  File "D:\Documents\GitHub\you-get\src\you_get\common.py", line 1013, in download_main
    download(url, **kwargs)
  File "D:\Documents\GitHub\you-get\src\you_get\common.py", line 1237, in any_download
    m.download(url, **kwargs)
  File "D:\Documents\GitHub\you-get\src\you_get\extractors\netease.py", line 119, in netease_download
    netease_cloud_music_download(url, output_dir, merge, info_only, **kwargs)
  File "D:\Documents\GitHub\you-get\src\you_get\extractors\netease.py", line 66, in netease_cloud_music_download
    netease_song_download(j["songs"][0], output_dir=output_dir, info_only=info_only)
  File "D:\Documents\GitHub\you-get\src\you_get\extractors\netease.py", line 106, in netease_song_download
    output_dir=output_dir, info_only=info_only)
  File "D:\Documents\GitHub\you-get\src\you_get\extractors\netease.py", line 109, in netease_download_common
    songtype, ext, size = url_info(url_best)
  File "D:\Documents\GitHub\you-get\src\you_get\common.py", line 346, in url_info
    response = request.urlopen(request.Request(url))
  File "urllib\request.py", line 162, in urlopen
  File "urllib\request.py", line 471, in open
  File "urllib\request.py", line 581, in http_response
  File "urllib\request.py", line 509, in error
  File "urllib\request.py", line 443, in _call_chain
  File "urllib\request.py", line 589, in http_error_default
urllib.error.HTTPError: HTTP Error 404: Not Found
```


* 修改为 p + song['mp3Url'] 域名成功下载：
```
Site:       163.com
Title:      1. 吻别
Type:       MP3 (audio/mpeg)
Size:       11.68 MiB (12249483 Bytes)

Downloading 1. 吻别.mp3 ...
100.0% ( 11.7/11.7 MB) ├████████████████████████████████████████┤[1/1]    1 MB/s

Saving 1. 吻别.lrc ...Done.
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/915)
<!-- Reviewable:end -->
