### PR TITLE
fix bug  -- youku change the JSON metadata format

### DIFF
--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -228,7 +228,7 @@ class Youku(VideoExtractor):
                         'video_profile': stream_types[stream_id]['video_profile'],
                         'size': stream['size'],
                         'pieces': [{
-                            'fileid': stream['stream_fileid'],
+                            'fileid': stream['segs'][0]['fileid'],
                             'segs': stream['segs']
                         }]
                     }
@@ -252,14 +252,14 @@ class Youku(VideoExtractor):
                         'video_profile': stream_types[stream_id]['video_profile'],
                         'size': stream['size'],
                         'pieces': [{
-                            'fileid': stream['stream_fileid'],
+                            'fileid': stream['segs'][0]['fileid'],
                             'segs': stream['segs']
                         }]
                     }
                 else:
                     self.streams_fallback[stream_id]['size'] += stream['size']
                     self.streams_fallback[stream_id]['pieces'].append({
-                        'fileid': stream['stream_fileid'],
+                        'fileid': stream['segs'][0]['fileid'],
                         'segs': stream['segs']
                     })
 


### PR DESCRIPTION
fix the bug , youku change the JSON metadate format from http://play.youku.com/play/get.json?
for example : http://play.youku.com/play/get.json?vid=XMjcwOTIwMzAwOA&ct=12  response json  use new fileid at [data][stream][segs][*][fileid] instead old streamfileid at  [data][stream][stream_fileid]