### PR TITLE
[common] url_info should not ignore refer when called in url_save

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -479,6 +479,9 @@ def url_locations(urls, faker = False, headers = {}):
     return locations
 
 def url_save(url, filepath, bar, refer = None, is_part = False, faker = False, headers = {}, timeout = None, **kwargs):
+#When a referer specified with param refer, the key must be 'Referer' for the hack here
+    if refer is not None:
+        headers['Referer'] = refer
     file_size = url_size(url, faker = faker, headers = headers)
 
     if os.path.exists(filepath):


### PR DESCRIPTION
#1942

details are in the following discussion.