### PR TITLE
common.py append ext name when -O flag existed

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -737,7 +737,10 @@ class DummyProgressBar:
 def get_output_filename(urls, title, ext, output_dir, merge):
     # lame hack for the --output-filename option
     global output_filename
-    if output_filename: return output_filename
+    if output_filename:
+        if ext:
+            return output_filename + '.' + ext
+        return output_filename
 
     merged_ext = ext
     if (len(urls) > 1) and merge:


### PR DESCRIPTION
#1836

```
./you-get  -O foo 'http://v.youku.com/v_show/id_XMjY5MTQ1MDg2OA==.html'
site:                优酷 (Youku)
title:               朴槿惠今天在看守所接受二次讯问 170406
stream:
    - format:        mp4
      container:     mp4
      video-profile: 高清
      size:          9.6 MiB (10041856 bytes)
    # download-with: you-get --format=mp4 [URL]

Downloading foo.mp4 ...
```