### PR TITLE
[iQiyi] Use FFmpeg to record M3U file

### DIFF
--- a/src/you_get/extractors/iqiyi.py
+++ b/src/you_get/extractors/iqiyi.py
@@ -147,6 +147,71 @@ class Iqiyi(VideoExtractor):
             except:
                 log.i("vd: {} is not handled".format(stream['vd']))
                 log.i("info is {}".format(stream))
+    
+
+    def download(self, **kwargs):
+        """Override the original one
+        Ugly ugly dirty hack"""
+        if 'json_output' in kwargs and kwargs['json_output']:
+            json_output.output(self)
+        elif 'info_only' in kwargs and kwargs['info_only']:
+            if 'stream_id' in kwargs and kwargs['stream_id']:
+                # Display the stream
+                stream_id = kwargs['stream_id']
+                if 'index' not in kwargs:
+                    self.p(stream_id)
+                else:
+                    self.p_i(stream_id)
+            else:
+                # Display all available streams
+                if 'index' not in kwargs:
+                    self.p([])
+                else:
+                    stream_id = self.streams_sorted[0]['id'] if 'id' in self.streams_sorted[0] else self.streams_sorted[0]['itag']
+                    self.p_i(stream_id)
+
+        else:
+            if 'stream_id' in kwargs and kwargs['stream_id']:
+                # Download the stream
+                stream_id = kwargs['stream_id']
+            else:
+                # Download stream with the best quality
+                stream_id = self.streams_sorted[0]['id'] if 'id' in self.streams_sorted[0] else self.streams_sorted[0]['itag']
+
+            if 'index' not in kwargs:
+                self.p(stream_id)
+            else:
+                self.p_i(stream_id)
+
+            if stream_id in self.streams:
+                urls = self.streams[stream_id]['src']
+                ext = self.streams[stream_id]['container']
+                total_size = self.streams[stream_id]['size']
+            else:
+                urls = self.dash_streams[stream_id]['src']
+                ext = self.dash_streams[stream_id]['container']
+                total_size = self.dash_streams[stream_id]['size']
+
+            if not urls:
+                log.wtf('[Failed] Cannot extract video source.')
+            # For legacy main()
+            
+            #Here's the change!!
+            download_url_ffmpeg(urls[0], self.title, 'mp4',
+                          output_dir=kwargs['output_dir'],
+                          merge=kwargs['merge'],)
+
+            if not kwargs['caption']:
+                print('Skipping captions.')
+                return
+            for lang in self.caption_tracks:
+                filename = '%s.%s.srt' % (get_filename(self.title), lang)
+                print('Saving %s ... ' % filename, end="", flush=True)
+                srt = self.caption_tracks[lang]
+                with open(os.path.join(kwargs['output_dir'], filename),
+                          'w', encoding='utf-8') as x:
+                    x.write(srt)
+                print('Done.')    
 
 '''
         if info["code"] != "A000000":


### PR DESCRIPTION
I don't like the code I wrote, especially working in a weather > 30 °C.

But it works:

```
$ python3 you-get --debug http://www.iqiyi.com/v_19rrne7134.html
[DEBUG] get_content: http://cache.m.iqiyi.com/tmts/304454700/4ae17335b6d0c0283d4f29129927a8d2/?t=1467936544580&sc=3d320f9133696f45b28f08949a028169&src=76f90cbd92f94a2e925d83e8ccd22cb7
site:                爱奇艺 (Iqiyi)
title:               刘宇珽 
stream:
    - format:        BD
      container:     m3u8
      video-profile: 1080p
      size:          0.0 MiB (0 bytes)
    # download-with: you-get --format=BD [URL]

Downloading streaming content with FFmpeg, press q to stop recording...
ffmpeg -y -re -i http://cache.m.iqiyi.com/dc/dt/3ff73fa4x20048e50x777a6171/20140917/05/1b/37df9290540397d04a1b357d9a42dbf3.m3u8?qd_sc=fa25a2ff4675331ac255340d799e28f6&t_sign=-0-76f90cbd92f94a2e925d83e8ccd22cb7-304454700_04022000001000000000_5 -c copy -bsf:a aac_adtstoasc 刘宇珽 .mp4
ffmpeg version 3.0.2 Copyright (c) 2000-2016 the FFmpeg developers
  built with Apple LLVM version 7.3.0 (clang-703.0.31)
  configuration: --prefix=/usr/local/Cellar/ffmpeg/3.0.2 --enable-shared --enable-pthreads --enable-gpl --enable-version3 --enable-hardcoded-tables --enable-avresample --cc=clang --host-cflags= --host-ldflags= --enable-opencl --enable-libx264 --enable-libmp3lame --enable-libxvid --enable-libfontconfig --enable-libfreetype --enable-librtmp --enable-libfaac --enable-libass --enable-ffplay --enable-libfdk-aac --enable-openssl --enable-libx265 --enable-libwebp --enable-nonfree --enable-vda
  libavutil      55. 17.103 / 55. 17.103
  libavcodec     57. 24.102 / 57. 24.102
  libavformat    57. 25.100 / 57. 25.100
  libavdevice    57.  0.101 / 57.  0.101
  libavfilter     6. 31.100 /  6. 31.100
  libavresample   3.  0.  0 /  3.  0.  0
  libswscale      4.  0.100 /  4.  0.100
  libswresample   2.  0.101 /  2.  0.101
  libpostproc    54.  0.100 / 54.  0.100
Input #0, hls,applehttp, from 'http://cache.m.iqiyi.com/dc/dt/3ff73fa4x20048e50x777a6171/20140917/05/1b/37df9290540397d04a1b357d9a42dbf3.m3u8?qd_sc=fa25a2ff4675331ac255340d799e28f6&t_sign=-0-76f90cbd92f94a2e925d83e8ccd22cb7-304454700_04022000001000000000_5':
  Duration: 00:03:11.00, start: 0.000000, bitrate: 0 kb/s
  Program 0 
    Metadata:
      variant_bitrate : 0
    Stream #0:0: Video: h264 (High) ([27][0][0][0] / 0x001B), yuv420p(tv, bt709), 1920x1072, 23.98 fps, 23.98 tbr, 90k tbn, 47.95 tbc
    Stream #0:1: Audio: aac (LC) ([15][0][0][0] / 0x000F), 44100 Hz, stereo, fltp, 167 kb/s
Output #0, mp4, to '刘宇珽 .mp4':
  Metadata:
    encoder         : Lavf57.25.100
    Stream #0:0: Video: h264 ([33][0][0][0] / 0x0021), yuv420p, 1920x1072, q=2-31, 23.98 fps, 23.98 tbr, 90k tbn, 90k tbc
    Stream #0:1: Audio: aac (LC) ([64][0][0][0] / 0x0040), 44100 Hz, stereo, 167 kb/s
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
  Stream #0:1 -> #0:1 (copy)
Press [q] to stop, [?] for help
frame=   13 fps=0.0 q=-1.0 size=     320kB time=00:00:00.50 bitrate=5235.4kbits/frame=   26 fps= 26 q=-1.0 size=     665kB time=00:00:01.04 bitrate=5224.7kbits/frame=   37 fps= 24 q=-1.0 size=     991kB time=00:00:01.55 bitrate=5218.9kbits/frame=   50 fps= 25 q=-1.0 size=    1244kB time=00:00:02.04 bitrate=4986.5kbits/frame=   62 fps= 25 q=-1.0 size=    1426kB time=00:00:02.54 bitrate=4593.5kbits/[mp4 @ 0x7f938d801800] Timestamps are unset in a packet for stream 0. This is deprecated and will stop working in the future. Fix your code to set the timestamps properly
[mp4 @ 0x7f938d801800] pts has no value
^Cframe=   73 fps= 24 q=-1.0 Lsize=    1661kB time=00:00:03.00 bitrate=4531.5kbits/s speed=   1x    
video:1598kB audio:59kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 0.248468%
Exiting normally, received signal 2.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1259)
<!-- Reviewable:end -->
