### PR TITLE
add support Panda.tv

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Use `--url`/`-u` to get a list of downloadable resource URLs extracted from the 
 | Dilidili | <http://www.dilidili.com/>     |✓| | |
 | 豆瓣     | <http://www.douban.com/>       | | |✓|
 | 斗鱼     | <http://www.douyutv.com/>      |✓| | |
+| Panda<br/>熊猫 | <http://www.panda.tv/>      |✓| | |
 | 凤凰视频 | <http://v.ifeng.com/>          |✓| | |
 | 风行网   | <http://www.fun.tv/>           |✓| | |
 | iQIYI<br/>爱奇艺 | <http://www.iqiyi.com/> |✓| | |

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -54,6 +54,7 @@ SITES = {
     'musicplayon'      : 'musicplayon',
     '7gogo'            : 'nanagogo',
     'nicovideo'        : 'nicovideo',
+    'panda'            : 'panda',
     'pinterest'        : 'pinterest',
     'pixnet'           : 'pixnet',
     'pptv'             : 'pptv',

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -47,6 +47,7 @@ from .musicplayon import *
 from .nanagogo import *
 from .netease import *
 from .nicovideo import *
+from .panda import *
 from .pinterest import *
 from .pixnet import *
 from .pptv import *

--- a/src/you_get/extractors/panda.py
+++ b/src/you_get/extractors/panda.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+__all__ = ['panda_download']
+
+from ..common import *
+import json
+import time
+
+def panda_download(url, output_dir = '.', merge = True, info_only = False, **kwargs):
+    roomid = url[url.rfind('/')+1:]
+    json_request_url = 'http://www.panda.tv/api_room?roomid={}&pub_key=&_={}'.format(roomid, int(time.time()))
+    content = get_html(json_request_url)
+    errno = json.loads(content)['errno']
+    errmsg = json.loads(content)['errmsg']
+    if errno:
+        raise ValueError("Errno : {}, Errmsg : {}".format(errno, errmsg))
+
+    data = json.loads(content)['data']
+    title = data.get('roominfo')['name']
+    room_key = data.get('videoinfo')['room_key']
+    status = data.get('videoinfo')['status']
+    if status is not "2":
+        raise ValueError("The live stream is not online! (status:%s)" % status)
+    real_url = 'http://pl3.live.panda.tv/live_panda/{}.flv'.format(room_key)
+
+    print_info(site_info, title, 'flv', float('inf'))
+    if not info_only:
+        download_urls([real_url], title, 'flv', None, output_dir, merge = merge)
+
+site_info = "panda.tv"
+download = panda_download
+download_playlist = playlist_not_supported('panda')


### PR DESCRIPTION
some test:
```
$ you-get http://www.panda.tv/11175
Site:       panda.tv
Title:      解说米勒：6.9版本无敌上分套路
Type:       Flash video (video/x-flv)
Size:       inf MiB (inf Bytes)

Downloading 解说米勒：6.9版本无敌上分套路.flv ...
 0.0% ( 70.2/  infMB) ├────────────────────────────────────────────────┤[1/1]  241 kB/s
```
```
$ you-get -i http://www.panda.tv/11175
Site:       panda.tv
Title:      解说米勒：6.9版本无敌上分套路
Type:       Flash video (video/x-flv)
Size:       inf MiB (inf Bytes)
```
```
$ you-get --json http://www.panda.tv/11175
{
    "site": "panda.tv",
    "streams": {
        "__default__": {
            "container": "flv",
            "size": null,
            "src": [
                "http://pl3.live.panda.tv/live_panda/ff219f7a58fe290ef8e39e7df4986f7c.flv"
            ],
            "video_profile": "__default__"
        }
    },
    "title": "解说米勒：6.9版本无敌上分套路",
    "url": null
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1123)
<!-- Reviewable:end -->
