### PR TITLE
[Videomega] Fix support

### DIFF
--- a/src/you_get/extractors/videomega.py
+++ b/src/you_get/extractors/videomega.py
@@ -1,47 +1,41 @@
 #!/usr/bin/env python
 
-from ..common import *
-from ..extractor import VideoExtractor
+__all__ = ['videomega_download']
 
+from ..common import *
 import ssl
 
-class Videomega(VideoExtractor):
-    name = "Videomega"
+def videomega_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
+    # Hot-plug cookie handler
+    ssl_context = request.HTTPSHandler(
+        context=ssl.SSLContext(ssl.PROTOCOL_TLSv1))
+    cookie_handler = request.HTTPCookieProcessor()
+    opener = request.build_opener(ssl_context, cookie_handler)
+    opener.addheaders = [('Referer', url),
+                         ('Cookie', 'noadvtday=0')]
+    request.install_opener(opener)
 
-    stream_types = [
-        {'id': 'original'}
-    ]
+    content = get_content(url)
+    m = re.search(r'ref="([^"]*)";\s*width="([^"]*)";\s*height="([^"]*)"', content)
+    ref = m.group(1)
+    width, height = m.group(2), m.group(3)
+    php_url = 'http://videomega.tv/view.php?ref=%s&width=%s&height=%s' % (ref, width, height)
+    content = get_content(php_url)
 
-    def prepare(self, **kwargs):
-        # Hot-plug cookie handler
-        ssl_context = request.HTTPSHandler(
-            context=ssl.SSLContext(ssl.PROTOCOL_TLSv1))
-        cookie_handler = request.HTTPCookieProcessor()
-        opener = request.build_opener(ssl_context, cookie_handler)
-        opener.addheaders = [('Referer', self.url),
-                             ('Cookie', 'noadvtday=0')]
-        request.install_opener(opener)
+    title = match1(content, r'<title>(.*)</title>')
+    js = match1(content, r'(eval.*)')
+    t = match1(js, r'\$\("\w+"\)\.\w+\("\w+","([^"]+)"\)')
+    t = re.sub(r'(\w)', r'{\1}', t)
+    t = t.translate({87 + i: str(i) for i in range(10, 36)})
+    s = match1(js, r"'([^']+)'\.split").split('|')
+    src = t.format(*s)
 
-        ref = match1(self.url, r'ref=(\w+)')
-        php_url = 'http://videomega.tv/view.php?ref=' + ref
-        content = get_content(php_url)
+    type, ext, size = url_info(src, faker=True)
 
-        self.title = match1(content, r'<title>(.*)</title>')
-        js = match1(content, r'(eval.*)')
-        t = match1(js, r'\$\("\d+"\)\.\d+\("\d+","([^"]+)"\)')
-        t = re.sub(r'(\w)', r'{\1}', t)
-        t = t.translate({87 + i: str(i) for i in range(10, 36)})
-        s = match1(js, r"'([^']+)'\.split").split('|')
-        self.streams['original'] = {
-            'url': t.format(*s)
-        }
+    print_info(site_info, title, type, size)
+    if not info_only:
+        download_urls([src], title, ext, size, output_dir, merge=merge, faker=True)
 
-    def extract(self, **kwargs):
-        for i in self.streams:
-            s = self.streams[i]
-            _, s['container'], s['size'] = url_info(s['url'])
-            s['src'] = [s['url']]
-
-site = Videomega()
-download = site.download_by_url
-download_playlist = site.download_by_url
+site_info = "Videomega.tv"
+download = videomega_download
+download_playlist = playlist_not_supported('videomega')


### PR DESCRIPTION
Since it does UA sniffing now, the implementation of `videomega.py` has to be switched from `VideoExtractor` back to plain `download_urls`. Oldie but goodie.

```
$ you-get -di 'http://videomega.tv/?ref=QLFRB3LTK66KTL3BRFLQ'
[DEBUG] get_content: http://videomega.tv/view.php?ref=QLFRB3LTK66KTL3BRFLQ
you-get: version 0.4.431, a tiny downloader that scrapes the web.
you-get: ['http://videomega.tv/?ref=QLFRB3LTK66KTL3BRFLQ']
Traceback (most recent call last):
  File "/home/soimort/Projects/you-get/you-get", line 11, in <module>
    you_get.main(repo_path=_filepath)
  File "/home/soimort/Projects/you-get/src/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/home/soimort/Projects/you-get/src/you_get/common.py", line 1291, in main
    script_main('you-get', any_download, any_download_playlist, **kwargs)
  File "/home/soimort/Projects/you-get/src/you_get/common.py", line 1204, in script_main
    download_main(download, download_playlist, args, playlist, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output, caption=caption)
  File "/home/soimort/Projects/you-get/src/you_get/common.py", line 1041, in download_main
    download(url, **kwargs)
  File "/home/soimort/Projects/you-get/src/you_get/common.py", line 1284, in any_download
    m.download(url, **kwargs)
  File "/home/soimort/Projects/you-get/src/you_get/extractor.py", line 40, in download_by_url
    self.prepare(**kwargs)
  File "/home/soimort/Projects/you-get/src/you_get/extractors/videomega.py", line 32, in prepare
    t = re.sub(r'(\w)', r'{\1}', t)
  File "/usr/lib/python3.5/re.py", line 182, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
```

```
$ you-get -di 'http://videomega.tv/?ref=QLFRB3LTK66KTL3BRFLQ'
[DEBUG] get_content: http://videomega.tv/?ref=QLFRB3LTK66KTL3BRFLQ
[DEBUG] get_content: http://videomega.tv/view.php?ref=QLFRB3LTK66KTL3BRFLQ&width=100%&height=400
Site:       Videomega.tv
Title:      Videomega.tv - STAR-574
Type:       MPEG-4 video (video/mp4)
Size:       1163.0 MiB (1219497865 Bytes)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1171)
<!-- Reviewable:end -->
