### PR TITLE
[YouTube] Fix signature extraction

### DIFF
--- a/src/you_get/extractors/youtube.py
+++ b/src/you_get/extractors/youtube.py
@@ -52,7 +52,7 @@ class YouTube(VideoExtractor):
             return code
 
         js = js.replace('\n', ' ')
-        f1 = match1(js, r'\w+\.sig\|\|([$\w]+)\(\w+\.\w+\)')
+        f1 = match1(js, r'"signature",([\w]+)\(\w+\.\w+\)')
         f1def = match1(js, r'function %s(\(\w+\)\{[^\{]+\})' % re.escape(f1)) or \
                 match1(js, r'\W%s=function(\(\w+\)\{[^\{]+\})' % re.escape(f1))
         f1def = re.sub(r'([$\w]+\.)([$\w]+\(\w+,\d+\))', r'\2', f1def)


### PR DESCRIPTION
YouTube keeps updating the `base.js`. That's it.

https://www.youtube.com/yts/jsbin/player-da_DK-vflWlK-zq/base.js

```
$ yg -di 'https://www.youtube.com/watch?v=raNaAVxHqK8'
[DEBUG] get_content: https://www.youtube.com/get_video_info?video_id=raNaAVxHqK8
[DEBUG] get_content: https://www.youtube.com/watch?v=raNaAVxHqK8
[DEBUG] get_content: https://www.youtube.com/yts/jsbin/player-da_DK-vflWlK-zq/base.js
you-get: version 0.4.648, a tiny downloader that scrapes the web.
you-get: ['https://www.youtube.com/watch?v=raNaAVxHqK8']
Traceback (most recent call last):
  File "/home/soimort/.local/lib/python3.6/site-packages/you_get/extractors/youtube.py", line 263, in prepare
    dashmpd = ytplayer_config['args']['dashmpd']
KeyError: 'dashmpd'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/soimort/.local/bin/you-get", line 11, in <module>
    load_entry_point('you-get==0.4.648', 'console_scripts', 'you-get')()
  File "/home/soimort/.local/lib/python3.6/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/home/soimort/.local/lib/python3.6/site-packages/you_get/common.py", line 1407, in main
    script_main('you-get', any_download, any_download_playlist, **kwargs)
  File "/home/soimort/.local/lib/python3.6/site-packages/you_get/common.py", line 1320, in script_main
    download_main(download, download_playlist, args, playlist, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output, caption=caption)
  File "/home/soimort/.local/lib/python3.6/site-packages/you_get/common.py", line 1136, in download_main
    download(url, **kwargs)
  File "/home/soimort/.local/lib/python3.6/site-packages/you_get/common.py", line 1400, in any_download
    m.download(url, **kwargs)
  File "/home/soimort/.local/lib/python3.6/site-packages/you_get/extractor.py", line 41, in download_by_url
    self.prepare(**kwargs)
  File "/home/soimort/.local/lib/python3.6/site-packages/you_get/extractors/youtube.py", line 336, in prepare
    sig = self.__class__.decipher(self.js, stream['s'])
  File "/home/soimort/.local/lib/python3.6/site-packages/you_get/extractors/youtube.py", line 56, in decipher
    f1def = match1(js, r'function %s(\(\w+\)\{[^\{]+\})' % re.escape(f1)) or \
  File "/usr/lib/python3.6/re.py", line 267, in escape
    for c in pattern:
TypeError: 'NoneType' object is not iterable
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1662)
<!-- Reviewable:end -->
