### PR TITLE
[dilidili]Repair, Fix #987, close #986 

### DIFF
--- a/src/you_get/extractors/dilidili.py
+++ b/src/you_get/extractors/dilidili.py
@@ -3,12 +3,26 @@
 __all__ = ['dilidili_download']
 
 from ..common import *
+from .ckplayer import ckplayer_download
+
+headers = {
+    'DNT': '1',
+    'Accept-Encoding': 'gzip, deflate, sdch, br',
+    'Accept-Language': 'en-CA,en;q=0.8,en-US;q=0.6,zh-CN;q=0.4,zh;q=0.2',
+    'Upgrade-Insecure-Requests': '1',
+    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36',
+    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+    'Cache-Control': 'max-age=0',
+    'Referer': 'http://www.dilidili.com/',
+    'Connection': 'keep-alive',
+    'Save-Data': 'on',
+}
 
 #----------------------------------------------------------------------
-def dilidili_parser_data_to_stream_types(typ ,vid ,hd2 ,sign):
+def dilidili_parser_data_to_stream_types(typ ,vid ,hd2 ,sign, tmsign, ulk):
     """->list"""
-    parse_url = 'http://player.005.tv/parse.php?xmlurl=null&type={typ}&vid={vid}&hd={hd2}&sign={sign}'.format(typ = typ, vid = vid, hd2 = hd2, sign = sign)
-    html = get_html(parse_url)
+    parse_url = 'http://player.005.tv/parse.php?xmlurl=null&type={typ}&vid={vid}&hd={hd2}&sign={sign}&tmsign={tmsign}&userlink={ulk}'.format(typ = typ, vid = vid, hd2 = hd2, sign = sign, tmsign = tmsign, ulk = ulk)
+    html = get_content(parse_url, headers=headers)
     
     info = re.search(r'(\{[^{]+\})(\{[^{]+\})(\{[^{]+\})(\{[^{]+\})(\{[^{]+\})', html).groups()
     info = [i.strip('{}').split('->') for i in info]
@@ -19,46 +33,52 @@ def dilidili_parser_data_to_stream_types(typ ,vid ,hd2 ,sign):
         stream_types.append({'id': str(i[1][-1]), 'container': 'mp4', 'video_profile': i[0]})
     return stream_types
 
-#----------------------------------------------------------------------
-def dilidili_parser_data_to_download_url(typ ,vid ,hd2 ,sign):
-    """->str"""
-    parse_url = 'http://player.005.tv/parse.php?xmlurl=null&type={typ}&vid={vid}&hd={hd2}&sign={sign}'.format(typ = typ, vid = vid, hd2 = hd2, sign = sign)
-    html = get_html(parse_url)
+##----------------------------------------------------------------------
+#def dilidili_parser_data_to_download_url(typ ,vid ,hd2 ,sign, tmsign, ulk):
+    #"""Not used for now"""
+    #parse_url = 'http://player.005.tv/parse.php?xmlurl=null&type={typ}&vid={vid}&hd={hd2}&sign={sign}&tmsign={tmsign}&userlink={ulk}'.format(typ = typ, vid = vid, hd2 = hd2, sign = sign, tmsign = tmsign, ulk = ulk)
+    #html = get_content(parse_url, headers=headers)
     
-    return match1(html, r'<file><!\[CDATA\[(.+)\]\]></file>')
+    #return match1(html, r'<file><!\[CDATA\[(.+)\]\]></file>')
 
 #----------------------------------------------------------------------
 def dilidili_download(url, output_dir = '.', merge = False, info_only = False, **kwargs):
     if re.match(r'http://www.dilidili.com/watch/\w+', url):
-        html = get_html(url)
+        html = get_content(url)
         title = match1(html, r'<title>(.+)丨(.+)</title>')  #title
         
         # player loaded via internal iframe
         frame_url = re.search(r'<iframe (.+)src="(.+)\" f(.+)</iframe>', html).group(2)
+        #print(frame_url)
+        
         #https://player.005.tv:60000/?vid=a8760f03fd:a04808d307&v=yun&sign=a68f8110cacd892bc5b094c8e5348432
-        html = get_html(frame_url)
+        html = get_content(frame_url, headers=headers)
         
         match = re.search(r'(.+?)var video =(.+?);', html)
         vid = match1(html, r'var vid="(.+)"')
         hd2 = match1(html, r'var hd2="(.+)"')
         typ = match1(html, r'var typ="(.+)"')
         sign = match1(html, r'var sign="(.+)"')
+        tmsign = match1(html, r'tmsign=([A-Za-z0-9]+)')
+        ulk =  match1(html, r'var ulk="(.+)"')
         
         # here s the parser...
-        stream_types = dilidili_parser_data_to_stream_types(typ, vid, hd2, sign)
+        stream_types = dilidili_parser_data_to_stream_types(typ, vid, hd2, sign, tmsign, ulk)
         
         #get best
         best_id = max([i['id'] for i in stream_types])
         
-        url = dilidili_parser_data_to_download_url(typ, vid, best_id, sign)
+        parse_url = 'http://player.005.tv/parse.php?xmlurl=null&type={typ}&vid={vid}&hd={hd2}&sign={sign}&tmsign={tmsign}&userlink={ulk}'.format(typ = typ, vid = vid, hd2 = best_id, sign = sign, tmsign = tmsign, ulk = ulk)
+        
+        ckplayer_download(parse_url, output_dir, merge, info_only, is_xml = True, title = title, headers = headers)
 
-        type_ = ''
-        size = 0
+        #type_ = ''
+        #size = 0
 
-        type_, ext, size = url_info(url)
-        print_info(site_info, title, type_, size)
-        if not info_only:
-            download_urls([url], title, ext, total_size=None, output_dir=output_dir, merge=merge)
+        #type_, ext, size = url_info(url)
+        #print_info(site_info, title, type_, size)
+        #if not info_only:
+            #download_urls([url], title, ext, total_size=None, output_dir=output_dir, merge=merge)
 
 site_info = "dilidili"
 download = dilidili_download

--- a/src/you_get/extractors/dilidili.py
+++ b/src/you_get/extractors/dilidili.py
@@ -33,14 +33,6 @@ def dilidili_parser_data_to_stream_types(typ ,vid ,hd2 ,sign, tmsign, ulk):
         stream_types.append({'id': str(i[1][-1]), 'container': 'mp4', 'video_profile': i[0]})
     return stream_types
 
-##----------------------------------------------------------------------
-#def dilidili_parser_data_to_download_url(typ ,vid ,hd2 ,sign, tmsign, ulk):
-    #"""Not used for now"""
-    #parse_url = 'http://player.005.tv/parse.php?xmlurl=null&type={typ}&vid={vid}&hd={hd2}&sign={sign}&tmsign={tmsign}&userlink={ulk}'.format(typ = typ, vid = vid, hd2 = hd2, sign = sign, tmsign = tmsign, ulk = ulk)
-    #html = get_content(parse_url, headers=headers)
-    
-    #return match1(html, r'<file><!\[CDATA\[(.+)\]\]></file>')
-
 #----------------------------------------------------------------------
 def dilidili_download(url, output_dir = '.', merge = False, info_only = False, **kwargs):
     if re.match(r'http://www.dilidili.com/watch/\w+', url):


### PR DESCRIPTION
I am using the latest ```ckplayer``` to do the extracting.

I am thinking should we have TAPS sometime in the future, this would reduce a lot of works.

I am still having some problems with sources at Tudou, like http://www.dilidili.com/watch/9901/ . But I cannot play it anyway from my side. 

```
python3 you-get --debug http://www.dilidili.com/watch/27625/
Site:       CKPlayer General
Title:      Schwarzesmarken死亡黑标 第3话 第3话
Type:       Flash video (video/x-flv)
Size:       205.79 MiB (215785120 Bytes)

Downloading Schwarzesmarken死亡黑标 第3话 第3话.flv ...
 0.0% (  0.0/205.8MB) ├─────────────────────────────────────────┤[1/8] ^C
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/990)
<!-- Reviewable:end -->
