### PR TITLE
[Google+] Get multiple photos

### DIFF
--- a/src/you_get/extractors/google.py
+++ b/src/you_get/extractors/google.py
@@ -56,6 +56,8 @@ def google_download(url, output_dir = '.', merge = True, info_only = False, **kw
             t[0], t[-2] = t[0] or 'https:', 's0-d'
             u = '/'.join(t)
             real_urls.append(u)
+        if real_urls is None:
+            real_urls = [r1(r'<meta property="og:image" content="([^"]+)', html)]
         post_date = r1(r'"(20\d\d-[01]\d-[0123]\d)"', html)
         post_id = r1(r'/posts/([^"]+)', html)
         title = post_date + "_" + post_id

--- a/src/you_get/extractors/google.py
+++ b/src/you_get/extractors/google.py
@@ -49,6 +49,8 @@ def google_download(url, output_dir = '.', merge = True, info_only = False, **kw
     if service == 'plus': # Google Plus
 
         # attempt to extract images first
+        # TBD: posts with > 4 images
+        # TBD: album links
         html = get_html(parse.unquote(url))
         real_urls = []
         for src in re.findall(r'src="([^"]+)"[^>]*itemprop="image"', html):
@@ -56,7 +58,7 @@ def google_download(url, output_dir = '.', merge = True, info_only = False, **kw
             t[0], t[-2] = t[0] or 'https:', 's0-d'
             u = '/'.join(t)
             real_urls.append(u)
-        if real_urls is None:
+        if not real_urls:
             real_urls = [r1(r'<meta property="og:image" content="([^"]+)', html)]
         post_date = r1(r'"(20\d\d-[01]\d-[0123]\d)"', html)
         post_id = r1(r'/posts/([^"]+)', html)


### PR DESCRIPTION
When a Google+ post contains multiple photos, `you-get` should download them all instead of just the first one.

```console
$ you-get -di https://plus.google.com/+ChrisLord/posts/MCn6XgXSzSp
Site:       Google.com
Title:      2016-01-29_MCn6XgXSzSp
Type:       JPEG Image (image/jpeg)
Size:       0.24 MiB (246744 Bytes)

$ you-get https://plus.google.com/107241677527739013868/posts/FRokFB1ytCi
Site:       Google.com
Title:      2016-02-27_FRokFB1ytCi
Type:       Portable Network Graphics (image/png)
Size:       0.82 MiB (864494 Bytes)

Downloading 2016-02-27_FRokFB1ytCi.png ...
 100% (  0.8/  0.8MB) ├███████████████████████████████████████████┤[1/1]   26 MB/s
```

TODO: currently we don't handle ajax, so the maximum number of photos we get at once (achieved from an HTML page) is 4. Also, there is no support for album links.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/938)
<!-- Reviewable:end -->
