### PR TITLE
Retry request if timeout in get_content

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -98,6 +98,7 @@ import logging
 import os
 import platform
 import re
+import socket
 import sys
 import time
 from urllib import request, parse, error
@@ -308,7 +309,14 @@ def get_content(url, headers={}, decoded=True):
     if cookies:
         cookies.add_cookie_header(req)
         req.headers.update(req.unredirected_hdrs)
-    response = request.urlopen(req)
+
+    for i in range(10):
+        try:
+            response = request.urlopen(req, timeout=10)
+            break
+        except socket.timeout:
+            logging.debug('request attempt %s timeout' % str(i + 1))
+
     data = response.read()
 
     # Handle HTTP compression for gzip and deflate (zlib)

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -312,7 +312,7 @@ def get_content(url, headers={}, decoded=True):
 
     for i in range(10):
         try:
-            response = request.urlopen(req, timeout=10)
+            response = request.urlopen(req)
             break
         except socket.timeout:
             logging.debug('request attempt %s timeout' % str(i + 1))
@@ -1071,11 +1071,12 @@ def script_main(script_name, download, download_playlist, **kwargs):
     -x | --http-proxy <HOST:PORT>       Use an HTTP proxy for downloading.
     -y | --extractor-proxy <HOST:PORT>  Use an HTTP proxy for extracting only.
          --no-proxy                     Never use a proxy.
+    -t | --timeout <SECONDS>            Set socket timeout.
     -d | --debug                        Show traceback and other debug info.
     '''
 
-    short_opts = 'Vhfiuc:ndF:O:o:p:x:y:'
-    opts = ['version', 'help', 'force', 'info', 'url', 'cookies', 'no-caption', 'no-merge', 'no-proxy', 'debug', 'json', 'format=', 'stream=', 'itag=', 'output-filename=', 'output-dir=', 'player=', 'http-proxy=', 'extractor-proxy=', 'lang=']
+    short_opts = 'Vhfiuc:ndF:O:o:p:x:y:t:'
+    opts = ['version', 'help', 'force', 'info', 'url', 'cookies', 'no-caption', 'no-merge', 'no-proxy', 'debug', 'json', 'format=', 'stream=', 'itag=', 'output-filename=', 'output-dir=', 'player=', 'http-proxy=', 'extractor-proxy=', 'lang=', 'timeout=']
     if download_playlist:
         short_opts = 'l' + short_opts
         opts = ['playlist'] + opts
@@ -1105,6 +1106,7 @@ def script_main(script_name, download, download_playlist, **kwargs):
     proxy = None
     extractor_proxy = None
     traceback = False
+    timeout = 600
     for o, a in opts:
         if o in ('-V', '--version'):
             version()
@@ -1178,6 +1180,8 @@ def script_main(script_name, download, download_playlist, **kwargs):
             extractor_proxy = a
         elif o in ('--lang',):
             lang = a
+        elif o in ('-t', '--timeout'):
+            timeout = int(a)
         else:
             log.e("try 'you-get --help' for more options")
             sys.exit(2)
@@ -1186,6 +1190,8 @@ def script_main(script_name, download, download_playlist, **kwargs):
         sys.exit()
 
     set_http_proxy(proxy)
+
+    socket.setdefaulttimeout(timeout)
 
     try:
         if stream_id:


### PR DESCRIPTION
To workaround #1155, I've implemented automatic retry if the request timeout after 10 seconds.
It works pretty well for me.
```
C:\Users\JayXon\Documents\GitHub\you-get (develop)
λ python you-get -d -o d: http://www.youku.com/show_page/id_z3411ef989cc211e5b2ad.html
[DEBUG] get_content: http://www.youku.com/show_episode/id_z3411ef989cc211e5b2ad
site:                优酷 (Youku)
playlist:            None
videos:
[DEBUG] get_content: http://play.youku.com/play/get.json?vid=XMTQxNDgxODc4OA==&ct=10
[DEBUG] request attempt 1 timeout
[DEBUG] request attempt 2 timeout
[DEBUG] request attempt 3 timeout
[DEBUG] get_content: http://play.youku.com/play/get.json?vid=XMTQxNDgxODc4OA==&ct=12
[DEBUG] request attempt 1 timeout
[DEBUG] request attempt 2 timeout
[DEBUG] get_content: http://k.youku.com/player/getFlvPath/sid/646398349212412466457_00/st/flv/fileid/0300800B0056709DB929512FC2939CAD5A2E01-F9B4-4744-3EA8-D256A08225F9?yxon=1&token=2924&ctype=12&ev=1&oip=847826864&ep=dCaSGUCFVcoJ5yLdjD8bYyrkcHIIXP4J9h%2BNgdIQALshTu%2B%2FkEqjzp%2B5S%2F5AYIobeyEPY5qFrqHlH0AVYYZK22wQ20msPfrji4Hr5dlRwZZxZhE0cMihvVScSjL1&K=a788335c5e9e250324129d92
[DEBUG] get_content: http://k.youku.com/player/getFlvPath/sid/646398349212412466457_00/st/flv/fileid/0300800B0156709DB929512FC2939CAD5A2E01-F9B4-4744-3EA8-D256A08225F9?yxon=1&token=2924&ctype=12&ev=1&oip=847826864&ep=dCaSGUCFVcoJ5yLdjD8bYyrkcHIIXP4J9h%2BNgdIQALohTu%2B%2FkEqjzp%2B5S%2F5AYIobeyEPY5qFrqHlH0AVYYZK22wQ20msPfrji4Hr5dlRwZZxZhE0cMihvVScSjL1&K=7674d0f9772b04ce24129d92
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1159)
<!-- Reviewable:end -->
