### PR TITLE
Catch UnicodeEncodeError and ask users to change the locale

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -1183,6 +1183,14 @@ def script_main(script_name, download, download_playlist, **kwargs):
             raise
         else:
             sys.exit(1)
+    except UnicodeEncodeError:
+        log.e('[error] oops, the current environment does not seem to support Unicode.')
+        log.e('please set it to a UTF-8-aware locale first,')
+        log.e('so as to save the video (with some Unicode characters) correctly.')
+        log.e('you can do it like this:')
+        log.e('    (Windows)    % chcp 65001 ')
+        log.e('    (Linux)      $ LC_CTYPE=en_US.UTF-8')
+        sys.exit(1)
     except Exception:
         if not traceback:
             log.e('[error] oops, something went wrong.')


### PR DESCRIPTION
There has been many times users report issues about `UnicodeEncodeError`, when they're trying to download a video with some non-Latin characters in its title, but the system locale does not actually has the required charset.

Clearly not everyone wants to read the [FAQ](https://github.com/soimort/you-get/wiki/FAQ), so there has to be a better way to give instructions to users. Here it is.
![screenshot from 2016-03-10 22-21-20](https://cloud.githubusercontent.com/assets/342945/13685775/88232436-e712-11e5-94e0-c676b292296d.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/974)
<!-- Reviewable:end -->
