### PR TITLE
Fix ffmpeg wrong folder format and douyu discard output folder

### DIFF
--- a/src/you_get/extractors/douyutv.py
+++ b/src/you_get/extractors/douyutv.py
@@ -49,7 +49,7 @@ def douyutv_download(url, output_dir = '.', merge = True, info_only = False, **k
 
     print_info(site_info, title, 'flv', float('inf'))
     if not info_only:
-        download_url_ffmpeg(real_url, title, 'flv', None, output_dir, merge = merge)
+        download_url_ffmpeg(real_url, title, 'flv', None, output_dir = output_dir, merge = merge)
 
 site_info = "douyu.com"
 download = douyutv_download

--- a/src/you_get/processor/ffmpeg.py
+++ b/src/you_get/processor/ffmpeg.py
@@ -209,7 +209,7 @@ def ffmpeg_download_stream(files, title, ext, params={}, output_dir='.'):
     output = title + '.' + ext
     
     if not (output_dir == '.'):
-        output = output_dir + output
+        output = output_dir + '/' + output
         
     ffmpeg_params = []
     #should these exist...


### PR DESCRIPTION
```
 python3 you-get -o dow http://www.douyu.com/611813
Site:       douyu.com
Title:      台妹髮型師～美髮院直播
Type:       Flash video (video/x-flv)
Size:       inf MiB (inf Bytes)

Downloading streaming content with FFmpeg, press q to stop recording...
ffmpeg -y -re -i http://hdla.douyucdn.cn/live/611813re7VjmtaHO.flv?wsAuth=27185bfe7901f7d65f88834a427ef3dd&token=web-0-611813-260fc67c9f304fe923401dc7d0406014&logo=0&expire=0 -c copy -bsf:a aac_adtstoasc dow/台妹髮型師～美髮院直播.flv
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1342)
<!-- Reviewable:end -->
