### PR TITLE
[common] log URLs in more functions with network requests

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -255,6 +255,8 @@ def undeflate(data):
 
 # DEPRECATED in favor of get_content()
 def get_response(url, faker = False):
+    logging.debug('get_response: %s' % url)
+
     # install cookies
     if cookies:
         opener = request.build_opener(request.HTTPCookieProcessor(cookies))
@@ -275,11 +277,15 @@ def get_response(url, faker = False):
 
 # DEPRECATED in favor of get_content()
 def get_html(url, encoding = None, faker = False):
+    logging.debug('get_html: %s' % url)
+
     content = get_response(url, faker).data
     return str(content, 'utf-8', 'ignore')
 
 # DEPRECATED in favor of get_content()
 def get_decoded_html(url, faker = False):
+    logging.debug('get_decoded_html: %s' % url)
+
     response = get_response(url, faker)
     data = response.data
     charset = r1(r'charset=([\w-]+)', response.headers['content-type'])
@@ -289,6 +295,8 @@ def get_decoded_html(url, faker = False):
         return data
 
 def get_location(url):
+    logging.debug('get_location: %s' % url)
+
     response = request.urlopen(url)
     # urllib will follow redirections and it's too much code to tell urllib
     # not to do that
@@ -394,6 +402,8 @@ def urls_size(urls, faker = False, headers = {}):
     return sum([url_size(url, faker=faker, headers=headers) for url in urls])
 
 def get_head(url, headers = {}, get_method = 'HEAD'):
+    logging.debug('get_head: %s' % url)
+
     if headers:
         req = request.Request(url, headers=headers)
     else:
@@ -403,6 +413,8 @@ def get_head(url, headers = {}, get_method = 'HEAD'):
     return dict(res.headers)
 
 def url_info(url, faker = False, headers = {}):
+    logging.debug('url_info: %s' % url)
+
     if faker:
         response = urlopen_with_retry(request.Request(url, headers=fake_headers))
     elif headers:
@@ -456,6 +468,8 @@ def url_info(url, faker = False, headers = {}):
 def url_locations(urls, faker = False, headers = {}):
     locations = []
     for url in urls:
+        logging.debug('url_locations: %s' % url)
+
         if faker:
             response = urlopen_with_retry(request.Request(url, headers=fake_headers))
         elif headers:


### PR DESCRIPTION
This is a follow-up to #999.

This commit adds the

    <function_name>: <url>

debug message, which was previously only emitted by `get_content` and `post_content`, to all high level utility functions with network requests except `url_size`, `url_save` and `url_save_chunked` (in order not to ruin progress bars).

---

Rationale: I've been very happy with the `get_content: <url>` messages since their introduction, so expansion to all utility functions seems a good idea to me.

To respond to the original review comment in #999:

> Honestly speaking, I've not needed debug messages like this; leaving tcpdump open and you'll get a bit of everything underhood (at least for HTTP-only sites like Youku and Tudou, which is commonly the case for most Chinese websites).
>
> However, it could be easier to tell in which URL you're stuck purely from the debug message of you-get itself. And it works for HTTPS links.

tcpdump works, but it could be very noisy when you're multitasking on one interface. Moreover, if you're running multiple you-get sessions at once, and maybe even have pages from the same website(s) open in the browser at the same time, it's hard to tell which request originated from which session.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1677)
<!-- Reviewable:end -->
