### PR TITLE
reset url and vid when download in serial

### DIFF
--- a/src/you_get/extractor.py
+++ b/src/you_get/extractor.py
@@ -33,6 +33,7 @@ class VideoExtractor():
 
     def download_by_url(self, url, **kwargs):
         self.url = url
+        self.vid= None
 
         if 'extractor_proxy' in kwargs and kwargs['extractor_proxy']:
             set_proxy(parse_host(kwargs['extractor_proxy']))
@@ -50,6 +51,7 @@ class VideoExtractor():
         self.download(**kwargs)
 
     def download_by_vid(self, vid, **kwargs):
+        self.url = None
         self.vid = vid
 
         if 'extractor_proxy' in kwargs and kwargs['extractor_proxy']:


### PR DESCRIPTION
you-get URL1 URL2 时，如果URL1和URL2是同一个网站，并且这个网站的解析是用VidoeExtractor来实现的。
download_by_url 不会更新vid，vid总是第一个链接的vid。
所以必须重置vid.
同理download_by_vid不会更新url。

to fix https://github.com/soimort/you-get/issues/906

**(请将本内容完整替换为PULL REQUEST的详细内容)**

when use xxx_download_by_url(url1/url2)
vid will not reset, only first url will download

Signed-off-by: Zhang Ning <zhangn1985@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/977)
<!-- Reviewable:end -->
