### PR TITLE
ffmpeg: set loglevel to info in debug mode

### DIFF
--- a/src/you_get/processor/ffmpeg.py
+++ b/src/you_get/processor/ffmpeg.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import logging
 import os.path
 import subprocess
 from ..util.strings import parameterize
@@ -21,7 +22,10 @@ def get_usable_ffmpeg(cmd):
         return None
 
 FFMPEG, FFMPEG_VERSION = get_usable_ffmpeg('ffmpeg') or get_usable_ffmpeg('avconv') or (None, None)
-LOGLEVEL = ['-loglevel', 'quiet']
+if logging.getLogger().isEnabledFor(logging.DEBUG):
+    LOGLEVEL = ['-loglevel', 'info']
+else:
+    LOGLEVEL = ['-loglevel', 'quiet']
 
 def has_ffmpeg_installed():
     return FFMPEG is not None


### PR DESCRIPTION
Occasionally, the FFmpeg invocation fails (which could be due to bugs in you-get; see #1558 for instance), but `-loglevel quiet` means nothing is printed other than the exit status (pretty much always 1) in Python's traceback, which is not helpful at all.

This commit restores FFmpeg's regular output (`-loglevel info`) when `--debug` is specified. We're not using `verbose`, `debug` or `trace` because those levels are mostly only useful for debugging FFmpeg itself, which is not our goal.

Due to lack of meaningful API to access the global logging level, this is a hack based on two assumptions:

1. When `--debug` is enabled, the root logger level is set to `DEBUG`;
2. `processor.ffmpeg` is lazily imported, after command line options are parsed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1575)
<!-- Reviewable:end -->
