### PR TITLE
Support new dilidili domain name and api

### DIFF
--- a/src/you_get/extractors/ckplayer.py
+++ b/src/you_get/extractors/ckplayer.py
@@ -15,16 +15,13 @@ def ckplayer_get_info_by_xml(ckinfo):
     """str->dict
     Information for CKPlayer API content."""
     e = ET.XML(ckinfo)
+    logging.debug('video xml info:\n{}'.format(ckinfo))
+
     video_dict = {'title': '',
                   #'duration': 0,
                   'links': [],
                   'size': 0,
                   'flashvars': '',}
-    if '_text' in dictify(e)['ckplayer']['info'][0]['title'][0]:  #title
-        video_dict['title'] = dictify(e)['ckplayer']['info'][0]['title'][0]['_text'].strip()
-
-    #if dictify(e)['ckplayer']['info'][0]['title'][0]['_text'].strip():  #duration
-        #video_dict['title'] = dictify(e)['ckplayer']['info'][0]['title'][0]['_text'].strip()
 
     if '_text' in dictify(e)['ckplayer']['video'][0]['size'][0]:  #size exists for 1 piece
         video_dict['size'] = sum([int(i['size'][0]['_text']) for i in dictify(e)['ckplayer']['video']])
@@ -36,6 +33,7 @@ def ckplayer_get_info_by_xml(ckinfo):
         video_dict['flashvars'] = dictify(e)['ckplayer']['flashvars'][0]['_text'].strip()
 
     return video_dict
+
 
 #----------------------------------------------------------------------
 #helper

--- a/src/you_get/extractors/dilidili.py
+++ b/src/you_get/extractors/dilidili.py
@@ -16,12 +16,15 @@ headers = {
     'Referer': 'http://www.dilidili.com/',
     'Connection': 'keep-alive',
     'Save-Data': 'on',
+    'Save-Data': 'on',
 }
 
 #----------------------------------------------------------------------
 def dilidili_parser_data_to_stream_types(typ ,vid ,hd2 ,sign, tmsign, ulk):
     """->list"""
-    parse_url = 'http://player.005.tv/parse.php?xmlurl=null&type={typ}&vid={vid}&hd={hd2}&sign={sign}&tmsign={tmsign}&userlink={ulk}'.format(typ = typ, vid = vid, hd2 = hd2, sign = sign, tmsign = tmsign, ulk = ulk)
+    parse_url = 'http://player.005.tv/parse.php?' \
+                'xmlurl=null&type={typ}&vid={vid}&hd={hd2}&sign={sign}&tmsign={tmsign}&userlink={ulk}'\
+        .format(typ = typ, vid = vid, hd2 = hd2, sign = sign, tmsign = tmsign, ulk = ulk)
     html = get_content(parse_url, headers=headers)
     
     info = re.search(r'(\{[^{]+\})(\{[^{]+\})(\{[^{]+\})(\{[^{]+\})(\{[^{]+\})', html).groups()
@@ -35,7 +38,7 @@ def dilidili_parser_data_to_stream_types(typ ,vid ,hd2 ,sign, tmsign, ulk):
 
 #----------------------------------------------------------------------
 def dilidili_download(url, output_dir = '.', merge = False, info_only = False, **kwargs):
-    if re.match(r'http://www.dilidili.com/watch\S+', url):
+    if re.match(r'http://www.dilidili.(com|wang|mobi|name)/watch\S+', url):
         html = get_content(url)
         title = match1(html, r'<title>(.+)丨(.+)</title>')  #title
         
@@ -60,7 +63,9 @@ def dilidili_download(url, output_dir = '.', merge = False, info_only = False, *
         #get best
         best_id = max([i['id'] for i in stream_types])
         
-        parse_url = 'http://player.005.tv/parse.php?xmlurl=null&type={typ}&vid={vid}&hd={hd2}&sign={sign}&tmsign={tmsign}&userlink={ulk}'.format(typ = typ, vid = vid, hd2 = best_id, sign = sign, tmsign = tmsign, ulk = ulk)
+        parse_url = 'http://player.005.tv/parse.php?' \
+                    'xmlurl=null&type={typ}&vid={vid}&hd={hd2}&sign={sign}&tmsign={tmsign}&userlink={ulk}'\
+            .format(typ = typ, vid = vid, hd2 = best_id, sign = sign, tmsign = tmsign, ulk = ulk)
         
         ckplayer_download(parse_url, output_dir, merge, info_only, is_xml = True, title = title, headers = headers)
 

--- a/src/you_get/extractors/dilidili.py
+++ b/src/you_get/extractors/dilidili.py
@@ -15,8 +15,7 @@ headers = {
     'Cache-Control': 'max-age=0',
     'Referer': 'http://www.dilidili.com/',
     'Connection': 'keep-alive',
-    'Save-Data': 'on',
-    'Save-Data': 'on',
+    'Save-Data': 'on'
 }
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
1.accept new dilidili domain name
2.remove useless code which is finding title in video xml in ckplayer.py, and also the reason why download  
video from dilidili failed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1671)
<!-- Reviewable:end -->
