### PR TITLE
[youku]update api

### DIFF
--- a/src/you_get/extractors/tudou.py
+++ b/src/you_get/extractors/tudou.py
@@ -61,7 +61,7 @@ def tudou_download(url, output_dir = '.', merge = True, info_only = False, **kwa
         vcode = match1(html, r'viden\s*[:=]\s*\"([\w+/=]+)\"')
     if vcode:
         from .youku import youku_download_by_vid
-        return youku_download_by_vid(vcode, title=title, output_dir=output_dir, merge=merge, info_only=info_only, **kwargs)
+        return youku_download_by_vid(vcode, title=title, output_dir=output_dir, merge=merge, info_only=info_only, src='tudou', **kwargs)
 
     iid = r1(r'iid\s*[:=]\s*(\d+)', html)
     if not iid:

--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -177,8 +177,11 @@ class Youku(VideoExtractor):
             data = youku_ups(self.vid, '0402')['data']
         else:
             data = youku_ups(self.vid)['data']
-        if data.get('error'):
-            log.wtf(data['error']['note'])
+        if data.get('stream') is None:
+            if data.get('error'):
+                log.wtf(data['error']['note'])
+            log.wtf('Unknown error')
+
         self.title = data['video']['title']
         stream_types = dict([(i['id'], i) for i in self.stream_types])
         audio_lang = data['stream'][0]['audio_lang']

--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -10,16 +10,23 @@ import time
 import traceback
 import json
 import urllib.request
+import urllib.parse
+
+def quote_cna(cna):
+    if '%' in cna:
+        return cna
+    return urllib.parse.quote(cna)
 
 def fetch_cna():
     if cookies:
         for cookie in cookies:
             if cookie.name == 'cna' and cookie.domain == '.youku.com':
                 log.i('Found cna in imported cookies. Use it')
-                return cookie.value
+                return quote_cna(cookie.value)
     url = 'http://gm.mmstat.com/yt/ykcomment.play.commentInit?cna='
     req = urllib.request.urlopen(url)
-    return req.info()['Set-Cookie'].split(';')[0].split('=')[1]
+    cna = req.info()['Set-Cookie'].split(';')[0].split('=')[1]
+    return quote_cna(cna)
 
 def youku_ups(vid, ccode='0401'):
     url = 'https://ups.youku.com/ups/get.json?vid={}&ccode={}'.format(vid, ccode)

--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -23,10 +23,17 @@ def fetch_cna():
             if cookie.name == 'cna' and cookie.domain == '.youku.com':
                 log.i('Found cna in imported cookies. Use it')
                 return quote_cna(cookie.value)
-    url = 'http://gm.mmstat.com/yt/ykcomment.play.commentInit?cna='
+    url = 'http://log.mmstat.com/eg.js'
     req = urllib.request.urlopen(url)
-    cna = req.info()['Set-Cookie'].split(';')[0].split('=')[1]
-    return quote_cna(cna)
+    headers = req.getheaders()
+    for header in headers:
+        if header[0].lower() == 'set-cookie':
+            n_v = header[1].split(';')[0]
+            name, value = n_v.split('=')
+            if name == 'cna':
+                return quote_cna(value)
+    log.w('It seems that the client failed to fetch a cna cookie. Please load your own cookie if possible')
+    return quote_cna('DOG4EdW4qzsCAbZyXbU+t7Jt')
 
 def youku_ups(vid, ccode='0401'):
     url = 'https://ups.youku.com/ups/get.json?vid={}&ccode={}'.format(vid, ccode)

--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -8,6 +8,25 @@ import base64
 import ssl
 import time
 import traceback
+import json
+import urllib.request
+
+def fetch_cna():
+    if cookies:
+        for cookie in cookies:
+            if cookie.name == 'cna' and cookie.domain == '.youku.com':
+                log.i('Found cna in imported cookies. Use it')
+                return cookie.value
+    url = 'http://gm.mmstat.com/yt/ykcomment.play.commentInit?cna='
+    req = urllib.request.urlopen(url)
+    return req.info()['Set-Cookie'].split(';')[0].split('=')[1]
+
+def youku_ups(vid, ccode='0401'):
+    url = 'https://ups.youku.com/ups/get.json?vid={}&ccode={}'.format(vid, ccode)
+    url += '&client_ip=192.168.1.1'
+    url += '&utid=' + fetch_cna()
+    url += '&client_ts=' + str(int(time.time()))
+    return json.loads(get_content(url))
 
 class Youku(VideoExtractor):
     name = "优酷 (Youku)"
@@ -154,66 +173,19 @@ class Youku(VideoExtractor):
             if self.vid is None:
                 self.download_playlist_by_url(self.url, **kwargs)
                 exit(0)
-
-        #HACK!
-        if 'api_url' in kwargs:
-            api_url = kwargs['api_url']  #85
-            api12_url = kwargs['api12_url']  #86
-            self.ctype = kwargs['ctype']
-            self.title = kwargs['title']
-
+        if kwargs.get('src') and kwargs['src'] == 'tudou':
+            data = youku_ups(self.vid, '0402')['data']
         else:
-            api_url = 'http://play.youku.com/play/get.json?vid=%s&ct=10' % self.vid
-            api12_url = 'http://play.youku.com/play/get.json?vid=%s&ct=12' % self.vid
-
-        try:
-            meta = json.loads(get_content(
-                api_url,
-                headers={'Referer': 'http://static.youku.com/'}
-            ))
-            meta12 = json.loads(get_content(
-                api12_url,
-                headers={'Referer': 'http://static.youku.com/'}
-            ))
-            data = meta['data']
-            data12 = meta12['data']
-            assert 'stream' in data
-        except AssertionError:
-            if 'error' in data:
-                if data['error']['code'] == -202:
-                    # Password protected
-                    self.password_protected = True
-                    self.password = input(log.sprint('Password: ', log.YELLOW))
-                    api_url += '&pwd={}'.format(self.password)
-                    api12_url += '&pwd={}'.format(self.password)
-                    meta = json.loads(get_content(
-                        api_url,
-                        headers={'Referer': 'http://static.youku.com/'}
-                    ))
-                    meta12 = json.loads(get_content(
-                        api12_url,
-                        headers={'Referer': 'http://static.youku.com/'}
-                    ))
-                    data = meta['data']
-                    data12 = meta12['data']
-                else:
-                    log.wtf('[Failed] ' + data['error']['note'])
-            else:
-                log.wtf('[Failed] Video not found.')
-
-        if not self.title:  #86
-            self.title = data['video']['title']
-        self.ep = data12['security']['encrypt_string']
-        self.ip = data12['security']['ip']
-
-        if 'stream' not in data and self.password_protected:
-            log.wtf('[Failed] Wrong password.')
-
+            data = youku_ups(self.vid)['data']
+        if data.get('error'):
+            log.wtf(data['error']['note'])
+        self.title = data['video']['title']
         stream_types = dict([(i['id'], i) for i in self.stream_types])
         audio_lang = data['stream'][0]['audio_lang']
 
         for stream in data['stream']:
             stream_id = stream['stream_type']
+            is_preview = False
             if stream_id in stream_types and stream['audio_lang'] == audio_lang:
                 if 'alias-of' in stream_types[stream_id]:
                     stream_id = stream_types[stream_id]['alias-of']
@@ -227,40 +199,34 @@ class Youku(VideoExtractor):
                             'segs': stream['segs']
                         }]
                     }
+                    src = []
+                    for seg in stream['segs']:
+                        if seg.get('cdn_url'):
+                            src.append(seg['cdn_url'])
+                        else:
+                            is_preview = True
+                    self.streams[stream_id]['src'] = src
                 else:
                     self.streams[stream_id]['size'] += stream['size']
                     self.streams[stream_id]['pieces'].append({
                         'segs': stream['segs']
                     })
-
-        self.streams_fallback = {}
-        for stream in data12['stream']:
-            stream_id = stream['stream_type']
-            if stream_id in stream_types and stream['audio_lang'] == audio_lang:
-                if 'alias-of' in stream_types[stream_id]:
-                    stream_id = stream_types[stream_id]['alias-of']
-
-                if stream_id not in self.streams_fallback:
-                    self.streams_fallback[stream_id] = {
-                        'container': stream_types[stream_id]['container'],
-                        'video_profile': stream_types[stream_id]['video_profile'],
-                        'size': stream['size'],
-                        'pieces': [{
-                            'segs': stream['segs']
-                        }]
-                    }
-                else:
-                    self.streams_fallback[stream_id]['size'] += stream['size']
-                    self.streams_fallback[stream_id]['pieces'].append({
-                        'segs': stream['segs']
-                    })
+                    src = []
+                    for seg in stream['segs']:
+                        if seg.get('cdn_url'):
+                            src.append(seg['cdn_url'])
+                        else:
+                            is_preview = True
+                    self.streams[stream_id]['src'].extend(src)
+            if is_preview:
+                log.w('{} is a preview'.format(stream_id))
 
         # Audio languages
         if 'dvd' in data and 'audiolang' in data['dvd']:
             self.audiolang = data['dvd']['audiolang']
             for i in self.audiolang:
                 i['url'] = 'http://v.youku.com/v_show/id_{}'.format(i['vid'])
-
+    '''
     def extract(self, **kwargs):
         if 'stream_id' in kwargs and kwargs['stream_id']:
             # Extract the stream
@@ -279,7 +245,6 @@ class Youku(VideoExtractor):
             base64.b64decode(bytes(self.ep, 'ascii'))
         )
         sid, token = e_code.split('_')
-
         while True:
             try:
                 ksegs = []
@@ -327,6 +292,7 @@ class Youku(VideoExtractor):
 
         if not kwargs['info_only']:
             self.streams[stream_id]['src'] = ksegs
+    '''
 
     def open_download_by_vid(self, client_id, vid, **kwargs):
         """self, str, str, **kwargs->None
@@ -394,3 +360,6 @@ download_playlist = site.download_playlist_by_url
 youku_download_by_vid = site.download_by_vid
 youku_open_download_by_vid = site.open_download_by_vid
 # Used by: acfun.py bilibili.py miomio.py tudou.py
+# acfun has its own proxy and won't use it
+# miomio is dead
+# tudou doesn't use ct85 so open_download_by_vid is uesless now.


### PR DESCRIPTION
NOTE:

1.  ```yxon``` not impled. F. I. 10 segs in hd3, 8 ones in hd2, 5 ones both in mp4 and flv. 28 extra network requests will be sent, which makes the program seem stuck or produces lots of noise in the debugging log. #1058

2.  Failed with ```http://v.youku.com/v_show/id_XMjc3MjQ0MjEwMA==.html```. ep40 of Zetianji. But it works when downloading ep1 and ep45. Perhaps you should curse the CDN before a VIP user of youku find out what's wrong.

---

1. ```yxon```没有放进代码里。比如一个视频，hd3有10个片段，hd2有8个，mp4和flv各5个，那么一共需要发出28个网络请求，程序会看上去像卡住了一样，或者输出大量没什么用的debugging log。另外可以参考 #1058 ，有人需要。

2. 择天记第40集下载会失败（hd3，其他分辨率正常）。但是择天记的第一集或是第45集都正常，选1080p需要vip所以也没法在浏览器里面看是不是正常。大概只能怪youku的CDN了。

```
$ ./you-get -d 'http://v.youku.com/v_show/id_XMjc4MTQ3MzY5Mg==.html'
[DEBUG] get_content: https://ups.youku.com/ups/get.json?vid=XMjc4MTQ3MzY5Mg==&ccode=0401&client_ip=192.168.1.1&utid=3nOsESeJhAUCAbZyXYm8UflX&client_ts=1495631326
site:                优酷 (Youku)
title:               李志、电声与管弦乐 03.尽头
stream:
    - format:        hd3
      container:     flv
      video-profile: 1080P
      size:          60.3 MiB (63205554 bytes)
    # download-with: you-get --format=hd3 [URL]

Downloading 李志、电声与管弦乐 03.尽头.flv ...
 100% ( 60.3/ 60.3MB) ├█████████████████████████████████████████┤[2/2]    1 MB/s
Merging video parts... ffmpeg version 3.3.1 Copyright (c) 2000-2017 the FFmpeg developers
  built with Apple LLVM version 8.1.0 (clang-802.0.42)
  configuration: --prefix=/usr/local/Cellar/ffmpeg/3.3.1 --enable-shared --enable-pthreads --enable-gpl --enable-version3 --enable-hardcoded-tables --enable-avresample --cc=clang --host-cflags= --host-ldflags= --enable-libmp3lame --enable-libx264 --enable-libxvid --enable-opencl --disable-lzma --enable-vda
  libavutil      55. 58.100 / 55. 58.100
  libavcodec     57. 89.100 / 57. 89.100
  libavformat    57. 71.100 / 57. 71.100
  libavdevice    57.  6.100 / 57.  6.100
  libavfilter     6. 82.100 /  6. 82.100
  libavresample   3.  5.  0 /  3.  5.  0
  libswscale      4.  6.100 /  4.  6.100
  libswresample   2.  7.100 /  2.  7.100
  libpostproc    54.  5.100 / 54.  5.100
[flv @ 0x7fa849800a00] Auto-inserting h264_mp4toannexb bitstream filter
Input #0, concat, from './李志、电声与管弦乐 03.尽头.mp4.txt':
  Duration: N/A, start: 0.000000, bitrate: 1877 kb/s
    Stream #0:0: Video: h264 (High), yuv420p(tv, bt709, progressive), 1920x1080 [SAR 1:1 DAR 16:9], 1748 kb/s, 25.03 fps, 25 tbr, 1k tbn, 50 tbc
    Stream #0:1: Audio: aac (LC), 44100 Hz, stereo, fltp, 128 kb/s
Output #0, mp4, to './李志、电声与管弦乐 03.尽头.mp4':
  Metadata:
    encoder         : Lavf57.71.100
    Stream #0:0: Video: h264 (High) ([33][0][0][0] / 0x0021), yuv420p(tv, bt709, progressive), 1920x1080 [SAR 1:1 DAR 16:9], q=2-31, 1748 kb/s, 25.03 fps, 25 tbr, 16k tbn, 1k tbc
    Stream #0:1: Audio: aac (LC) ([64][0][0][0] / 0x0040), 44100 Hz, stereo, fltp, 128 kb/s
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
  Stream #0:1 -> #0:1 (copy)
Press [q] to stop, [?] for help
[flv @ 0x7fa849800a00] Auto-inserting h264_mp4toannexb bitstream filter
frame= 3451 fps=0.0 q=-1.0 size=   31623kB time=00:02:17.98 bitrate=1877.4kbits/frame= 4651 fps=4651 q=-1.0 size=   45169kB time=00:03:06.00 bitrate=1989.4kbitsframe= 5542 fps=3676 q=-1.0 size=   55299kB time=00:03:41.62 bitrate=2044.1kbitsframe= 6595 fps=3615 q=-1.0 Lsize=   61601kB time=00:04:23.85 bitrate=1912.5kbits/s speed= 145x
video:57281kB audio:4123kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 0.320389%
Merged into 李志、电声与管弦乐 03.尽头.mp4
```

fix #2012 #2014 #2037 #1847

It's a quick fix, far from satisfactory but too many users need ```youku.py```.