### PR TITLE
bandcamp: Sometimes the first key is video_caption

### DIFF
--- a/src/you_get/extractors/bandcamp.py
+++ b/src/you_get/extractors/bandcamp.py
@@ -6,7 +6,7 @@ from ..common import *
 
 def bandcamp_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
     html = get_html(url)
-    trackinfo = json.loads(r1(r'(\[{"video_poster_url".*}\]),', html))
+    trackinfo = json.loads(r1(r'(\[{"(video_poster_url|video_caption)".*}\]),', html))
     for track in trackinfo:
         track_num = track['track_num']
         title = '%s. %s' % (track_num, track['title'])


### PR DESCRIPTION
This fixes the exception:

    File "you-get/lib/python3.4/site-packages/you_get/extractors/bandcamp.py", line 9, in bandcamp_download
      trackinfo = json.loads(r1(r'(\[{"video_poster_url".*}\]),', html))
    File "/usr/lib64/python3.4/json/__init__.py", line 312, in loads
      s.__class__.__name__))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1097)
<!-- Reviewable:end -->
