### PR TITLE
youku: warn about segments skipped due to paywall

### DIFF
--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -295,9 +295,14 @@ class Youku(VideoExtractor):
                 for piece in pieces:
                     segs = piece['segs']
                     streamfileid = piece['fileid']
-                    for no in range(0, len(segs)):
+                    seg_count = len(segs)
+                    for no in range(0, seg_count):
                         k = segs[no]['key']
-                        if k == -1: break # we hit the paywall; stop here
+                        if k == -1:
+                            # we hit the paywall; stop here
+                            log.w('Skipping %d out of %d segments due to paywall' %
+                                  (seg_count - no, seg_count))
+                            break
                         fileid, ep = self.__class__.generate_ep(self, no, streamfileid,
                                                                 sid, token)
                         q = parse.urlencode(dict(


### PR DESCRIPTION
This is especially helpful in cases where the entire video is blocked by paywall, resulting in an unhelpful error message

```
you-get: [Failed] Cannot extract video source.
```

I spent quite a few minutes debugging a URL like that,^ which could have been saved by the message

```
you-get: Skipping 27 out of 27 segments due to paywall
```

added by this commit.

^The video is completely region-blocked where I am, so I didn't know it was behind a paywall before feeding it to you-get — with a Mainland-based extractor proxy of course. That should explain my initial confusion — it would have been obvious if I checked its availability in a Unblock Youku-enabled browser session first. Still, more self-contained information should make you-get better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1744)
<!-- Reviewable:end -->
