### PR TITLE
[YouTube] Bypass age restriction

### DIFF
--- a/src/you_get/extractors/youtube.py
+++ b/src/you_get/extractors/youtube.py
@@ -152,8 +152,11 @@ class YouTube(VideoExtractor):
 
                 # Parse video page (for DASH)
                 video_page = get_content('https://www.youtube.com/watch?v=%s' % self.vid)
-                ytplayer_config = json.loads(re.search('ytplayer.config\s*=\s*([^\n]+?});', video_page).group(1))
-                self.html5player = 'https:' + ytplayer_config['assets']['js']
+                try:
+                    ytplayer_config = json.loads(re.search('ytplayer.config\s*=\s*([^\n]+?});', video_page).group(1))
+                    self.html5player = 'https:' + ytplayer_config['assets']['js']
+                except:
+                    self.html5player = None
 
             else:
                 # Parse video page instead
@@ -294,6 +297,7 @@ class YouTube(VideoExtractor):
                         }
         except:
             # VEVO
+            if not self.html5player: return
             self.js = get_content(self.html5player)
             if 'adaptive_fmts' in ytplayer_config['args']:
                 streams = [dict([(i.split('=')[0],


### PR DESCRIPTION
Obviously some YouTube videos require a login for age confirmation. Luckily, restrictions as such can be easily bypassed (unlike country/region restriction).

![](https://pbs.twimg.com/media/BjqzwxfIYAE8Qgk.png:large)


```console
$ you-get -di 'https://www.youtube.com/watch?v=CMpBT5iG4nU'
you-get: version 0.4.322, a tiny downloader that scrapes the web.
you-get: ['https://www.youtube.com/watch?v=CMpBT5iG4nU']
Traceback (most recent call last):
  File "./you-get", line 11, in <module>
    you_get.main(repo_path=_filepath)
  File "./src/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "./src/you_get/common.py", line 1257, in main
    script_main('you-get', any_download, any_download_playlist, **kwargs)
  File "./src/you_get/common.py", line 1178, in script_main
    download_main(download, download_playlist, args, playlist, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output, caption=caption)
  File "./src/you_get/common.py", line 1026, in download_main
    download(url, **kwargs)
  File "./src/you_get/common.py", line 1250, in any_download
    m.download(url, **kwargs)
  File "./src/you_get/extractor.py", line 39, in download_by_url
    self.prepare(**kwargs)
  File "./src/you_get/extractors/youtube.py", line 155, in prepare
    ytplayer_config = json.loads(re.search('ytplayer.config\s*=\s*([^\n]+?});', video_page).group(1))
AttributeError: 'NoneType' object has no attribute 'group'
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/956)
<!-- Reviewable:end -->
