### PR TITLE
[common zhanqi]m3u8 code in common; rewrite zhanqi

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -161,6 +161,22 @@ def rc4(key, data):
         out_list.append(char ^ prn)
 
     return bytes(out_list)
+
+def general_m3u8_extractor(url):
+    path_len = len(url.split('/')[-1])
+    base_url = url[:-path_len]
+
+    m3u8_list = get_content(url).split('\n')
+    urls = []
+    for line in m3u8_list:
+        line = line.strip()
+        if line and not line.startswith('#'):
+            if line.startswith('http'):
+                urls.append(line)
+            else:
+                urls.append(base_url + line)
+    return urls
+
 def maybe_print(*s):
     try: print(*s)
     except: pass
@@ -1027,7 +1043,7 @@ def playlist_not_supported(name):
         raise NotImplementedError('Playlist is not supported for ' + name)
     return f
 
-def print_info(site_info, title, type, size):
+def print_info(site_info, title, type, size, **kwargs):
     if json_output:
         json_output_.print_info(site_info=site_info, title=title, type=type, size=size)
         return
@@ -1092,14 +1108,22 @@ def print_info(site_info, title, type, size):
         type_info = "Portable Network Graphics (%s)" % type
     elif type in ['image/gif']:
         type_info = "Graphics Interchange Format (%s)" % type
-
+    elif type in ['m3u8']:
+        if 'm3u8_type' in kwargs:
+            if kwargs['m3u8_type'] == 'master':
+                type_info = 'M3U8 Master {}'.format(type)
+        else:
+            type_info = 'M3U8 Playlist {}'.format(type)
     else:
         type_info = "Unknown type (%s)" % type
 
     maybe_print("Site:      ", site_info)
     maybe_print("Title:     ", unescape_html(tr(title)))
     print("Type:      ", type_info)
-    print("Size:      ", round(size / 1048576, 2), "MiB (" + str(size) + " Bytes)")
+    if type != 'm3u8':
+        print("Size:      ", round(size / 1048576, 2), "MiB (" + str(size) + " Bytes)")
+    if type == 'm3u8' and 'm3u8_url' in kwargs:
+        print('M3U8 Url:   {}'.format(kwargs['m3u8_url']))
     print()
 
 def mime_to_container(mime):

--- a/src/you_get/extractors/zhanqi.py
+++ b/src/you_get/extractors/zhanqi.py
@@ -4,53 +4,48 @@ __all__ = ['zhanqi_download']
 
 from ..common import *
 import json
+import base64
+from urllib.parse import urlparse
 
 def zhanqi_download(url, output_dir = '.', merge = True, info_only = False, **kwargs):
-    host_name = url.split('/')[2]
-    first_folder_path = url.split('/')[3].split('?')[0]
+    path = urlparse(url).path[1:]
 
-    if first_folder_path != 'videos': #url = "https://www.zhanqi.tv/huashan?param_s=1_0.2.0"
-        if first_folder_path == 'topic': #https://www.zhanqi.tv/topic/lyingman
-            first_folder_path = url.split('/')[4].split('?')[0]
-        api_url = "https://www.zhanqi.tv/api/static/v2.1/room/domain/" + first_folder_path + ".json"
-        api_json = json.loads(get_html(api_url))
-        data = api_json['data']
-        status = data['status']
-        if status != '4':
-            raise ValueError ("The live stream is not online!")
-
-        nickname = data['nickname']
-        title = nickname + ": " + data['title']
-
-        roomid = data['id']
-        videoId = data['videoId']
-        jump_url = "http://wshdl.load.cdn.zhanqi.tv/zqlive/" + videoId + ".flv?get_url=1"
-        jump_url = jump_url.strip('\r\n')
-
-        real_url = get_html(jump_url)
-        real_url = real_url.strip('\r\n')
-        site_info = "www.zhanqi.tv"
-
-        print_info(site_info, title, 'flv', float('inf'))
-        if not info_only:
-            download_url_ffmpeg(real_url, title, 'flv', {}, output_dir = output_dir, merge = merge)
-
+    if not path.startswith('videos'): #url = "https://www.zhanqi.tv/huashan?param_s=1_0.2.0"
+        path_list = path.split('/')
+        room_id = path_list[1] if path_list[0] == 'topic' else path_list[0]
+        zhanqi_live(room_id, merge=merge, output_dir=output_dir, info_only=info_only, **kwargs)
     else: #url = 'https://www.zhanqi.tv/videos/Lyingman/2017/01/182308.html'
-        video_id = url.split('/')[-1].split('?')[0].split('.')[0]
-        assert video_id
-        api_url = "https://www.zhanqi.tv/api/static/v2.1/video/" + video_id + ".json"
-        api_json = json.loads(get_html(api_url))
-        data = api_json['data']
+        video_id = path.split('.')[0].split('/')[-1]
+        zhanqi_video(video_id, merge=merge, output_dir=output_dir, info_only=info_only, **kwargs)
 
-        title = data['title']
+def zhanqi_live(room_id, merge=True, output_dir='.', info_only=False, **kwargs):
+    api_url = "https://www.zhanqi.tv/api/static/v2.1/room/domain/{}.json".format(room_id)
+    json_data = json.loads(get_content(api_url))['data']
+    status = json_data['status']
+    if status != '4':
+        raise Exception("The live stream is not online!")
 
-        video_url_id = data['flashvars']['VideoID']
-        real_url = "http://dlvod.cdn.zhanqi.tv/" + video_url_id
-        site_info = "www.zhanqi.tv/videos"
+    nickname = json_data['nickname']
+    title = nickname + ": " + json_data['title']
+    video_levels = base64.b64decode(json_data['flashvars']['VideoLevels']).decode('utf8')
+    m3u8_url = json.loads(video_levels)['streamUrl']
 
-        print_info(site_info, title, 'flv', float('inf'))
-        if not info_only:
-            download_url_ffmpeg(real_url, title, 'flv', {}, output_dir = output_dir, merge = merge)
+    print_info(site_info, title, 'm3u8', 0, m3u8_url=m3u8_url, m3u8_type='master')
+    if not info_only:
+        download_url_ffmpeg(m3u8_url, title, 'mp4', output_dir=output_dir, merge=merge)
 
+def zhanqi_video(video_id, output_dir='.', info_only=False, merge=True, **kwargs):
+    api_url = 'https://www.zhanqi.tv/api/static/v2.1/video/{}.json'.format(video_id)
+    json_data = json.loads(get_content(api_url))['data']
+
+    title = json_data['title']
+    vid = json_data['flashvars']['VideoID']
+    m3u8_url = 'http://dlvod.cdn.zhanqi.tv/' + vid
+    urls = general_m3u8_extractor(m3u8_url)
+    print_info(site_info, title, 'm3u8', 0)
+    if not info_only:
+        download_urls(urls, title, 'ts', 0, output_dir=output_dir, merge=merge, **kwargs)
+
+site_info = "www.zhanqi.tv"
 download = zhanqi_download
 download_playlist = playlist_not_supported('zhanqi')


### PR DESCRIPTION
```
$ ./you-get -d 'https://www.zhanqi.tv/edmunddzhang'
[DEBUG] get_content: https://www.zhanqi.tv/api/static/v2.1/room/domain/edmunddzhang.json
Site:       www.zhanqi.tv
Title:      EdmundDZhang: 【老E】今晚可能休息？！
Type:       M3U8 Master m3u8
M3U8 Url:   http://dlhls.cdn.zhanqi.tv/zqlive/9469_lNZYA.m3u8

Downloading streaming content with FFmpeg, press q to stop recording...
ffmpeg -y -re -i http://dlhls.cdn.zhanqi.tv/zqlive/9469_lNZYA.m3u8 -c copy -bsf:a aac_adtstoasc EdmundDZhang- 【老E】今晚可能休息？！.mp4
ffmpeg version 3.3.1 Copyright (c) 2000-2017 the FFmpeg developers
  built with Apple LLVM version 8.1.0 (clang-802.0.42)
  configuration: --prefix=/usr/local/Cellar/ffmpeg/3.3.1 --enable-shared --enable-pthreads --enable-gpl --enable-version3 --enable-hardcoded-tables --enable-avresample --cc=clang --host-cflags= --host-ldflags= --enable-libmp3lame --enable-libx264 --enable-libxvid --enable-opencl --disable-lzma --enable-vda
  libavutil      55. 58.100 / 55. 58.100
  libavcodec     57. 89.100 / 57. 89.100
  libavformat    57. 71.100 / 57. 71.100
  libavdevice    57.  6.100 / 57.  6.100
  libavfilter     6. 82.100 /  6. 82.100
  libavresample   3.  5.  0 /  3.  5.  0
  libswscale      4.  6.100 /  4.  6.100
  libswresample   2.  7.100 /  2.  7.100
  libpostproc    54.  5.100 / 54.  5.100
Input #0, hls,applehttp, from 'http://dlhls.cdn.zhanqi.tv/zqlive/9469_lNZYA.m3u8':
  Duration: N/A, start: 3575.057333, bitrate: N/A
  Program 0
    Metadata:
      variant_bitrate : 10240
    Stream #0:0: Video: h264 (High) ([27][0][0][0] / 0x001B), yuv420p(tv, bt709/bt709/iec61966-2-1), 1280x720, 45 tbr, 90k tbn, 2k tbc
    Metadata:
      variant_bitrate : 10240
    Stream #0:1: Audio: aac (LC) ([15][0][0][0] / 0x000F), 48000 Hz, stereo, fltp
    Metadata:
      variant_bitrate : 10240
Output #0, mp4, to 'EdmundDZhang- 【老E】今晚可能休息？！.mp4':
  Metadata:
    encoder         : Lavf57.71.100
    Stream #0:0: Video: h264 (High) ([33][0][0][0] / 0x0021), yuv420p(tv, bt709/bt709/iec61966-2-1), 1280x720, q=2-31, 45 tbr, 90k tbn, 90k tbc
    Metadata:
      variant_bitrate : 10240
    Stream #0:1: Audio: aac (LC) ([64][0][0][0] / 0x0040), 48000 Hz, stereo, fltp
    Metadata:
      variant_bitrate : 10240
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
  Stream #0:1 -> #0:1 (copy)
Press [q] to stop, [?] for help
frame=   19 fps=0.0 q=-1.0 size=     402kB time=00:00:00.53 bitrate=6206.8kbits/s speframe=   31 fps= 24 q=-1.0 size=     461kB time=00:00:00.79 bitrate=4735.2kbits/s speframe=   39 fps= 16 q=-1.0 size=     513kB time=00:00:00.97 bitrate=4309.5kbits/s spe
```

```
$ ./you-get -di 'https://www.zhanqi.tv/videos/zjyx/2017/06/207420.html'
[DEBUG] get_content: https://www.zhanqi.tv/api/static/v2.1/video/207420.json
[DEBUG] get_content: http://dlvod.cdn.zhanqi.tv/BjABYgE6WGsLMV0wBzQFaA1r_2017_06_27_BjMBYgE9WGwLNV02
Site:       www.zhanqi.tv
Title:      【老E】灵魂画师的艺术造纸！
Type:       M3U8 Playlist m3u8
```