### PR TITLE
refactoring miaopai.py

### DIFF
--- a/src/you_get/extractors/miaopai.py
+++ b/src/you_get/extractors/miaopai.py
@@ -5,39 +5,35 @@ __all__ = ['miaopai_download']
 from ..common import *
 import urllib.error
 
-def miaopai_download_by_url(url, output_dir = '.', merge = False, info_only = False, **kwargs):
+def miaopai_download_by_fid(fid, output_dir = '.', merge = False, info_only = False, **kwargs):
     '''Source: Android mobile'''
-    if re.match(r'http://video.weibo.com/show\?fid=(\d{4}:\w{32})\w*', url):
-        fake_headers_mobile = {
-            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-            'Accept-Charset': 'UTF-8,*;q=0.5',
-            'Accept-Encoding': 'gzip,deflate,sdch',
-            'Accept-Language': 'en-US,en;q=0.8',
-            'User-Agent': 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36'
-        }
-        webpage_url = re.search(r'(http://video.weibo.com/show\?fid=\d{4}:\w{32})\w*', url).group(1) + '&type=mp4'  #mobile
+    fake_headers_mobile = {
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Charset': 'UTF-8,*;q=0.5',
+        'Accept-Encoding': 'gzip,deflate,sdch',
+        'Accept-Language': 'en-US,en;q=0.8',
+        'User-Agent': 'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36'
+    }
+    page_url = 'http://video.weibo.com/show?fid=' + fid + '&type=mp4'
 
-        #grab download URL
-        a = get_content(webpage_url, headers= fake_headers_mobile , decoded=True)
-        url = match1(a, r'<video id=.*?src=[\'"](.*?)[\'"]\W')
-
-        #grab title
-        b = get_content(webpage_url)  #normal
-        title = match1(b, r'<meta name="description" content="([\s\S]*?)\"\W')
-
-        type_, ext, size = url_info(url)
-        print_info(site_info, title, type_, size)
-        if not info_only:
-            download_urls([url], title.replace('\n',''), ext, total_size=None, output_dir=output_dir, merge=merge)
+    mobile_page = get_content(page_url, headers=fake_headers_mobile)
+    url = match1(mobile_page, r'<video id=.*?src=[\'"](.*?)[\'"]\W')
+    title = match1(mobile_page, r'<title>([^<]+)</title>')
+    type_, ext, size = url_info(url)
+    print_info(site_info, title, type_, size)
+    if not info_only:
+        download_urls([url], title.replace('\n',''), ext, total_size=None, output_dir=output_dir, merge=merge)
 
 #----------------------------------------------------------------------
 def miaopai_download(url, output_dir = '.', merge = False, info_only = False, **kwargs):
-    """"""
-    if re.match(r'http://video.weibo.com/show\?fid=(\d{4}:\w{32})\w*', url):
-        miaopai_download_by_url(url, output_dir, merge, info_only)
-    elif re.match(r'http://weibo.com/p/230444\w+', url):
-        _fid = match1(url, r'http://weibo.com/p/230444(\w+)')
-        miaopai_download_by_url('http://video.weibo.com/show?fid=1034:{_fid}'.format(_fid = _fid), output_dir, merge, info_only)
+    fid = match1(url, r'\?fid=(\d{4}:\w{32})')
+    if fid is not None:
+        miaopai_download_by_fid(fid, output_dir, merge, info_only)
+    elif '/p/230444' in url:
+        fid = match1(url, r'/p/230444(\w+)')
+        miaopai_download_by_fid('1034:'+fid, output_dir, merge, info_only)
+    else:
+        raise Exception('Unknown pattern')
 
 site_info = "miaopai"
 download = miaopai_download


### PR DESCRIPTION
1. for ```miaopai_download```
get fid from the urls and raise exception if no pattern can be matched with

2. change ```miaopai_download_by_url``` to ```miaopai_download_by_fid```
access the mobile page only once and fetch both the video url and title

test case for /p/230444
```
./you-get 'http://weibo.com/p/230444bf778220fe93887030056812aeaffa39'
Site:       miaopai
Title:      #邓紫棋# "十支歌选一首""不能选 十只手指有长短"[喵喵]"如果给这张专辑打分""一百分！！"这傲娇的小公举😂😂😂
Type:       MPEG-4 video (video/mp4)
Size:       0.94 MiB (988586 Bytes)

Downloading #邓紫棋# "十支歌选一首""不能选 十只手指有长短"[喵喵]"如果给这张专辑打分""一百分！！"这傲娇的小公举😂😂😂.mp4 ...
 100% (  0.9/  0.9MB) ├█████████████████████████████████████████┤[1/1]  296 MB/s
```

test case for ```fid=\d{4}:\w{32}```
```
./you-get 'http://weibo.com/tv/v/d052ec5abf86de2354f8ac21f1defe88?fid=1034:d052ec5abf86de2354f8ac21f1defe88'
Site:       miaopai
Title:      #重庆这些事#男生女生看了赶快收藏哟，为你爱的人做意想不到的惊喜[挤眼][挤眼][挤眼] via@重庆这些事
Type:       MPEG-4 video (video/mp4)
Size:       3.68 MiB (3861405 Bytes)

Downloading #重庆这些事#男生女生看了赶快收藏哟，为你爱的人做意想不到的惊喜[挤眼][挤眼][挤眼] via@重庆这些事.mp4 ...
 100% (  3.7/  3.7MB) ├█████████████████████████████████████████┤[1/1]   25 MB/s
```