### PR TITLE
Tuning debugging message

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -1358,7 +1358,8 @@ def script_main(script_name, download, download_playlist, **kwargs):
         else:
             sys.exit(1)
     except UnicodeEncodeError:
-        raise
+        if traceback:
+            raise
         log.e('[error] oops, the current environment does not seem to support Unicode.')
         log.e('please set it to a UTF-8-aware locale first,')
         log.e('so as to save the video (with some Unicode characters) correctly.')

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -279,15 +279,11 @@ def get_response(url, faker = False):
 
 # DEPRECATED in favor of get_content()
 def get_html(url, encoding = None, faker = False):
-    logging.debug('get_html: %s' % url)
-
     content = get_response(url, faker).data
     return str(content, 'utf-8', 'ignore')
 
 # DEPRECATED in favor of get_content()
 def get_decoded_html(url, faker = False):
-    logging.debug('get_decoded_html: %s' % url)
-
     response = get_response(url, faker)
     data = response.data
     charset = r1(r'charset=([\w-]+)', response.headers['content-type'])
@@ -1362,6 +1358,7 @@ def script_main(script_name, download, download_playlist, **kwargs):
         else:
             sys.exit(1)
     except UnicodeEncodeError:
+        raise
         log.e('[error] oops, the current environment does not seem to support Unicode.')
         log.e('please set it to a UTF-8-aware locale first,')
         log.e('so as to save the video (with some Unicode characters) correctly.')

--- a/src/you_get/processor/ffmpeg.py
+++ b/src/you_get/processor/ffmpeg.py
@@ -21,10 +21,12 @@ def get_usable_ffmpeg(cmd):
         out, err = p.communicate()
         vers = str(out, 'utf-8').split('\n')[0].split()
         assert (vers[0] == 'ffmpeg' and vers[2][0] > '0') or (vers[0] == 'avconv')
-        #if the version is strange like 'N-1234-gd1111', set version to 2.0
+        #set version to 1.0 for nightly build and print warning
         try:
             version = [int(i) for i in vers[2].split('.')]
         except:
+            print('It seems that your ffmpeg is a nightly build.')
+            print('Please switch to the latest stable if merging failed.')
             version = [1, 0]
         return cmd, version
     except:


### PR DESCRIPTION
1. print stack trace when ```UnicodeEncodeError``` caught
2. remove deugging message from ```get_html``` and ```get_decoded_html```, which call ```get_responce``` and print two message for one HTTP request.
3. print a hit when an ffmpeg nightly build, which uses concat protocol when merges video segs.