### PR TITLE
[qq] support for videos embedded in weixin

### DIFF
--- a/src/you_get/extractors/qq.py
+++ b/src/you_get/extractors/qq.py
@@ -73,7 +73,14 @@ def qq_download_by_vid(vid, title, output_dir='.', merge=True, info_only=False):
 def qq_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
     """"""
     if 'live.qq.com' in url:
-        qieDownload(url,output_dir=output_dir, merge=merge, info_only=info_only)
+        qieDownload(url, output_dir=output_dir, merge=merge, info_only=info_only)
+        return
+
+    if 'mp.weixin.qq.com/s?' in url:
+        content = get_html(url)
+        vids = matchall(content, [r'\bvid=(\w+)'])
+        for vid in vids:
+            qq_download_by_vid(vid, vid, output_dir, merge, info_only)
         return
 
     #do redirect
@@ -100,8 +107,6 @@ def qq_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
         title = match1(content, r'title">([^"]+)</p>') if not title else title
         title = match1(content, r'"title":"([^"]+)"') if not title else title
         title = vid if not title else title #general fallback
-
-
 
     qq_download_by_vid(vid, title, output_dir, merge, info_only)
 


### PR DESCRIPTION
下载微信文章里的视频。其实更好的解决办法是 #1281，但是微信域名的 URL 会被分派到这边，所以就这样了。

example url:
http://mp.weixin.qq.com/s?__biz=MzA3OTgxODI4NQ==&mid=2653200488&idx=1&sn=bd6d0279b2430cc208d9da74226871db&chksm=847dbb2ab30a323c4b1735887158daf1e295abe586aff0a646ce4257a48010f80bcfb1379c95&scene=0#rd

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1607)
<!-- Reviewable:end -->
