### PR TITLE
[mgtv] add bsf:a aac_adtstoasc to ffmpeg params, fix #1458.

### DIFF
--- a/src/you_get/processor/ffmpeg.py
+++ b/src/you_get/processor/ffmpeg.py
@@ -125,7 +125,7 @@ def ffmpeg_concat_flv_to_mp4(files, output='output.mp4'):
 
         params = [FFMPEG] + LOGLEVEL + ['-f', 'concat', '-safe', '-1', '-y', '-i']
         params.append(output + '.txt')
-        params += ['-c', 'copy', output]
+        params += ['-c', 'copy', '-bsf:a', 'aac_adtstoasc', output]
 
         subprocess.check_call(params)
         os.remove(output + '.txt')


### PR DESCRIPTION
Add `'-bsf:a', 'aac_adtstoasc'` params to ffmpeg, solves #1458 . I have manually tested this with some other video sites which use `ffmpeg_concat_flv_to_mp4()` and it seems everything works fine, the bsf param have no side effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1518)
<!-- Reviewable:end -->
