### PR TITLE
fix non-ascii url

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -259,6 +259,7 @@ def undeflate(data):
 
 # DEPRECATED in favor of get_content()
 def get_response(url, faker = False):
+    url = parse.quote(url,':/')
     # install cookies
     if cookies:
         opener = request.build_opener(request.HTTPCookieProcessor(cookies))


### PR DESCRIPTION
When you pass a non-ascii url to you-get, for example, url with Chinese character, get_response(url) will throw a UnicodeEncodeError, causing you-get to terminate with an error message asking you to set locale to UTF-8. But setting locale to UTF-8 won't fix the problem, since it is a URL encoding problem.

This problem is rare, since browsers will encode the url when you copy it out, thus the url you copy from browsers and pass to you-get will always be encoded in URL-conformed format. However, if you use a script to scrape a web page and then pass the urls you find in the page directly to you-get, you will get this error.

This patch addresses this issue by encoding the url passed to get_response(). It should not affect normal URLs, and should allow users to pass non-ascii URLs directly to you-get.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1644)
<!-- Reviewable:end -->
