### PR TITLE
[Showroom] Add support via HLS M3U, fix #1218

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -62,6 +62,7 @@ SITES = {
     'pptv'             : 'pptv',
     'qianmo'           : 'qianmo',
     'qq'               : 'qq',
+    'showroom-live'    : 'showroom',
     'sina'             : 'sina',
     'smgbb'            : 'bilibili',
     'sohu'             : 'sohu',
@@ -912,7 +913,7 @@ def download_url_ffmpeg(url,title, ext,params={}, total_size=0, output_dir='.', 
         ffmpeg_play_stream(player, url, params)
         return
 
-    from .processor.ffmpeg import has_ffmpeg_installed, ffmpeg_download_streaming
+    from .processor.ffmpeg import has_ffmpeg_installed, ffmpeg_download_stream
     assert has_ffmpeg_installed(), "FFmpeg not installed."
     ffmpeg_download_stream(url, title, ext, params, output_dir)
 

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -55,6 +55,7 @@ from .pptv import *
 from .qianmo import *
 from .qie import *
 from .qq import *
+from .showroom import *
 from .sina import *
 from .sohu import *
 from .soundcloud import *

--- a/src/you_get/extractors/showroom.py
+++ b/src/you_get/extractors/showroom.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+__all__ = ['showroom_download']
+
+from ..common import *
+import urllib.error
+from json import loads
+from time import time
+
+#----------------------------------------------------------------------
+def showroom_get_roomid_by_room_url_key(room_url_key):
+    """str->str"""
+    fake_headers_mobile = {
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Charset': 'UTF-8,*;q=0.5',
+        'Accept-Encoding': 'gzip,deflate,sdch',
+        'Accept-Language': 'en-US,en;q=0.8',
+        'User-Agent': 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36'
+    }
+    webpage_url = 'https://www.showroom-live.com/' + room_url_key
+    html = get_content(webpage_url, headers = fake_headers_mobile)
+    roomid = match1(html, r'room\?room_id\=(\d+)')
+    assert roomid
+    return roomid
+
+def showroom_download_by_room_id(room_id, output_dir = '.', merge = False, info_only = False, **kwargs):
+    '''Source: Android mobile'''
+    timestamp = str(int(time() * 1000))
+    api_endpoint = 'https://www.showroom-live.com/api/live/streaming_url?room_id={room_id}&_={timestamp}'.format(room_id = room_id, timestamp = timestamp)
+    html = get_content(api_endpoint)
+    html = json.loads(html)
+    #{'streaming_url_list': [{'url': 'rtmp://52.197.69.198:1935/liveedge', 'id': 1, 'label': 'original spec(low latency)', 'is_default': True, 'type': 'rtmp', 'stream_name': '7656a6d5baa1d77075c971f6d8b6dc61b979fc913dc5fe7cc1318281793436ed'}, {'url': 'http://52.197.69.198:1935/liveedge/7656a6d5baa1d77075c971f6d8b6dc61b979fc913dc5fe7cc1318281793436ed/playlist.m3u8', 'is_default': True, 'id': 2, 'type': 'hls', 'label': 'original spec'}, {'url': 'rtmp://52.197.69.198:1935/liveedge', 'id': 3, 'label': 'low spec(low latency)', 'is_default': False, 'type': 'rtmp', 'stream_name': '7656a6d5baa1d77075c971f6d8b6dc61b979fc913dc5fe7cc1318281793436ed_low'}, {'url': 'http://52.197.69.198:1935/liveedge/7656a6d5baa1d77075c971f6d8b6dc61b979fc913dc5fe7cc1318281793436ed_low/playlist.m3u8', 'is_default': False, 'id': 4, 'type': 'hls', 'label': 'low spec'}]}
+    if len(html) < 1:
+        log.wtf('Cannot find any live URL! Maybe the live have ended or haven\'t start yet?')
+        
+    #This is mainly for testing the M3U FFmpeg parser so I would ignore any non-m3u ones
+    stream_url = [i['url'] for i in html['streaming_url_list'] if i['is_default'] and i['type'] == 'hls'][0]
+    
+    assert stream_url
+    
+    #title
+    title = ''
+    profile_api = 'https://www.showroom-live.com/api/room/profile?room_id={room_id}'.format(room_id = room_id)
+    html = loads(get_content(profile_api))
+    try:
+        title = html['main_name']
+    except KeyError:
+        title = 'Showroom_{room_id}'.format(room_id = room_id)
+    
+    type_, ext, size = url_info(stream_url)
+    print_info(site_info, title, type_, size)
+    if not info_only:
+        download_url_ffmpeg(url=stream_url, title=title, ext= 'mp4', output_dir=output_dir)
+    
+
+#----------------------------------------------------------------------
+def showroom_download(url, output_dir = '.', merge = False, info_only = False, **kwargs):
+    """"""
+    if re.match( r'(\w+)://www.showroom-live.com/(\w*)', url):
+        room_url_key = match1(url, r'\w+://www.showroom-live.com/(\w*)')
+        room_id = showroom_get_roomid_by_room_url_key(room_url_key)
+        showroom_download_by_room_id(room_id, output_dir, merge, 
+                                    info_only)
+
+site_info = "Showroom"
+download = showroom_download
+download_playlist = playlist_not_supported('showroom')


### PR DESCRIPTION
Let it rain.

```
$ python3 you-get --debug https://www.showroom-live.com/62ca1628936
[DEBUG] get_content: https://www.showroom-live.com/62ca1628936
[DEBUG] get_content: https://www.showroom-live.com/api/live/streaming_url?room_id=62565&_=1467349598375
[DEBUG] get_content: https://www.showroom-live.com/api/room/profile?room_id=62565
Site:       Showroom
Title:      みかん色の愛を君に…♡
Type:       Unknown type (None)
Size:       0.0 MiB (150 Bytes)

Downloading streaming content with FFmpeg, press q to stop recording...
ffmpeg -y -re -i http://52.69.84.185:1935/liveedge/fce6e36abcbf9c73f06bd6c21320a7e4f8d6930966ab3a3686959ad050f54cac/playlist.m3u8 -c copy -bsf:a aac_adtstoasc みかん色の愛を君に…♡.mp4
ffmpeg version 3.0.2 Copyright (c) 2000-2016 the FFmpeg developers
  built with Apple LLVM version 7.3.0 (clang-703.0.31)
  configuration: --prefix=/usr/local/Cellar/ffmpeg/3.0.2 --enable-shared --enable-pthreads --enable-gpl --enable-version3 --enable-hardcoded-tables --enable-avresample --cc=clang --host-cflags= --host-ldflags= --enable-opencl --enable-libx264 --enable-libmp3lame --enable-libxvid --enable-libfontconfig --enable-libfreetype --enable-librtmp --enable-libfaac --enable-libass --enable-ffplay --enable-libfdk-aac --enable-openssl --enable-libx265 --enable-libwebp --enable-nonfree --enable-vda
  libavutil      55. 17.103 / 55. 17.103
  libavcodec     57. 24.102 / 57. 24.102
  libavformat    57. 25.100 / 57. 25.100
  libavdevice    57.  0.101 / 57.  0.101
  libavfilter     6. 31.100 /  6. 31.100
  libavresample   3.  0.  0 /  3.  0.  0
  libswscale      4.  0.100 /  4.  0.100
  libswresample   2.  0.101 /  2.  0.101
  libpostproc    54.  0.100 / 54.  0.100
Input #0, hls,applehttp, from 'http://52.69.84.185:1935/liveedge/fce6e36abcbf9c73f06bd6c21320a7e4f8d6930966ab3a3686959ad050f54cac/playlist.m3u8':
  Duration: N/A, start: 2154.756000, bitrate: N/A
  Program 0 
    Metadata:
      variant_bitrate : 562490
    Stream #0:0: Data: timed_id3 (ID3  / 0x20334449)
    Metadata:
      variant_bitrate : 562490
    Stream #0:1: Video: h264 (Baseline) ([27][0][0][0] / 0x001B), yuv420p, 640x360, 9.25 tbr, 90k tbn, 180k tbc
    Metadata:
      variant_bitrate : 562490
    Stream #0:2: Audio: aac (LC) ([15][0][0][0] / 0x000F), 44100 Hz, mono, fltp, 98 kb/s
    Metadata:
      variant_bitrate : 562490
Output #0, mp4, to 'みかん色の愛を君に…♡.mp4':
  Metadata:
    encoder         : Lavf57.25.100
    Stream #0:0: Video: h264 ([33][0][0][0] / 0x0021), yuv420p, 640x360, q=2-31, 9.25 tbr, 90k tbn, 90k tbc
    Metadata:
      variant_bitrate : 562490
    Stream #0:1: Audio: aac (LC) ([64][0][0][0] / 0x0040), 44100 Hz, mono, 98 kb/s
    Metadata:
      variant_bitrate : 562490
Stream mapping:
  Stream #0:1 -> #0:0 (copy)
  Stream #0:2 -> #0:1 (copy)
Press [q] to stop, [?] for help
frame=    4 fps=0.0 q=-1.0 size=      52kB time=00:00:00.54 bitrate= 782.1kbits/frame=    9 fps=8.8 q=-1.0 size=      60kB time=00:00:01.05 bitrate= 470.9kbits/frame=   13 fps=8.5 q=-1.0 size=     113kB time=00:00:01.54 bitrate= 596.9kbits/frame=   18 fps=8.9 q=-1.0 size=     122kB time=00:00:02.05 bitrate= 487.2kbits/frame=   23 fps=9.1 q=-1.0 size=     176kB time=00:00:02.58 bitrate= 559.4kbits/frame=   27 fps=8.9 q=-1.0 size=     185kB time=00:00:03.08 bitrate= 489.5kbits/skipping 1 segments ahead, expired from playlists
frame=   29 fps=6.5 q=-1.0 size=     188kB time=00:00:05.42 bitrate= 283.9kbits/frame=   29 fps=5.8 q=-1.0 size=     188kB time=00:00:05.42 bitrate= 283.9kbits/frame=   30 fps=5.5 q=-1.0 size=     190kB time=00:00:05.52 bitrate= 281.4kbits/frame=   35 fps=5.8 q=-1.0 size=     245kB time=00:00:06.01 bitrate= 333.3kbits/frame=   39 fps=6.0 q=-1.0 size=     252kB time=00:00:06.54 bitrate= 315.8kbits/frame=   43 fps=6.1 q=-1.0 size=     305kB time=00:00:07.05 bitrate= 353.8kbits/frame=   48 fps=6.4 q=-1.0 size=     316kB time=00:00:07.53 bitrate= 342.9kbits/^Cframe=   48 fps=6.3 q=-1.0 Lsize=     323kB time=00:00:07.61 bitrate= 347.5kbits/s speed=   1x    
video:256kB audio:62kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 1.512827%
Exiting normally, received signal 2.
```

![image](https://cloud.githubusercontent.com/assets/1560962/16512368/8f39c914-3f28-11e6-8c10-5ce68604c1f2.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1241)
<!-- Reviewable:end -->
