### PR TITLE
[SHOWROOM] Do polling on offline broadcasts

### DIFF
--- a/src/you_get/extractors/showroom.py
+++ b/src/you_get/extractors/showroom.py
@@ -5,7 +5,7 @@ __all__ = ['showroom_download']
 from ..common import *
 import urllib.error
 from json import loads
-from time import time
+from time import time, sleep
 
 #----------------------------------------------------------------------
 def showroom_get_roomid_by_room_url_key(room_url_key):
@@ -25,19 +25,22 @@ def showroom_get_roomid_by_room_url_key(room_url_key):
 
 def showroom_download_by_room_id(room_id, output_dir = '.', merge = False, info_only = False, **kwargs):
     '''Source: Android mobile'''
-    timestamp = str(int(time() * 1000))
-    api_endpoint = 'https://www.showroom-live.com/api/live/streaming_url?room_id={room_id}&_={timestamp}'.format(room_id = room_id, timestamp = timestamp)
-    html = get_content(api_endpoint)
-    html = json.loads(html)
-    #{'streaming_url_list': [{'url': 'rtmp://52.197.69.198:1935/liveedge', 'id': 1, 'label': 'original spec(low latency)', 'is_default': True, 'type': 'rtmp', 'stream_name': '7656a6d5baa1d77075c971f6d8b6dc61b979fc913dc5fe7cc1318281793436ed'}, {'url': 'http://52.197.69.198:1935/liveedge/7656a6d5baa1d77075c971f6d8b6dc61b979fc913dc5fe7cc1318281793436ed/playlist.m3u8', 'is_default': True, 'id': 2, 'type': 'hls', 'label': 'original spec'}, {'url': 'rtmp://52.197.69.198:1935/liveedge', 'id': 3, 'label': 'low spec(low latency)', 'is_default': False, 'type': 'rtmp', 'stream_name': '7656a6d5baa1d77075c971f6d8b6dc61b979fc913dc5fe7cc1318281793436ed_low'}, {'url': 'http://52.197.69.198:1935/liveedge/7656a6d5baa1d77075c971f6d8b6dc61b979fc913dc5fe7cc1318281793436ed_low/playlist.m3u8', 'is_default': False, 'id': 4, 'type': 'hls', 'label': 'low spec'}]}
-    if len(html) < 1:
-        log.wtf('Cannot find any live URL! Maybe the live have ended or haven\'t start yet?')
-        
+    while True:
+        timestamp = str(int(time() * 1000))
+        api_endpoint = 'https://www.showroom-live.com/api/live/streaming_url?room_id={room_id}&_={timestamp}'.format(room_id = room_id, timestamp = timestamp)
+        html = get_content(api_endpoint)
+        html = json.loads(html)
+        #{'streaming_url_list': [{'url': 'rtmp://52.197.69.198:1935/liveedge', 'id': 1, 'label': 'original spec(low latency)', 'is_default': True, 'type': 'rtmp', 'stream_name': '7656a6d5baa1d77075c971f6d8b6dc61b979fc913dc5fe7cc1318281793436ed'}, {'url': 'http://52.197.69.198:1935/liveedge/7656a6d5baa1d77075c971f6d8b6dc61b979fc913dc5fe7cc1318281793436ed/playlist.m3u8', 'is_default': True, 'id': 2, 'type': 'hls', 'label': 'original spec'}, {'url': 'rtmp://52.197.69.198:1935/liveedge', 'id': 3, 'label': 'low spec(low latency)', 'is_default': False, 'type': 'rtmp', 'stream_name': '7656a6d5baa1d77075c971f6d8b6dc61b979fc913dc5fe7cc1318281793436ed_low'}, {'url': 'http://52.197.69.198:1935/liveedge/7656a6d5baa1d77075c971f6d8b6dc61b979fc913dc5fe7cc1318281793436ed_low/playlist.m3u8', 'is_default': False, 'id': 4, 'type': 'hls', 'label': 'low spec'}]}
+        if len(html) >= 1:
+            break
+        log.w('The live show is currently offline.')
+        sleep(1)
+
     #This is mainly for testing the M3U FFmpeg parser so I would ignore any non-m3u ones
     stream_url = [i['url'] for i in html['streaming_url_list'] if i['is_default'] and i['type'] == 'hls'][0]
-    
+
     assert stream_url
-    
+
     #title
     title = ''
     profile_api = 'https://www.showroom-live.com/api/room/profile?room_id={room_id}'.format(room_id = room_id)
@@ -46,12 +49,12 @@ def showroom_download_by_room_id(room_id, output_dir = '.', merge = False, info_
         title = html['main_name']
     except KeyError:
         title = 'Showroom_{room_id}'.format(room_id = room_id)
-    
+
     type_, ext, size = url_info(stream_url)
     print_info(site_info, title, type_, size)
     if not info_only:
         download_url_ffmpeg(url=stream_url, title=title, ext= 'mp4', output_dir=output_dir)
-    
+
 
 #----------------------------------------------------------------------
 def showroom_download(url, output_dir = '.', merge = False, info_only = False, **kwargs):
@@ -59,7 +62,7 @@ def showroom_download(url, output_dir = '.', merge = False, info_only = False, *
     if re.match( r'(\w+)://www.showroom-live.com/([-\w]+)', url):
         room_url_key = match1(url, r'\w+://www.showroom-live.com/([-\w]+)')
         room_id = showroom_get_roomid_by_room_url_key(room_url_key)
-        showroom_download_by_room_id(room_id, output_dir, merge, 
+        showroom_download_by_room_id(room_id, output_dir, merge,
                                     info_only)
 
 site_info = "Showroom"


### PR DESCRIPTION
When a show has not started yet, `you-get` summarily fails with an error message:

```console
$ yg -di https://www.showroom-live.com/48_Rena_Kato
[DEBUG] get_content: https://www.showroom-live.com/48_Rena_Kato
[DEBUG] get_content: https://www.showroom-live.com/api/live/streaming_url?room_id=61567&_=1468130011718
you-get: Cannot find any live URL! Maybe the live have ended or haven't start yet?
```

So it only works when the live show has _already started_, but that would be usually too late. Better to do some polling on that. (so `you-get` can record the stream as soon as it is available)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1268)
<!-- Reviewable:end -->
