### PR TITLE
Enhanced debug logging: Print URL of get_content call when --debug is enabled

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -91,6 +91,7 @@ SITES = {
 import getopt
 import json
 import locale
+import logging
 import os
 import platform
 import re
@@ -297,6 +298,8 @@ def get_content(url, headers={}, decoded=True):
     Returns:
         The content as a string.
     """
+
+    logging.debug('get_content: %s' % url)
 
     req = request.Request(url, headers=headers)
     if cookies:
@@ -1032,6 +1035,8 @@ def script_main(script_name, download, download_playlist, **kwargs):
               % get_version(kwargs['repo_path']
             if 'repo_path' in kwargs else __version__))
 
+    logging.basicConfig(format='[%(levelname)s] %(message)s')
+
     help = 'Usage: %s [OPTION]... [URL]...\n\n' % script_name
     help += '''Startup options:
     -V | --version                      Print version and exit.
@@ -1055,7 +1060,7 @@ def script_main(script_name, download, download_playlist, **kwargs):
     -x | --http-proxy <HOST:PORT>       Use an HTTP proxy for downloading.
     -y | --extractor-proxy <HOST:PORT>  Use an HTTP proxy for extracting only.
          --no-proxy                     Never use a proxy.
-    -d | --debug                        Show traceback for debugging.
+    -d | --debug                        Show traceback and other debug info.
     '''
 
     short_opts = 'Vhfiuc:ndF:O:o:p:x:y:'
@@ -1145,6 +1150,8 @@ def script_main(script_name, download, download_playlist, **kwargs):
             proxy = ''
         elif o in ('-d', '--debug'):
             traceback = True
+            # Set level of root logger to DEBUG
+            logging.getLogger().setLevel(logging.DEBUG)
         elif o in ('-F', '--format', '--stream', '--itag'):
             stream_id = a
         elif o in ('-O', '--output-filename'):


### PR DESCRIPTION
I know this PR is unsolicited and may be controversial (especially in terms of implementation), but the undeniable fact is currently the `--debug` option doesn't live up to its name. It only enables a traceback upon failure, which is useless most of the time (at least for me) without dropping into a debugger.

Most errors I have ever encountered occur at the extraction stage, so it's essential to know the URLs that you-get is trying to retrieve and parse in order to determine why it fails to do so. It also helps to know what's being retrieved in the case of zero failure yet seemingly hanging forever (happens to me often enough — connection to Mainland is really bad). AFAIK `get_content` is the most common and non-deprecated function used in the extraction stage, so in this PR I'm printing the URL of each `get_content` call when `--debug` is enabled. Here's an example:

```
> you-get -u -d http://v.youku.com/v_show/id_XMTUwNTkyOTQwNA\=\=.html
[DEBUG] get_content: http://play.youku.com/play/get.json?vid=XMTUwNTkyOTQwNA==&ct=10
[DEBUG] get_content: http://play.youku.com/play/get.json?vid=XMTUwNTkyOTQwNA==&ct=12
[DEBUG] get_content: http://k.youku.com/player/getFlvPath/sid/4458453567965121132a9_00/st/flv/fileid/030002010056EE397AB0EC11E60AB5BF5D6B79-F671-7D3E-FF81-C960F44E973B?ev=1&ep=diaREk2IVcsG4irZjT8bZi3hdiYGXP4J9h%2BFg9JjALshTp3KmjfWtu%2BwO4xDF4wfclN0FZmHrqThGEcdYYZFrmkQ2DqrTPqWiPji5d5awpB2Yh1De8rUxlScQjL4&K=3eedbd22d6eabeeb261ee89d&yxon=1&oip=1657983508&ctype=12&token=2129
site:                优酷 (Youku)
title:               Test
stream:
    - format:        flvhd
      container:     flv
      video-profile: 标清
      size:          0.0 MiB (28622 bytes)
    # download-with: you-get --format=flvhd [URL]

Real URLs:
http://103.38.56.154/youku/6573FE04A9D3E7A94929F6296/030002010056EE397AB0EC11E60AB5BF5D6B79-F671-7D3E-FF81-C960F44E973B.flv
```

Of course this debug logging mechanism may be extended to other functions too. The output format could be tweaked. (Note that I'm using `logging.debug` instead of `util.log.d` because the latter is unconditional, and passing an extra parameter around is too much trouble.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/999)
<!-- Reviewable:end -->
