### PR TITLE
[Facebook] use hd_src whenever possible

### DIFF
--- a/src/you_get/extractors/facebook.py
+++ b/src/you_get/extractors/facebook.py
@@ -9,17 +9,22 @@ def facebook_download(url, output_dir='.', merge=True, info_only=False, **kwargs
     html = get_html(url)
 
     title = r1(r'<title id="pageTitle">(.+)</title>', html)
-    sd_urls = [
+    sd_urls = list(set([
         unicodize(str.replace(i, '\\/', '/'))
         for i in re.findall(r'"sd_src_no_ratelimit":"([^"]*)"', html)
-    ]
+    ]))
+    hd_urls = list(set([
+        unicodize(str.replace(i, '\\/', '/'))
+        for i in re.findall(r'"hd_src_no_ratelimit":"([^"]*)"', html)
+    ]))
+    urls = hd_urls if hd_urls else sd_urls
 
-    type, ext, size = url_info(sd_urls[0], True)
-    size = urls_size(sd_urls)
+    type, ext, size = url_info(urls[0], True)
+    size = urls_size(urls)
 
     print_info(site_info, title, type, size)
     if not info_only:
-        download_urls(sd_urls, title, ext, size, output_dir, merge=False)
+        download_urls(urls, title, ext, size, output_dir, merge=False)
 
 site_info = "Facebook.com"
 download = facebook_download


### PR DESCRIPTION
Commit 13dc2e9d61dee1db5a7e843a5c1d24c4dca4309d that fixed #1203 dropped `hd_src`, so many videos were no longer available in their best possible quality (720p). Now HD download is back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1242)
<!-- Reviewable:end -->
