### PR TITLE
fix DNS resolve issue when using socks proxy

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -1214,15 +1214,18 @@ def script_main(script_name, download, download_playlist, **kwargs):
 
     if (socks_proxy):
         try:
-          import socket
-          import socks
-          socks_proxy_addrs = socks_proxy.split(':')
-          socks.set_default_proxy(socks.SOCKS5, 
-                                  socks_proxy_addrs[0], 
-                                  int(socks_proxy_addrs[1]))
-          socket.socket = socks.socksocket
+            import socket
+            import socks
+            socks_proxy_addrs = socks_proxy.split(':')
+            socks.set_default_proxy(socks.SOCKS5, 
+                                    socks_proxy_addrs[0], 
+                                    int(socks_proxy_addrs[1]))
+            socket.socket = socks.socksocket
+            def getaddrinfo(*args):
+                return [(socket.AF_INET, socket.SOCK_STREAM, 6, '', (args[0], args[1]))]
+            socket.getaddrinfo = getaddrinfo
         except ImportError:
-          log.w('Error importing PySocks library, socks proxy ignored.'
+            log.w('Error importing PySocks library, socks proxy ignored.'
                 'In order to use use socks proxy, please install PySocks.')
     else:
         import socket


### PR DESCRIPTION
Some ISPs in mainland China now pollutes DNS for websites like tumblr and youtube. When using SOCKS proxy, we need to resolve the DNS through the SOCKS proxy, too.

This patch will enable resolving DNS through the specified SOCKS proxy, so it would work correctly.

To validate this patch, you can use a SOCKS5 proxy (127.0.0.1:1080 in this case) and then issue the following command:
`you-get -s 127.0.0.1:1080 http://muslimkings.tumblr.com/post/146985235471/me-when-a-straight-white-boy-tries-talking-2-me`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1290)
<!-- Reviewable:end -->
