### PR TITLE
fix bug about renaming videos when downloading with ffmpeg

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -916,6 +916,11 @@ def download_url_ffmpeg(url,title, ext,params={}, total_size=0, output_dir='.', 
 
     from .processor.ffmpeg import has_ffmpeg_installed, ffmpeg_download_stream
     assert has_ffmpeg_installed(), "FFmpeg not installed."
+    global output_filename
+    if(output_filename)
+        dotPos = output_filename.rfind(".")
+        title = output_filename[:dotPos]
+        ext = output_filename[dotPos+1:]
     ffmpeg_download_stream(url, title, ext, params, output_dir)
 
 def playlist_not_supported(name):


### PR DESCRIPTION
when i was downloading videos at iqiyi, i found the video name can't be renamed, the problem is supposed to be when downloading with ffmpeg, it hasn't dealed with the output_filename variable, i have fixed it and now it works well.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1424)

<!-- Reviewable:end -->
