### PR TITLE
Add support for InfoQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Use `--url`/`-u` to get a list of downloadable resource URLs extracted from the 
 | JPopsuki TV | <http://www.jpopsuki.tv/>     |✓| | |
 | Internet Archive | <https://archive.org/>   |✓| | |
 | **Instagram** | <https://instagram.com/>    |✓|✓| |
+| InfoQ       | <http://www.infoq.com/presentations/> |✓| | |
 | Imgur       | <http://imgur.com/>           | |✓| |
 | Heavy Music Archive | <http://www.heavy-music.ru/> | | |✓|
 | **Google+** | <https://plus.google.com/>    |✓|✓| |

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -28,6 +28,7 @@ SITES = {
     'ifeng'            : 'ifeng',
     'imgur'            : 'imgur',
     'in'               : 'alive',
+    'infoq'            : 'infoq',
     'instagram'        : 'instagram',
     'interest'         : 'interest',
     'iqilu'            : 'iqilu',
@@ -365,6 +366,7 @@ def url_info(url, faker = False, headers = {}):
         'image/jpeg': 'jpg',
         'image/png': 'png',
         'image/gif': 'gif',
+        'application/pdf': 'pdf',
     }
     if type in mapping:
         ext = mapping[type]

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -22,6 +22,7 @@ from .google import *
 from .heavymusic import *
 from .ifeng import *
 from .imgur import *
+from .infoq import *
 from .instagram import *
 from .interest import *
 from .iqilu import *

--- a/src/you_get/extractors/infoq.py
+++ b/src/you_get/extractors/infoq.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+from ..common import *
+from ..extractor import VideoExtractor
+
+import ssl
+
+class Infoq(VideoExtractor):
+    name = "InfoQ"
+
+    stream_types = [
+        {'id': 'video'},
+        {'id': 'audio'},
+        {'id': 'slides'}
+    ]
+
+    def prepare(self, **kwargs):
+        content = get_content(self.url)
+        self.title = match1(content, r'<title>([^<]+)</title>')
+        s = match1(content, r'P\.s\s*=\s*\'([^\']+)\'')
+        scp = match1(content, r'InfoQConstants\.scp\s*=\s*\'([^\']+)\'')
+        scs = match1(content, r'InfoQConstants\.scs\s*=\s*\'([^\']+)\'')
+        sck = match1(content, r'InfoQConstants\.sck\s*=\s*\'([^\']+)\'')
+
+        mp3 = match1(content, r'name="filename"\s*value="([^"]+\.mp3)"')
+        if mp3: mp3 = 'http://res.infoq.com/downloads/mp3downloads/%s' % mp3
+
+        pdf = match1(content, r'name="filename"\s*value="([^"]+\.pdf)"')
+        if pdf: pdf = 'http://res.infoq.com/downloads/pdfdownloads/%s' % pdf
+
+        # cookie handler
+        ssl_context = request.HTTPSHandler(
+            context=ssl.SSLContext(ssl.PROTOCOL_TLSv1))
+        cookie_handler = request.HTTPCookieProcessor()
+        opener = request.build_opener(ssl_context, cookie_handler)
+        opener.addheaders = [
+            ('Referer', self.url),
+            ('Cookie',
+             'CloudFront-Policy=%s;CloudFront-Signature=%s;CloudFront-Key-Pair-Id=%s' % (scp, scs, sck))
+        ]
+        request.install_opener(opener)
+
+        self.streams = {
+            'video'  : { 'url': s },
+            'audio'  : { 'url': mp3 },
+            'slides' : { 'url': pdf }
+        }
+
+    def extract(self, **kwargs):
+        for i in self.streams:
+            s = self.streams[i]
+            _, s['container'], s['size'] = url_info(s['url'])
+            s['src'] = [s['url']]
+
+site = Infoq()
+download = site.download_by_url
+download_playlist = site.download_by_url


### PR DESCRIPTION
You can download InfoQ presentations, MP3 or slides as you like (without having an account)

Example: [[1]](http://www.infoq.com/presentations/lmdb-lighting-memory-mapped-database)

```console
$ you-get -di http://www.infoq.com/presentations/lmdb-lighting-memory-mapped-database
site:                InfoQ
title:               The Lightning Memory-mapped Database
streams:             # Available quality and codecs
    [ DEFAULT ] _________________________________
    - format:        video
      container:     mp4
      size:          327.6 MiB (343479057 bytes)
    # download-with: you-get --format=video [URL]

    - format:        audio
      container:     mp3
      size:          53.3 MiB (55854710 bytes)
    # download-with: you-get --format=audio [URL]

    - format:        slides
      container:     pdf
      size:          1.1 MiB (1119614 bytes)
    # download-with: you-get --format=slides [URL]

```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/950)
<!-- Reviewable:end -->
