### PR TITLE
Extend unit tests for extractors

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -20,11 +20,3 @@ class YouGetTests(unittest.TestCase):
 
     def test_mixcloud(self):
         mixcloud.download("http://www.mixcloud.com/DJVadim/north-america-are-you-ready/", info_only=True)
-
-    def test_vimeo(self):
-        vimeo.download("http://vimeo.com/56810854", info_only=True)
-
-    def test_youtube(self):
-        youtube.download("http://www.youtube.com/watch?v=pzKerr0JIPA", info_only=True)
-        youtube.download("http://youtu.be/pzKerr0JIPA", info_only=True)
-        youtube.download("http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare", info_only=True)

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+import unittest
+
+from you_get.extractors import *
+
+class YouTubeTests(unittest.TestCase):
+
+    def test_download(self):
+        youtube.download("http://www.youtube.com/watch?v=pzKerr0JIPA", info_only=True)
+        youtube.download("http://youtu.be/pzKerr0JIPA", info_only=True)
+        youtube.download("http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare", info_only=True)
+
+    def test_download_playlist(self):
+        youtube.download_playlist("https://www.youtube.com/playlist?list=PLgjdyCiEceFiXM8veBtbOOMfyeWsoMinG", info_only=True)
+
+    def test_get_url_from_vid(self):
+        self.assertEqual(YouTube.get_url_from_vid('tdsTfZMqAxw'), 'https://youtu.be/tdsTfZMqAxw')
+
+    def test_get_vid_from_url(self):
+        self.assertEqual(YouTube.get_vid_from_url('https://www.youtube.com/watch?v=c3BlRCGPEbs'),
+                         'c3BlRCGPEbs')
+
+    def test_get_playlist_id_from_url(self):
+        self.assertEqual(YouTube.get_playlist_id_from_url('https://www.youtube.com/watch?v=VbfpW0pbvaU&index=10&list=PLDcnymzs18LVXfO_x0Ei0R24qDbVtyy66'),
+                         'PLDcnymzs18LVXfO_x0Ei0R24qDbVtyy66')
+
+
+class XiamiTests(unittest.TestCase):
+
+    def test_download_video(self):
+        xiami.download("http://www.xiami.com/play?ids=/song/playlist/id/1/type/9#open", info_only=True)
+
+    def test_download_pic(self):
+        xiami.download("http://www.xiami.com/artist/pic-detail/pid/13452?spm=0.0.0.0.2lEgvQ", info_only=True)
+
+    def test_download_song(self):
+        xiami.download("http://www.xiami.com/song/1775852230?spm=a1z1s.7400859.1392350021.4.oSFNmx", info_only=True)
+
+    def test_download_album(self):
+        xiami.download("http://www.xiami.com/album/2100217288?spm=a1z1s.7400860.1392350021.1.m0BAKq", info_only=True)
+
+
+class InstagramTests(unittest.TestCase):
+
+    def test_download_video(self):
+        instagram.download("https://www.instagram.com/p/BD8w6M3Pxei/", info_only=True)
+
+    def test_download_image(self):
+        instagram.download("https://www.instagram.com/p/BD8lTLIvxTn/", info_only=True)
+
+
+class TwitterTests(unittest.TestCase):
+
+    def test_download_video(self):
+        twitter.download("https://twitter.com/BlueJays/status/719272038318284800?lang=en", info_only=True)
+
+    def test_download_image(self):
+        twitter.download("https://twitter.com/Raptors/status/719350726745567232", info_only=True)
+
+
+class VineTests(unittest.TestCase):
+
+    def test_download_video(self):
+        vine.download("https://vine.co/v/MDl3QL0rK50", info_only=True)
+
+    def test_download_card(self):
+        vine.download("https://vine.co/v/iITOeY0mDuZ", info_only=True)
+
+
+class SoundcloudTests(unittest.TestCase):
+
+    def test_download_song(self):
+        soundcloud.download("https://soundcloud.com/nettwerkmusicgroup/angus-julia-stone-the-devils-tears", info_only=True)
+
+
+class PinterestTests(unittest.TestCase):
+
+    def test_download(self):
+        pinterest.download("https://www.pinterest.com/pin/177962622746499307/", info_only=True)
+
+
+class VimeoTests(unittest.TestCase):
+
+    def test_download(self):
+        vimeo.download("http://vimeo.com/56810854", info_only=True)
+
+
+class TumblrTests(unittest.TestCase):
+
+    def test_download(self):
+        tumblr.download("http://ben-smith-123.tumblr.com/post/138801913226", info_only=True)
+
+
+class TedTests(unittest.TestCase):
+
+    def test_download(self):
+        ted.download("https://www.ted.com/talks/linus_torvalds_the_mind_behind_linux", info_only=True)
+


### PR DESCRIPTION
Extended unit tests for youtube, xiami, vine, instagram, twitter, soundcloud, pinterest, tumbler, and ted extractor modules (26 test cases).

Each of the above websites have their test cases under one class (encapsulation).

Quick branch coverage was used to highlight the need for more unit test cases (using coverage.py).
Following is a table showing the improvements in coverage due to the extended unit tests:

| File | Before  | After |
| --- | --- | --- |
| src/you_get/extractors/youtube.py | 42% | 57% |
| src/you_get/extractors/xiami.py | 8% | 54%|
| src/you_get/extractors/vine.py | 30% | 80%|
| src/you_get/extractors/instagram.py |25% |92%|
| src/you_get/extractors/twitter.py |9% |64%|
| src/you_get/extractors/soundcloud.py |32%| 91%|
| src/you_get/extractors/pinterest.py|43%| 100%|
| src/you_get/extractors/ted.py|28%|84%|
| src/you_get/extractors/tumblr.py |10%| 39%|

