### PR TITLE
[BiliBili] Better Multi-Part Video Naming

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -167,10 +167,10 @@ def bilibili_download(url, output_dir='.', merge=True, info_only=False, **kwargs
                 if not pages:
                     cids = [cid]
                     titles = [r1(r'<option value=.* selected>\s*([^<>]+)\s*</option>', html) or title]
-
                 for i in range(len(cids)):
+                    completeTitle=title+"-"+titles[i]#Build Better Title
                     bilibili_download_by_cid(cids[i],
-                                             titles[i],
+                                             completeTitle,
                                              output_dir=output_dir,
                                              merge=merge,
                                              info_only=info_only)

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -168,7 +168,11 @@ def bilibili_download(url, output_dir='.', merge=True, info_only=False, **kwargs
                     cids = [cid]
                     titles = [r1(r'<option value=.* selected>\s*([^<>]+)\s*</option>', html) or title]
                 for i in range(len(cids)):
-                    completeTitle=title+"-"+titles[i]#Build Better Title
+                    completeTitle=None
+                    if (title == titles[i]):
+                        completeTitle=title
+                    else:
+                        completeTitle=title+"-"+titles[i]#Build Better Title
                     bilibili_download_by_cid(cids[i],
                                              completeTitle,
                                              output_dir=output_dir,


### PR DESCRIPTION
The older code of title naming results in useless and repetitive file naming under certain circumstances like "1.Part1.flv" for multi-part videos
This one-line patch fixed the issue by appending video title

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1571)
<!-- Reviewable:end -->
