### PR TITLE
[common] print user agent when dumping URLs (-u, --url)

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -751,12 +751,18 @@ def get_output_filename(urls, title, ext, output_dir, merge):
                 merged_ext = 'ts'
     return '%s.%s' % (title, merged_ext)
 
+def print_user_agent(faker=False):
+    urllib_default_user_agent = 'Python-urllib/%d.%d' % sys.version_info[:2]
+    user_agent = fake_headers['User-Agent'] if faker else urllib_default_user_agent
+    print('User Agent: %s' % user_agent)
+
 def download_urls(urls, title, ext, total_size, output_dir='.', refer=None, merge=True, faker=False, headers = {}, **kwargs):
     assert urls
     if json_output:
         json_output_.download_urls(urls=urls, title=title, ext=ext, total_size=total_size, refer=refer)
         return
     if dry_run:
+        print_user_agent(faker=faker)
         print('Real URLs:\n%s' % '\n'.join(urls))
         return
 
@@ -873,6 +879,7 @@ def download_urls(urls, title, ext, total_size, output_dir='.', refer=None, merg
 def download_urls_chunked(urls, title, ext, total_size, output_dir='.', refer=None, merge=True, faker=False, headers = {}, **kwargs):
     assert urls
     if dry_run:
+        print_user_agent(faker=faker)
         print('Real URLs:\n%s\n' % urls)
         return
 
@@ -952,6 +959,7 @@ def download_urls_chunked(urls, title, ext, total_size, output_dir='.', refer=No
 def download_rtmp_url(url,title, ext,params={}, total_size=0, output_dir='.', refer=None, merge=True, faker=False):
     assert url
     if dry_run:
+        print_user_agent(faker=faker)
         print('Real URL:\n%s\n' % [url])
         if params.get("-y",False): #None or unset ->False
             print('Real Playpath:\n%s\n' % [params.get("-y")])
@@ -969,6 +977,7 @@ def download_rtmp_url(url,title, ext,params={}, total_size=0, output_dir='.', re
 def download_url_ffmpeg(url,title, ext,params={}, total_size=0, output_dir='.', refer=None, merge=True, faker=False):
     assert url
     if dry_run:
+        print_user_agent(faker=faker)
         print('Real URL:\n%s\n' % [url])
         if params.get("-y",False): #None or unset ->False
             print('Real Playpath:\n%s\n' % [params.get("-y")])


### PR DESCRIPTION
This is just a suggestion.

Certain sites (known example: tudou.com; other sites may be affected too, currently or in the future) deny access to video URLs unless user agent matches the one used when retrieving URLs from the API, effectively rendering the URLs useless without the proper user agent. Therefore, exposing the user agent (which may not be even to find for casual users) in `-u, --url` output could come in handy at times.

This commit does not affect `--json` output.

Sample sessions:

```
$ you-get -u http://www.tudou.com/programs/view/QjZZ5dzxR9s/
Site:       Tudou.com
Title:      中华人民共和国国歌（义勇军进行曲）
Type:       MPEG-4 video (video/mp4)
Size:       0.64 MiB (672037 Bytes)

User Agent: Python-urllib/3.6
Real URLs:
http://58.205.218.5/mp4/61/125003061.h264_1.mp4?key=a0cbde8160cf77affa236658b3b93f0011c406d8cf&qrs=98225466&p=4149345344195641307&playtype=52&tk=142762909734852181110599083&brt=52&bc=0&xid=040052010051A775CC553C6DEE9CA13C870B90-2AF7-AA76-622A-58F2D9D1CABF&nt=0&nw=1&bs=0&ispid=1002&rc=200&inf=12&si=un&npc=1168&pp=0&ul=0&mt=0&sid=0&pc=0&cip=140.180.188.12&id=tudou&hf=0&hd=0&sta=0&ssid=0&cvid=&itemid=87497779&fi=0&sz=672037
```

```
$ you-get -u https://vimeo.com/118190268
Site:       Vimeo.com
Title:      1Password 5 for iOS – Setting Up One-Time Passwords from AgileBits on Vimeo
Type:       MPEG-4 video (video/mp4)
Size:       6.4 MiB (6710452 Bytes)

User Agent: Mozilla/5.0 (Windows NT 10.0; WOW64; rv:51.0) Gecko/20100101 Firefox/51.0
Real URLs:
https://13-lvl3-pdl.vimeocdn.com/01/3638/4/118190268/331170575.mp4?expires=1488177190&token=0cc335f9ce7c7759a09a2
```

## A note on programmatic parsing of `you-get -u` output

This change slightly breaks the expectations of `you-get -u` output. However, since the output includes video info to begin with, with is rather irregular across different sites or even videos from the same site, hopefully users who parse this output already have proper filtering in place (e.g. `sed -n '/^Real URLs:$/,$ { /^Real URLs:$/n; p; }'`, or even simpler, `grep '^http'`) which won't be affected by this injection.

There's also `--json` which isn't affected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1715)
<!-- Reviewable:end -->
