### PR TITLE
Fix cntv

### DIFF
--- a/src/you_get/extractors/cntv.py
+++ b/src/you_get/extractors/cntv.py
@@ -32,6 +32,8 @@ def cntv_download_by_id(id, title = None, output_dir = '.', merge = True, info_o
 def cntv_download(url, output_dir = '.', merge = True, info_only = False, **kwargs):
     if re.match(r'http://tv\.cntv\.cn/video/(\w+)/(\w+)', url):
         id = match1(url, r'http://tv\.cntv\.cn/video/\w+/(\w+)')
+    elif re.match(r'http://tv\.cctv\.com/\d+/\d+/\d+/\w+.shtml', url):
+        id = r1(r'var guid = "(\w+)"', get_html(url))
     elif re.match(r'http://\w+\.cntv\.cn/(\w+/\w+/(classpage/video/)?)?\d+/\d+\.shtml', url) or \
          re.match(r'http://\w+.cntv.cn/(\w+/)*VIDE\d+.shtml', url) or \
          re.match(r'http://(\w+).cntv.cn/(\w+)/classpage/video/(\d+)/(\d+).shtml', url) or \


### PR DESCRIPTION
This pull request fix cntv link like this:

http://tv.cctv.com/2017/03/31/VIDEsxkQyBHVNMXUTVi2Nvek170331.shtml

latest `you-get` has an error:

```
➜  ~ you-get --debug 'http://tv.cctv.com/2017/03/31/VIDEsxkQyBHVNMXUTVi2Nvek170331.shtml'
you-get: version 0.4.595, a tiny downloader that scrapes the web.
you-get: ['http://tv.cctv.com/2017/03/31/VIDEsxkQyBHVNMXUTVi2Nvek170331.shtml']
Traceback (most recent call last):
  File "/usr/local/bin/you-get", line 9, in <module>
    load_entry_point('you-get==0.4.595', 'console_scripts', 'you-get')()
  File "/usr/local/lib/python3.5/dist-packages/you_get-0.4.595-py3.5.egg/you_get/__main__.py", line 92, in main
  File "/usr/local/lib/python3.5/dist-packages/you_get-0.4.595-py3.5.egg/you_get/common.py", line 1409, in main
  File "/usr/local/lib/python3.5/dist-packages/you_get-0.4.595-py3.5.egg/you_get/common.py", line 1322, in script_main
  File "/usr/local/lib/python3.5/dist-packages/you_get-0.4.595-py3.5.egg/you_get/common.py", line 1138, in download_main
  File "/usr/local/lib/python3.5/dist-packages/you_get-0.4.595-py3.5.egg/you_get/common.py", line 1402, in any_download
  File "/usr/local/lib/python3.5/dist-packages/you_get-0.4.595-py3.5.egg/you_get/extractors/cntv.py", line 46, in cntv_download
  File "/usr/local/lib/python3.5/dist-packages/you_get-0.4.595-py3.5.egg/you_get/extractors/cntv.py", line 12, in cntv_download_by_id
AssertionError

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/1820)
<!-- Reviewable:end -->
