### PR TITLE
Fix Bilibili 403 error

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -518,8 +518,7 @@ def url_save(url, filepath, bar, refer = None, is_part = False, faker = False, h
             headers = headers
         else:
             headers = {}
-        if received:
-            headers['Range'] = 'bytes=' + str(received) + '-'
+        headers['Range'] = 'bytes=' + str(received) + '-'
         if refer:
             headers['Referer'] = refer
 

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -82,7 +82,7 @@ def bilibili_download_by_cids(cids, title, output_dir='.', merge=True, info_only
 
     print_info(site_info, title, type_, size)
     if not info_only:
-        download_urls(urls, title, type_, total_size=None, output_dir=output_dir, merge=merge)
+        download_urls(urls, title, type_, total_size=None, output_dir=output_dir, merge=merge, headers={'Referer': 'http://www.bilibili.com/'})
 
 
 def bilibili_download_by_cid(cid, title, output_dir='.', merge=True, info_only=False):
@@ -98,12 +98,12 @@ def bilibili_download_by_cid(cid, title, output_dir='.', merge=True, info_only=F
             type_ = ''
             size = 0
             for url in urls:
-                _, type_, temp = url_info(url)
+                _, type_, temp = url_info(url, headers={'Referer': 'http://www.bilibili.com/'})
                 size += temp or 0
 
             print_info(site_info, title, type_, size)
             if not info_only:
-                download_urls(urls, title, type_, total_size=None, output_dir=output_dir, merge=merge, timeout=1)
+                download_urls(urls, title, type_, total_size=None, output_dir=output_dir, merge=merge, timeout=1, headers={'Referer': 'http://www.bilibili.com/'})
         except socket.timeout:
             continue
         else:


### PR DESCRIPTION
1. Add `Referer` in both `url_info()` and `download_urls()`.
2. Specify the `Range` explicitly. 

Test links:
* http://www.bilibili.com/video/av10289657/
* http://www.bilibili.com/av10299156
* http://www.bilibili.com/av10354175