### PR TITLE
Fix(huomao): adapt to new url format

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Use `--url`/`-u` to get a list of downloadable resource URLs extracted from the 
 | 花瓣     | <http://huaban.com/>           | |✓| |
 | Naver<br/>네이버 | <http://tvcast.naver.com/>     |✓| | |
 | 芒果TV   | <http://www.mgtv.com/>         |✓| | |
+| 火猫TV   | <http://www.huomao.com/>         |✓| | |
 
 For all other sites not on the list, the universal extractor will take care of finding and downloading interesting resources from the page.
 

--- a/src/you_get/extractors/huomaotv.py
+++ b/src/you_get/extractors/huomaotv.py
@@ -6,7 +6,7 @@ from ..common import *
 
 
 def get_mobile_room_url(room_id):
-    return 'http://www.huomao.com/mobile/mob_live?cid=%s' % room_id
+    return 'http://www.huomao.com/mobile/mob_live/%s' % room_id
 
 
 def get_m3u8_url(stream_id):


### PR DESCRIPTION
HuomaoTV's mobile website takes a new url format.
Also added a row to the table of support list in README.

```
you-get -p mpv http://www.huomao.com/44
Site:       huomao.com
Title:      Faceless vs SG.T_火猫直播_年轻人的直播社区
Type:       Unknown type (m3u8)
Size:       inf MiB (inf Bytes)

Playing: http://live-ws.huomaotv.cn/live/35ftHT/playlist.m3u8
 (+) Video --vid=1 (h264)
 (+) Audio --aid=1 (aac)
AO: [coreaudio] 44100Hz stereo 2ch floatp
VO: [opengl] 1920x1080 yuv420p
AV: 00:00:02 A-V:  0.000 Cache:  2s+0KB
```

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1480)

<!-- Reviewable:end -->
