### PR TITLE
Fixed some songs on netease get 404 problem

### DIFF
--- a/src/you_get/extractors/netease.py
+++ b/src/you_get/extractors/netease.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from urllib.error import HTTPError
 
 __all__ = ['netease_download']
 
@@ -108,6 +108,7 @@ def netease_video_download(vinfo, output_dir='.', info_only=False):
 def netease_song_download(song, output_dir='.', info_only=False, playlist_prefix=""):
     title = "%s%s. %s" % (playlist_prefix, song['position'], song['name'])
     songNet = 'p' + song['mp3Url'].split('/')[2][1:]
+    url_backup = loads(get_content(url="https://api.imjad.cn/cloudmusic/?type=song&id=%s&br=320000" % song['id']))
 
     if 'hMusic' in song and song['hMusic'] != None:
         url_best = make_url(songNet, song['hMusic']['dfsId'])
@@ -115,9 +116,14 @@ def netease_song_download(song, output_dir='.', info_only=False, playlist_prefix
         url_best = song['mp3Url']
     elif 'bMusic' in song:
         url_best = make_url(songNet, song['bMusic']['dfsId'])
-
-    netease_download_common(title, url_best,
+        url_backup = get_content(
+            url="https://api.imjad.cn/cloudmusic/?type=song&id=%s&br=320000" % song['bMusic']['dfsId'])
+    try:
+        netease_download_common(title, url_best,
                             output_dir=output_dir, info_only=info_only)
+    except HTTPError:
+        netease_download_common(title, url_backup['data'][0]['url'],
+                                output_dir=output_dir, info_only=info_only)
 
 def netease_download_common(title, url_best, output_dir, info_only):
     songtype, ext, size = url_info(url_best)


### PR DESCRIPTION
The original branch will get some 404 problem when parse some song on netease,so i used some api to fix this.This is my first time to contribute code to opensource project,please correct me if there are some mistakes.
原来的版本在解析网易云上有些歌的地址时会得到无效地址，我用了api.imjad.cn上的api做了一个备用下载。这是我第一次给开源项目贡献代码，如果有做得不对的地方请指正。