### PR TITLE
log: mark xterm* terminals as ANSI escape sequences-compatible

### DIFF
--- a/src/you_get/util/log.py
+++ b/src/you_get/util/log.py
@@ -5,13 +5,13 @@ from ..version import script_name
 
 import os, sys
 
-IS_ANSI_TERMINAL = os.getenv('TERM') in (
+TERM = os.getenv('TERM', '')
+IS_ANSI_TERMINAL = TERM in (
     'eterm-color',
     'linux',
     'screen',
     'vt100',
-    'xterm',
-)
+) or TERM.startswith('xterm')
 
 # ANSI escape code
 # See <http://en.wikipedia.org/wiki/ANSI_escape_code>


### PR DESCRIPTION
`xterm-color`, `xterm-16color`, `xterm-88color` and `xterm-256color` are now covered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1745)
<!-- Reviewable:end -->
