### PR TITLE
[Dilidili] Fix codec, fix #1085

### DIFF
--- a/src/you_get/extractors/dilidili.py
+++ b/src/you_get/extractors/dilidili.py
@@ -40,11 +40,11 @@ def dilidili_download(url, output_dir = '.', merge = False, info_only = False, *
         title = match1(html, r'<title>(.+)丨(.+)</title>')  #title
         
         # player loaded via internal iframe
-        frame_url = re.search(r'<iframe (.+)src="(.+)\" f(.+)</iframe>', html).group(2)
+        frame_url = re.search(r'<iframe src=\"(.+?)\"', html).group(1)
         #print(frame_url)
         
         #https://player.005.tv:60000/?vid=a8760f03fd:a04808d307&v=yun&sign=a68f8110cacd892bc5b094c8e5348432
-        html = get_content(frame_url, headers=headers)
+        html = get_content(frame_url, headers=headers, decoded=False).decode('utf-8')
         
         match = re.search(r'(.+?)var video =(.+?);', html)
         vid = match1(html, r'var vid="(.+)"')


### PR DESCRIPTION
```
python3 you-get --debug http://www.dilidili.com/watch/3539/
[DEBUG] get_content: http://www.dilidili.com/watch/3539/
[DEBUG] get_content: https://player.005.tv:60000/?vid=XNTM1OTgxMjYw&v=youku&sign=602f02e01e9eb5e50010eb8d02a68aa4
[DEBUG] get_content: http://player.005.tv/parse.php?xmlurl=null&type=youku&vid=XNTM1OTgxMjYw&hd=2&sign=602f02e01e9eb5e50010eb8d02a68aa4&tmsign=3e2408856fae07b443098d72a6e75359&userlink=http%3A%2F%2Fwww.dilidili.com%2F
[DEBUG] get_content: http://player.005.tv/parse.php?xmlurl=null&type=youku&vid=XNTM1OTgxMjYw&hd=3&sign=602f02e01e9eb5e50010eb8d02a68aa4&tmsign=3e2408856fae07b443098d72a6e75359&userlink=http%3A%2F%2Fwww.dilidili.com%2F
Site:       CKPlayer General
Title:      银魂 第239话「忘年会上仍有不可忘记的事物」
Type:       Flash video (video/x-flv)
Size:       212.89 MiB (223227471 Bytes)

Downloading 银魂 第239话「忘年会上仍有不可忘记的事物」.flv ...
 0.2% (  0.5/212.9MB) ├─────────────────────────────────────────┤[1/8]    1 MB/s^CTraceback
```

![image](https://cloud.githubusercontent.com/assets/1560962/14868316/fd516580-0c9a-11e6-96ee-4b6ff2713d82.png)

```
import chardet
chardet.detect(a)
{'confidence': 1.0, 'encoding': 'UTF-8-SIG'}
```

Why you do that to me?

BTW this issue can be not reproducible with multiple trials. I am so luck to catch it at the first trial. 

The only thing I can say is this quick fix will not break anything...hopefully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1088)
<!-- Reviewable:end -->
