### PR TITLE
Add shell completion definitions for Bash, Fish and Zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ $ git clone git://github.com/soimort/you-get.git
 
 Then put the cloned directory into your `PATH`, or run `./setup.py install` to install `you-get` to a permanent path.
 
+### Shell completion
+
+Completion definitions for Bash, Fish and Zsh can be found in [`contrib/completion`](contrib/completion). Please consult your shell's manual for how to take advantage of them.
+
 ## Upgrading
 
 Based on which option you chose to install `you-get`, you may upgrade it via:

--- a/contrib/completion/_you-get
+++ b/contrib/completion/_you-get
@@ -1,0 +1,29 @@
+#compdef you-get
+
+# Zsh completion definition for soimort/you-get.
+
+setopt localoptions noshwordsplit noksharrays
+local -a args
+
+args=(
+    '(- : *)'{-V,--version}'[print version and exit]'
+    '(- : *)'{-h,--help}'[print help and exit]'
+    '(-i --info)'{-i,--info}'[print extracted information]'
+    '(-u --url)'{-u,--url}'[print extracted information with URLs]'
+    '(--json)--json[print extracted URLs in JSON format]'
+    '(-n --no-merge)'{-n,--no-merge}'[do not merge video parts]'
+    '(--no-caption)--no-caption[do not download captions]'
+    '(-f --force)'{-f,--force}'[force overwrite existing files]'
+    '(-F --format)'{-F,--format}'[set video format to the specified stream id]:stream id'
+    '(-O --output-filename)'{-O,--output-filename}'[set output filename]:filename:_files'
+    '(-o --output-dir)'{-o,--output-dir}'[set output directory]:directory:_files -/'
+    '(-p --player)'{-p,--player}'[stream extracted URL to the specified player]:player and options'
+    '(-c --cookies)'{-c,--cookies}'[load cookies.txt or cookies.sqlite]:cookies file:_files'
+    '(-x --http-proxy)'{-x,--http-proxy}'[use the specified HTTP proxy for downloading]:host\:port:'
+    '(-y --extractor-proxy)'{-y,--extractor-proxy}'[use the specified HTTP proxy for extraction only]:host\:port'
+    '(--no-proxy)--no-proxy[do not use a proxy]'
+    '(-t --timeout)'{-t,--timeout}'[set socket timeout]:seconds'
+    '(-d --debug)'{-d,--debug}'[show traceback and other debug info]'
+    '*: :_guard "^-*" url'
+)
+_arguments -S -s $args

--- a/contrib/completion/you-get-completion.bash
+++ b/contrib/completion/you-get-completion.bash
@@ -1,0 +1,31 @@
+# Bash completion definition for you-get.
+
+_you-get () {
+    COMPREPLY=()
+    local IFS=$' \n'
+    local cur=$2 prev=$3
+    local -a opts_without_arg opts_with_arg
+    opts_without_arg=(
+        -V --version -h --help -i --info -u --url --json -n --no-merge
+        --no-caption -f --force --no-proxy -d --debug
+    )
+    opts_with_arg=(
+        -F --format -O --output-filename -o --output-dir -p --player
+        -c --cookies -x --http-proxy -y --extractor-proxy -t --timeout
+    )
+
+    # Do not complete non option names
+    [[ $cur == -* ]] || return 1
+
+    # Do not complete when the previous arg is an option expecting an argument
+    for opt in "${opts_with_arg[@]}"; do
+        [[ $opt == $prev ]] && return 1
+    done
+
+    # Complete option names
+    COMPREPLY=( $(compgen -W "${opts_without_arg[*]} ${opts_with_arg[*]}" \
+                          -- "$cur") )
+    return 0
+}
+
+complete -F _you-get you-get

--- a/contrib/completion/you-get.fish
+++ b/contrib/completion/you-get.fish
@@ -1,0 +1,23 @@
+# Fish completion definition for you-get.
+
+complete -c you-get -s V -l version -d 'print version and exit'
+complete -c you-get -s h -l help -d 'print help and exit'
+complete -c you-get -s i -l info -d 'print extracted information'
+complete -c you-get -s u -l url -d 'print extracted information'
+complete -c you-get -l json -d 'print extracted URLs in JSON format'
+complete -c you-get -s n -l no-merge -d 'do not merge video parts'
+complete -c you-get -l no-caption -d 'do not download captions'
+complete -c you-get -s f -l force -d 'force overwrite existing files'
+complete -c you-get -s F -l format -x -d 'set video format to the specified stream id'
+complete -c you-get -s O -l output-filename -d 'set output filename' \
+         -x -a '(__fish_complete_path (commandline -ct) "output filename")'
+complete -c you-get -s o -l output-dir  -d 'set output directory' \
+         -x -a '(__fish_complete_directories (commandline -ct) "output directory")'
+complete -c you-get -s p -l player -x -d 'stream extracted URL to the specified player'
+complete -c you-get -s c -l cookies -d 'load cookies.txt or cookies.sqlite' \
+         -x -a '(__fish_complete_path (commandline -ct) "cookies.txt or cookies.sqlite")'
+complete -c you-get -s x -l http-proxy -x -d 'use the specified HTTP proxy for downloading'
+complete -c you-get -s y -l extractor-proxy -x -d 'use the specified HTTP proxy for extraction only'
+complete -c you-get -l no-proxy -d 'do not use a proxy'
+complete -c you-get -s t -l timeout -x -d 'set socket timeout'
+complete -c you-get -s d -l debug -d 'show traceback and other debug info'


### PR DESCRIPTION
See original discussion in #1178. I also wrote Bash and Fish completions for the sake of completeness.

---

Paths of completion definitions in this repo are inconsequential, and I don't know a convention for that, so I just modelled it on [git.git](https://github.com/git/git/tree/master/contrib/completion). What's different here is that instead of using a uniform naming scheme for each file (`you-get-completion.<shellname>`), I'm using the conventional name for each shell, which means `_you-get` for Zsh, for instance. Users of each shell should be able to pick out the completion definition for their shell based on the filenames; in the worst case, they can still tell from the comment at the top of each file.

Note that I'm no expert on Bash or Fish completion, so `you-get-completion.bash` and `you-get.fish` may not be written in the idiomatic way. (`you-get-completion.bash` is most certainly not idiomatic, if there's an idiom at all.)

Closes #1178.

---

### A word on automation

@cnbeining mentioned automation in https://github.com/soimort/you-get/issues/1178#issuecomment-222334019. It would be nice for sure, except it's hard to realize.

Zsh and Fish both support intuiting completion definition from docs. Zsh relies on `--help` (see documentation of the `--` option of `_arguments` in zcompsys) and requires a specific format. Here's what happens when it tries to parse `you-get`'s `--help`:

```zsh
> compdef '_arguments --' you-get
> you-get -<TAB>
 -- option --
--json        -- Print extracted URLs in JSON format.
--no-caption  -- Do not download captions.
--no-proxy    -- Never use a proxy.
-F            -- | --format <STREAM_ID>           Set video format to STREAM_ID.
-O            -- | --output-filename <FILE>       Set output filename.
-V            -- | --version                      Print version and exit.
-c            -- | --cookies <COOKIES_FILE>       Load cookies.txt or cookies.sqlite.
-d            -- | --debug                        Show traceback and other debug info.
-f            -- | --force                        Force overwriting existed files.
-h            -- | --help                         Print help and exit.
-i            -- | --info                         Print extracted information.
-n            -- | --no-merge                     Do not merge video parts.
-o            -- | --output-dir <PATH>            Set output directory.
-p            -- | --player <PLAYER (OPTIONS)>    Stream extracted URL to a PLAYER.
-t            -- | --timeout <SECONDS>            Set socket timeout.
-u            -- | --url                          Print extracted information with URLs.
-x            -- | --http-proxy <HOST-PORT>       Use an HTTP proxy for downloading.
-y            -- | --extractor-proxy <HOST-PORT>  Use an HTTP proxy for extracting only.
```

Obviously not cool.

Fish AFAIK (not a fish user) relies on man pages, and `you-get` doesn't have one. Even if it does, I doubt it will be able to match the granularity of hand-written definitions, e.g., only completing directories for `-o, --output-dir`.

Apart from automatic deduction, there are also examples of programmatic completion script generation, e.g., [`zsh.pl`](https://github.com/mpv-player/mpv/blob/master/TOOLS/zsh.pl) by mpv-player/mpv. But `mpv` has an option `--list-options` which generates a parseable list of options which they rely on in `zsh.pl`, and it makes sense for them because `mpv` has 408 options in 0.17.0. A similar approach would be overkill for `you-get`.

If there are other ideas I'm all ears.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1180)
<!-- Reviewable:end -->
