### PR TITLE
[Processor] Fix rtmpdump not portable under Windows

### DIFF
--- a/src/you_get/processor/rtmpdump.py
+++ b/src/you_get/processor/rtmpdump.py
@@ -42,15 +42,31 @@ def download_rtmpdump_stream(url, title, ext,params={},output_dir='.'):
     return
 
 #
-#To be refactor
-#To the future myself: Remember to refactor the same function in ffmpeg.py
-#
 def play_rtmpdump_stream(player, url, params={}):
-    cmdline="rtmpdump -r '%s' "%url
+    
+    #construct left side of pipe
+    cmdline = [RTMPDUMP, '-r']
+    cmdline.append(url)
+    
+    #append other params if exist
     for key in params.keys():
-        cmdline+=key+" "+params[key] if params[key]!=None else ""+" "
-    cmdline+=" -o - | %s -"%player
-    print(cmdline)
-    os.system(cmdline)
+        cmdline.append(key)
+        if params[key]!=None:
+            cmdline.append(params[key])
+
+    cmdline.append('-o')
+    cmdline.append('-')
+
+    #pipe start
+    cmdline.append('|')
+    cmdline.append(player)
+    cmdline.append('-')
+
+    #logging
+    print("Call rtmpdump:\n"+" ".join(cmdline)+"\n")
+
+    #call RTMPDump!
+    subprocess.call(cmdline)
+    
     # os.system("rtmpdump -r '%s' -y '%s' -o - | %s -" % (url, playpath, player))
     return


### PR DESCRIPTION
```
python3 you-get -p mpv http://www.zhanqi.tv/edmunddzhang
Site:       zhanqi.tv
Title:      【老E】正义的直播间
Type:       Flash video (video/x-flv)
Size:       inf MiB (inf Bytes)

Call rtmpdump:
rtmpdump -r rtmp://dlrtmp.cdn.zhanqi.tv/zqlive//9469_lNZYA?k=14e460f56dd93526eac8f92f0ec3d27a&t=57905434 -o - | mpv -

RTMPDump v2.4
(c) 2010 Andrej Stepanchuk, Howard Chu, The Flvstreamer Team; license: GPL
Connecting ...
INFO: Connected...
ERROR: RTMP_ReadPacket, failed to read RTMP packet header
```

So it should be working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1294)
<!-- Reviewable:end -->
