### PR TITLE
Fix youtube extractor bug

### DIFF
--- a/src/you_get/extractors/youtube.py
+++ b/src/you_get/extractors/youtube.py
@@ -165,7 +165,7 @@ class YouTube(VideoExtractor):
                 video_page = get_content('https://www.youtube.com/watch?v=%s' % self.vid)
                 try:
                     ytplayer_config = json.loads(re.search('ytplayer.config\s*=\s*([^\n]+?});', video_page).group(1))
-                    self.html5player = 'https:' + ytplayer_config['assets']['js']
+                    self.html5player = 'https://www.youtube.com' + ytplayer_config['assets']['js']
                     # Workaround: get_video_info returns bad s. Why?
                     stream_list = ytplayer_config['args']['url_encoded_fmt_stream_map'].split(',')
                 except:
@@ -177,7 +177,7 @@ class YouTube(VideoExtractor):
                 ytplayer_config = json.loads(re.search('ytplayer.config\s*=\s*([^\n]+?});', video_page).group(1))
 
                 self.title = ytplayer_config['args']['title']
-                self.html5player = 'https:' + ytplayer_config['assets']['js']
+                self.html5player = 'https://www.youtube.com' + ytplayer_config['assets']['js']
                 stream_list = ytplayer_config['args']['url_encoded_fmt_stream_map'].split(',')
 
         elif video_info['status'] == ['fail']:
@@ -193,7 +193,7 @@ class YouTube(VideoExtractor):
                     # 150 Restricted from playback on certain sites
                     # Parse video page instead
                     self.title = ytplayer_config['args']['title']
-                    self.html5player = 'https:' + ytplayer_config['assets']['js']
+                    self.html5player = 'https://www.youtube.com' + ytplayer_config['assets']['js']
                     stream_list = ytplayer_config['args']['url_encoded_fmt_stream_map'].split(',')
                 else:
                     log.wtf('[Error] The uploader has not made this video available in your country.')


### PR DESCRIPTION
Today when I try to download youtube video, I got an error like below.

```
$ ./you-get -d http://www.youtube.com/watch\?v\=pzKerr0JIPA
[DEBUG] get_content: https://www.youtube.com/get_video_info?video_id=pzKerr0JIPA
[DEBUG] get_content: https://www.youtube.com/watch?v=pzKerr0JIPA
[DEBUG] get_content: https:/yts/jsbin/player-ko_KR-vflSzkno7/base.js
you-get: version 0.4.626, a tiny downloader that scrapes the web.
you-get: ['http://www.youtube.com/watch?v=pzKerr0JIPA']
Traceback (most recent call last):
  File "/Users/leap/you-get/src/you_get/extractors/youtube.py", line 263, in prepare
    dashmpd = ytplayer_config['args']['dashmpd']
KeyError: 'dashmpd'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./you-get", line 11, in <module>
    you_get.main(repo_path=_filepath)
  File "/Users/leap/you-get/src/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/Users/leap/you-get/src/you_get/common.py", line 1411, in main
    script_main('you-get', any_download, any_download_playlist, **kwargs)
  File "/Users/leap/you-get/src/you_get/common.py", line 1324, in script_main
    download_main(download, download_playlist, args, playlist, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output, caption=caption)
  File "/Users/leap/you-get/src/you_get/common.py", line 1140, in download_main
    download(url, **kwargs)
  File "/Users/leap/you-get/src/you_get/common.py", line 1404, in any_download
    m.download(url, **kwargs)
  File "/Users/leap/you-get/src/you_get/extractor.py", line 41, in download_by_url
    self.prepare(**kwargs)
  File "/Users/leap/you-get/src/you_get/extractors/youtube.py", line 326, in prepare
    self.js = get_content(self.html5player)
  File "/Users/leap/you-get/src/you_get/common.py", line 327, in get_content
    response = urlopen_with_retry(req)
  File "/Users/leap/you-get/src/you_get/common.py", line 304, in urlopen_with_retry
    return request.urlopen(*args, **kwargs)
  File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/urllib/request.py", line 524, in open
    req = meth(req)
  File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/urllib/request.py", line 1241, in do_request_
    raise URLError('no host given')
urllib.error.URLError: <urlopen error no host given>
```

When I checked debug message and youtube page, I think this issue comes from using relative link in youtube page.
```
[DEBUG] get_content: https:/yts/jsbin/player-ko_KR-vflSzkno7/base.js
```
![youtube-js-relative-link](https://cloud.githubusercontent.com/assets/8179234/22506372/62cf1b32-e8c3-11e6-8283-84087f99c050.png)


Therefore, I changed the youtube extractor code to use full link and it worked for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1659)
<!-- Reviewable:end -->
