### PR TITLE
strip name of album fixed when download some album which name endwith…

### DIFF
--- a/src/you_get/extractors/netease.py
+++ b/src/you_get/extractors/netease.py
@@ -29,7 +29,7 @@ def netease_cloud_music_download(url, output_dir='.', merge=True, info_only=Fals
         j = loads(get_content("http://music.163.com/api/album/%s?id=%s&csrf_token=" % (rid, rid), headers={"Referer": "http://music.163.com/"}))
 
         artist_name = j['album']['artists'][0]['name']
-        album_name = j['album']['name']
+        album_name = j['album']['name'].strip()
         new_dir = output_dir + '/' + fs.legitimize("%s - %s" % (artist_name, album_name))
         if not info_only:
             if not os.path.exists(new_dir):


### PR DESCRIPTION
When download some album which name endwith spaces will rasie FileNotFoundError.
Because os.mkdir will automatically remove spaces in the end,so it will not find the correct path of tempfile.
Try this:http://music.163.com/#/album?id=34839428
当下载一些专辑名以空格结尾的专辑时，会引发FileNotFoundError。
因为os.mkdir会自动去除结尾的空格，所以程序找不到正确的临时文件的路径。
举个栗子：http://music.163.com/#/album?id=34839428