### PR TITLE
[common] url_info should not ignore refer when called in url_save

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -479,7 +479,13 @@ def url_locations(urls, faker = False, headers = {}):
     return locations
 
 def url_save(url, filepath, bar, refer = None, is_part = False, faker = False, headers = {}, timeout = None, **kwargs):
-    file_size = url_size(url, faker = faker, headers = headers)
+    new_headers = headers.copy()
+    if refer is not None:
+        for k in new_headers:
+            if k.lower() == 'referer':
+                del new_headers[k]
+        new_headers['referer'] = refer
+    file_size = url_size(url, faker = faker, headers = new_headers)
 
     if os.path.exists(filepath):
         if not force and file_size == os.path.getsize(filepath):


### PR DESCRIPTION
#1942

1. copy the headers.
2. check if there is already a key ```referer``` (case insensitive). If there is, ```del``` it.
3. Insert key pair ```'referer' : refer``` into ```new_headers```
4. call ```url_info``` with ```new_headers```

It seems correct to me.

