### PR TITLE
[embed] add support for bilibili's embedded player

### DIFF
--- a/src/you_get/extractors/embed.py
+++ b/src/you_get/extractors/embed.py
@@ -2,6 +2,7 @@ __all__ = ['embed_download']
 
 from ..common import *
 
+from .bilibili import bilibili_download
 from .iqiyi import iqiyi_download_by_vid
 from .le import letvcloud_download_by_vu
 from .netease import netease_download
@@ -42,6 +43,11 @@ netease_embed_patterns = [ '(http://\w+\.163\.com/movie/[^\'"]+)' ]
 
 vimeo_embed_patters = [ 'player\.vimeo\.com/video/(\d+)' ]
 
+"""
+check the share button on http://www.bilibili.com/video/av5079467/
+"""
+bilibili_embed_patterns = [ 'static\.hdslb\.com/miniloader\.swf.*aid=(\d+)' ]
+
 
 def embed_download(url, output_dir = '.', merge = True, info_only = False ,**kwargs):
     content = get_content(url, headers=fake_headers)
@@ -77,6 +83,12 @@ def embed_download(url, output_dir = '.', merge = True, info_only = False ,**kwa
     for url in urls:
         found = True
         vimeo_download_by_id(url, title=title, output_dir=output_dir, merge=merge, info_only=info_only)
+
+    aids = matchall(content, bilibili_embed_patterns)
+    for aid in aids:
+        found = True
+        url = 'http://www.bilibili.com/video/av%s/' % aid
+        bilibili_download(url, output_dir=output_dir, merge=merge, info_only=info_only)
 
     if not found:
         raise NotImplementedError(url)


### PR DESCRIPTION
Sample embed: for http://www.bilibili.com/video/av5079467/:

```html
<embed height="415" width="544" quality="high" allowfullscreen="true" type="application/x-shockwave-flash" src="http://static.hdslb.com/miniloader.swf" flashvars="aid=5079467&page=1" pluginspage="http://www.adobe.com/shockwave/download/download.cgi?P1_Prod_Version=ShockwaveFlash"></embed>
```

(See the "分享" button on the video page.)

Sample usage after this patch:

```
$ you-get --debug https://goo.gl/jSPH9A
[DEBUG] get_content: https://cdn.rawgit.com/zmwangx/7971f208bdb7ebc1bfc44e504789854f/raw/b133e9a07018d894b00e2490022ab078cfa04360/bilibili-embed.html
[DEBUG] get_content: http://www.bilibili.com/video/av5079467/
[DEBUG] get_content: http://interface.bilibili.com/playurl?&cid=8277792&from=miniplay&player=1&sign=df282f440d978ca32de1b18ecbb4bc18
Site:       bilibili.com
Title:      bilibili七周年 ★ 一路有你
Type:       Flash video (video/x-flv)
Size:       48.52 MiB (50872328 Bytes)

Downloading bilibili七周年 ★ 一路有你.flv ...
 100% ( 48.5/ 48.5MB) ├███████████████████████████████████████████████████████████████████████████████┤[1/1]   12 MB/s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1544)
<!-- Reviewable:end -->
