### PR TITLE
Ku6/fix extension error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,6 @@ docs/_build/
 target/
 
 # Misc
-_*
-*_
 *.3gp
 *.asf
 *.download

--- a/src/you_get/extractors/ku6.py
+++ b/src/you_get/extractors/ku6.py
@@ -14,7 +14,7 @@ def ku6_download_by_id(id, title = None, output_dir = '.', merge = True, info_on
     title = title or t
     assert title
     urls = f.split(',')
-    ext = re.sub(r'.*\.', '', urls[0])
+    ext = re.match(r'.*\.(\w+)\??[^\.]*', urls[0]).group(1)
     assert ext in ('flv', 'mp4', 'f4v'), ext
     ext = {'f4v': 'flv'}.get(ext, ext)
     size = 0


### PR DESCRIPTION
Fix error when parse url "http://v.ku6.com/show/dBKZbnO51PWi7N2xRa3Bmw...html".
Case the sub-url end with mp4?AccessKeyId=...&Expires=...&Signature=...
So the regex in ku6 should be improved to fix the error.