### PR TITLE
[YouTube] Add support for Live, fix #37

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -968,11 +968,15 @@ def download_url_ffmpeg(url,title, ext,params={}, total_size=0, output_dir='.', 
 
     from .processor.ffmpeg import has_ffmpeg_installed, ffmpeg_download_stream
     assert has_ffmpeg_installed(), "FFmpeg not installed."
+
     global output_filename
-    if(output_filename):
+    if output_filename:
         dotPos = output_filename.rfind(".")
         title = output_filename[:dotPos]
         ext = output_filename[dotPos+1:]
+
+    title = tr(get_filename(title))
+
     ffmpeg_download_stream(url, title, ext, params, output_dir)
 
 def playlist_not_supported(name):

--- a/src/you_get/extractors/youtube.py
+++ b/src/you_get/extractors/youtube.py
@@ -148,6 +148,17 @@ class YouTube(VideoExtractor):
         elif video_info['status'] == ['ok']:
             if 'use_cipher_signature' not in video_info or video_info['use_cipher_signature'] == ['False']:
                 self.title = parse.unquote_plus(video_info['title'][0])
+
+                # YouTube Live
+                if 'url_encoded_fmt_stream_map' not in video_info:
+                    hlsvp = video_info['hlsvp'][0]
+
+                    if 'info_only' in kwargs and kwargs['info_only']:
+                        return
+                    else:
+                        download_url_ffmpeg(hlsvp, self.title, 'mp4')
+                        exit(0)
+
                 stream_list = video_info['url_encoded_fmt_stream_map'][0].split(',')
 
                 # Parse video page (for DASH)


### PR DESCRIPTION
Requires `ffmpeg`.

```
$ you-get -di 'https://www.youtube.com/watch?v=RX8nEGQ1DeY'  
[DEBUG] get_content: https://www.youtube.com/get_video_info?video_id=RX8nEGQ1DeY
site:                YouTube
title:               CNN Live News Donald Trump Thank you Rally 12-1-16 CNN Donald Trump Carrier speech CNN News Stream
streams:             # Available quality and codecs
    [ DEFAULT ] _________________________________
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1541)
<!-- Reviewable:end -->
