### PR TITLE
[Douyutv]fix channel on event

### DIFF
--- a/src/you_get/extractors/douyutv.py
+++ b/src/you_get/extractors/douyutv.py
@@ -6,14 +6,15 @@ from ..common import *
 import json
 import hashlib
 import time
-import random
-import string
+import uuid
 import urllib.parse, urllib.request
 
 def douyutv_download(url, output_dir = '.', merge = True, info_only = False, **kwargs):
     html = get_content(url)
     room_id_patt = r'"room_id"\s*:\s*(\d+),'
     room_id = match1(html, room_id_patt)
+    if room_id == "0":
+        room_id = url[url.rfind('/')+1:]
 
     json_request_url = "http://m.douyu.com/html5/live?roomId=%s" % room_id
     content = get_content(json_request_url)
@@ -28,7 +29,7 @@ def douyutv_download(url, output_dir = '.', merge = True, info_only = False, **k
         raise ValueError("The live stream is not online! (Errno:%s)" % server_status)
 
     tt = int(time.time() / 60)
-    did = ''.join([random.choice(string.ascii_uppercase + string.digits) for n in range(32)])
+    did = uuid.uuid4().hex.upper()
     sign_content = '{room_id}{did}A12Svb&%1UUmf@hC{tt}'.format(room_id = room_id, did = did, tt = tt)
     sign = hashlib.md5(sign_content.encode('utf-8')).hexdigest()
 
@@ -37,10 +38,9 @@ def douyutv_download(url, output_dir = '.', merge = True, info_only = False, **k
     postdata = urllib.parse.urlencode(payload)
     req = urllib.request.Request(json_request_url, postdata.encode('utf-8'))
     with urllib.request.urlopen(req) as response:
-        the_page = response.read()
+        content = response.read()
 
-    content = json.loads(the_page.decode('utf-8'))
-    data = content['data']
+    data = json.loads(content.decode('utf-8'))['data']
     server_status = data.get('error',0)
     if server_status is not 0:
         raise ValueError("Server returned error:%s" % server_status)


### PR DESCRIPTION
some channel on event will redirect to event page
exp. http://www.douyu.com/65251 redirect to http://www.douyu.com/cms/zt/RioOlympics.html#a
if channel is on event, use entering url to get room_id, and non-digital room_id will not work

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1338)
<!-- Reviewable:end -->
