### PR TITLE
match 'http://www.dilidili.com/watch' and '/watch3'

### DIFF
--- a/src/you_get/extractors/dilidili.py
+++ b/src/you_get/extractors/dilidili.py
@@ -35,7 +35,7 @@ def dilidili_parser_data_to_stream_types(typ ,vid ,hd2 ,sign, tmsign, ulk):
 
 #----------------------------------------------------------------------
 def dilidili_download(url, output_dir = '.', merge = False, info_only = False, **kwargs):
-    if re.match(r'http://www.dilidili.com/watch/\w+', url):
+    if re.match(r'http://www.dilidili.com/watch\w+', url):
         html = get_content(url)
         title = match1(html, r'<title>(.+)丨(.+)</title>')  #title
         

--- a/src/you_get/extractors/dilidili.py
+++ b/src/you_get/extractors/dilidili.py
@@ -35,7 +35,7 @@ def dilidili_parser_data_to_stream_types(typ ,vid ,hd2 ,sign, tmsign, ulk):
 
 #----------------------------------------------------------------------
 def dilidili_download(url, output_dir = '.', merge = False, info_only = False, **kwargs):
-    if re.match(r'http://www.dilidili.com/watch\w+', url):
+    if re.match(r'http://www.dilidili.com/watch\S', url):
         html = get_content(url)
         title = match1(html, r'<title>(.+)丨(.+)</title>')  #title
         


### PR DESCRIPTION
I am very sorry that I commit a wrong code yesterday.

Now, it should be fixed.

It means to match `http://www.dilidili.com/watch3/37348/` and `http://www.dilidili.com/watch/29976` which is different from 'watch/' and 'watch3/'.

My test:

```
you-get -p mpv http://www.dilidili.com/watch3/37348/
Site:       CKPlayer General
Title:      我叫坂本我最屌 第4话 坂本是臭流氓吗？
Type:       MPEG-4 video (video/mp4)
Size:       184.63 MiB (193598554 Bytes)
```

```
you-get -p mpv http://www.dilidili.com/watch/29976/
Site:       CKPlayer General
Title:      Legal High 第1集
Type:       Flash video (video/x-flv)
Size:       703.8 MiB (737990733 Bytes)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1114)
<!-- Reviewable:end -->
