### PR TITLE
fix bug of youku.py

### DIFF
--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -143,6 +143,9 @@ class Youku(VideoExtractor):
             })
         else:
             proxy_handler = request.ProxyHandler({})
+        if not request._opener:
+            opener = request.build_opener(proxy_handler)
+            request.install_opener(opener)
         for handler in (ssl_context, cookie_handler, proxy_handler):
             request._opener.add_handler(handler)
         request._opener.addheaders = [('Cookie','__ysuid={}'.format(time.time()))]


### PR DESCRIPTION
When I want to download youku video from youku.com using my python code instead of command line, I found that it raise one exception. Like this:
```
>>> youku.download('http://v.youku.com/v_show/id_XMjE4Nzg2NzM3Ng==.html', info_only=False, output_dir='.', merge=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/you_get/extractor.py", line 41, in download_by_url
    self.prepare(**kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/you_get/extractors/youku.py", line 147, in prepare
    request._opener.add_handler(handler)
AttributeError: 'NoneType' object has no attribute 'add_handler'
```
Then I check the code, and I found the `request._opener` is not installed when I `download` directly, and if I use command-line, it's installed in `common. set_http_proxy`. So, I think there should judge whether `request._opener` is None, and if not, install it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1638)
<!-- Reviewable:end -->
