### PR TITLE
do not print size when container is m3u8

### DIFF
--- a/src/you_get/extractor.py
+++ b/src/you_get/extractor.py
@@ -98,7 +98,7 @@ class VideoExtractor():
         if 'quality' in stream:
             print("      quality:       %s" % stream['quality'])
 
-        if 'size' in stream:
+        if 'size' in stream and stream['container'].lower() != 'm3u8':
             print("      size:          %s MiB (%s bytes)" % (round(stream['size'] / 1048576, 1), stream['size']))
 
         if 'itag' in stream:


### PR DESCRIPTION
fix https://github.com/soimort/you-get/issues/1703

test case
```
./you-get -i 'http://www.iqiyi.com/v_19rradj4jc.html'
```

```
site:                爱奇艺 (Iqiyi)
title:               实拍一男子漂移竟将自己甩出车外 险遭碾压
streams:             # Available quality and codecs
    [ DEFAULT ] _________________________________
    - format:        TD
      container:     m3u8
      video-profile: 720p
    # download-with: you-get --format=TD [URL]

    - format:        HD
      container:     m3u8
      video-profile: 540p
    # download-with: you-get --format=HD [URL]

    - format:        SD
      container:     m3u8
      video-profile: 360p
    # download-with: you-get --format=SD [URL]

    - format:        LD
      container:     m3u8
      video-profile: 210p
    # download-with: you-get --format=LD [URL]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1705)
<!-- Reviewable:end -->
