### PR TITLE
Fix Dailymotion

### DIFF
--- a/src/you_get/extractors/dailymotion.py
+++ b/src/you_get/extractors/dailymotion.py
@@ -4,6 +4,11 @@ __all__ = ['dailymotion_download']
 
 from ..common import *
 
+def extract_m3u(url):
+    content = get_content(url)
+    m3u_url = re.findall(r'http://.*', content)[0]
+    return match1(m3u_url, r'([^#]+)')
+
 def dailymotion_download(url, output_dir = '.', merge = True, info_only = False, **kwargs):
     """Downloads Dailymotion videos by URL.
     """
@@ -13,7 +18,7 @@ def dailymotion_download(url, output_dir = '.', merge = True, info_only = False,
     title = match1(html, r'"video_title"\s*:\s*"([^"]+)"') or \
             match1(html, r'"title"\s*:\s*"([^"]+)"')
 
-    for quality in ['720','480','380','240','auto']:
+    for quality in ['1080','720','480','380','240','auto']:
         try:
             real_url = info[quality][0]["url"]
             if real_url:
@@ -21,11 +26,12 @@ def dailymotion_download(url, output_dir = '.', merge = True, info_only = False,
         except KeyError:
             pass
 
-    type, ext, size = url_info(real_url)
+    m3u_url = extract_m3u(real_url)
+    mime, ext, size = 'video/mp4', 'mp4', 0
 
-    print_info(site_info, title, type, size)
+    print_info(site_info, title, mime, size)
     if not info_only:
-        download_urls([real_url], title, ext, size, output_dir, merge = merge)
+        download_url_ffmpeg(m3u_url, title, ext, output_dir=output_dir, merge=merge)
 
 site_info = "Dailymotion.com"
 download = dailymotion_download

--- a/src/you_get/processor/ffmpeg.py
+++ b/src/you_get/processor/ffmpeg.py
@@ -212,15 +212,6 @@ def ffmpeg_download_stream(files, title, ext, params={}, output_dir='.'):
     if not (output_dir == '.'):
         output = output_dir + '/' + output
 
-    ffmpeg_params = []
-    #should these exist...
-    if params is not None:
-        if len(params) > 0:
-            for k, v in params:
-                ffmpeg_params.append(k)
-                ffmpeg_params.append(v)
-
-
     print('Downloading streaming content with FFmpeg, press q to stop recording...')
     ffmpeg_params = [FFMPEG] + ['-y', '-re', '-i']
     ffmpeg_params.append(files)  #not the same here!!!!
@@ -229,6 +220,12 @@ def ffmpeg_download_stream(files, title, ext, params={}, output_dir='.'):
         ffmpeg_params += ['-c', 'copy', output]
     else:
         ffmpeg_params += ['-c', 'copy', '-bsf:a', 'aac_adtstoasc']
+
+    if params is not None:
+        if len(params) > 0:
+            for k, v in params:
+                ffmpeg_params.append(k)
+                ffmpeg_params.append(v)
 
     ffmpeg_params.append(output)
 


### PR DESCRIPTION
1. Fix a bug in `ffmpeg_download_stream()`  (`params` was not actually passed to `ffmpeg`).
2. Switch the Dailymotion downloader to `download_url_ffmpeg`.
3. Add support for 1080P.

N.B. There seems to be a bug in FFmpeg that it doesn't handle URLs with fragment identifier `#` well. Both curl and wget truncate all characters starting from `#`, but ffmpeg includes it anyway, which invalidates the request and errs with 403.

```
GET /sec(565fe991420338c2d12acdfbe9ca64d3)/video/121/388/134883121_mp4_h264_aac_hd_2.m3u8#cell=core HTTP/1.1
Accept: */*
Range: bytes=0-
Connection: close
Host: proxy-069.dc3.dailymotion.com
Icy-MetaData: 1
```

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1483)

<!-- Reviewable:end -->
