### PR TITLE
[bilibili] use faker to fix 403 problem (CDN rejecting Python urllib's user agent)

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -77,12 +77,12 @@ def bilibili_download_by_cids(cids, title, output_dir='.', merge=True, info_only
     type_ = ''
     size = 0
     for url in urls:
-        _, type_, temp = url_info(url)
+        _, type_, temp = url_info(url, faker=True, headers={'Referer': 'http://www.bilibili.com/'})
         size += temp
 
     print_info(site_info, title, type_, size)
     if not info_only:
-        download_urls(urls, title, type_, total_size=None, output_dir=output_dir, merge=merge, headers={'Referer': 'http://www.bilibili.com/'})
+        download_urls(urls, title, type_, total_size=None, output_dir=output_dir, merge=merge, faker=True, headers={'Referer': 'http://www.bilibili.com/'})
 
 
 def bilibili_download_by_cid(cid, title, output_dir='.', merge=True, info_only=False):
@@ -98,12 +98,12 @@ def bilibili_download_by_cid(cid, title, output_dir='.', merge=True, info_only=F
             type_ = ''
             size = 0
             for url in urls:
-                _, type_, temp = url_info(url, headers={'Referer': 'http://www.bilibili.com/'})
+                _, type_, temp = url_info(url, faker=True, headers={'Referer': 'http://www.bilibili.com/'})
                 size += temp or 0
 
             print_info(site_info, title, type_, size)
             if not info_only:
-                download_urls(urls, title, type_, total_size=None, output_dir=output_dir, merge=merge, timeout=1, headers={'Referer': 'http://www.bilibili.com/'})
+                download_urls(urls, title, type_, total_size=None, output_dir=output_dir, merge=merge, timeout=1, faker=True, headers={'Referer': 'http://www.bilibili.com/'})
         except socket.timeout:
             continue
         else:


### PR DESCRIPTION
Bilibili's CDN now may reject requests with 403 when `urllib`'s default user agent is used. This appears to be location-based (and started today for me; others might have experienced this for a while): I tested on a bunch of U.S.-based nodes and all requests were rejected without a spoofed user agent, but when I tested on a Mainland China-based node, the requests went through.

To actually use the faker I had to make changes to faker logic in `common.py` (currently when `faker` is `True`, `headers` is simply ignored). Please refer to the commit message for details.

This PR appears to overlap with #1698, which attempts to do a bunch of things and hence hard for me to quickly evaluate. It also seems to roll its own user agent instead of using the existing faker. This PR only attempts to do one thing and hopefully do it well.
