### PR TITLE
[youtube]use mp4_audio track when no audio track for webm

### DIFF
--- a/src/you_get/extractors/youtube.py
+++ b/src/you_get/extractors/youtube.py
@@ -366,14 +366,22 @@ class YouTube(VideoExtractor):
                                 dash_url += '&signature={}'.format(sig)
                             dash_size = stream['clen']
                             itag = stream['itag']
+                            audio_url = None
+                            audio_size = None
+                            try:
+                                audio_url = dash_webm_a_url
+                                audio_size = int(dash_webm_a_size)
+                            except UnboundLocalError as e:
+                                audio_url = dash_mp4_a_url
+                                audio_size = int(dash_mp4_a_size)
                             self.dash_streams[itag] = {
                                 'quality': stream['size'],
                                 'itag': itag,
                                 'type': mimeType,
                                 'mime': mimeType,
                                 'container': 'webm',
-                                'src': [dash_url, dash_webm_a_url],
-                                'size': int(dash_size) + int(dash_webm_a_size)
+                                'src': [dash_url, audio_url],
+                                'size': int(dash_size) + int(audio_size)
                             }
 
     def extract(self, **kwargs):


### PR DESCRIPTION
#2167 

the reason for UnboundLocalError for dash_webm_a_url is there could be no audio track with ```audio/webm```

```
video/webm;+codecs="vp9"
video/mp4;+codecs="avc1.640032"
video/webm;+codecs="vp9"
video/mp4;+codecs="avc1.640028"
video/webm;+codecs="vp9"
video/mp4;+codecs="avc1.4d401f"
video/webm;+codecs="vp9"
video/mp4;+codecs="avc1.4d401e"
video/webm;+codecs="vp9"
video/mp4;+codecs="avc1.4d401e"
video/webm;+codecs="vp9"
video/mp4;+codecs="avc1.4d4015"
video/webm;+codecs="vp9"
video/mp4;+codecs="avc1.4d400c"
video/webm;+codecs="vp9"
audio/mp4;+codecs="mp4a.40.2"
```

16 tracks, 15 for videos and only one for audio
I believe the correct way is to fetch the ```audio/mp4``` with the ```video/webm``` track

```
./you-get -id https://www.youtube.com/watch\?v\=VaoAU6PvuTg
[DEBUG] get_content: https://www.youtube.com/get_video_info?video_id=VaoAU6PvuTg
[DEBUG] get_content: https://www.youtube.com/watch?v=VaoAU6PvuTg
[DEBUG] get_content: https://www.youtube.com/yts/jsbin/player-vflMaap-E/ja_JP/base.js
site:                YouTube
title:               青青河边草，最后的绿地之旅
streams:             # Available quality and codecs
    [ DASH ] ____________________________________
    - itag:          313
      container:     webm
      quality:       3840x2160
      size:          1146.6 MiB (1202279479 bytes)
    # download-with: you-get --itag=313 [URL]

    - itag:          264
      container:     mp4
      quality:       2560x1440
      size:          635.0 MiB (665812113 bytes)
    # download-with: you-get --itag=264 [URL]

    - itag:          271
      container:     webm
      quality:       2560x1440
      size:          564.1 MiB (591452544 bytes)
    # download-with: you-get --itag=271 [URL]

    - itag:          137
      container:     mp4
      quality:       1920x1080
      size:          271.5 MiB (284663035 bytes)
    # download-with: you-get --itag=137 [URL]

    - itag:          248
      container:     webm
      quality:       1920x1080
      size:          187.4 MiB (196451593 bytes)
    # download-with: you-get --itag=248 [URL]

    - itag:          136
      container:     mp4
      quality:       1280x720
      size:          149.5 MiB (156711794 bytes)
    # download-with: you-get --itag=136 [URL]

    - itag:          247
      container:     webm
      quality:       1280x720
      size:          108.1 MiB (113315065 bytes)
    # download-with: you-get --itag=247 [URL]

    - itag:          135
      container:     mp4
      quality:       854x480
      size:          77.9 MiB (81704497 bytes)
    # download-with: you-get --itag=135 [URL]

    - itag:          244
      container:     webm
      quality:       854x480
      size:          56.8 MiB (59576815 bytes)
    # download-with: you-get --itag=244 [URL]

    - itag:          134
      container:     mp4
      quality:       640x360
      size:          44.5 MiB (46613229 bytes)
    # download-with: you-get --itag=134 [URL]

    - itag:          243
      container:     webm
      quality:       640x360
      size:          35.2 MiB (36882441 bytes)
    # download-with: you-get --itag=243 [URL]

    - itag:          133
      container:     mp4
      quality:       426x240
      size:          23.0 MiB (24164650 bytes)
    # download-with: you-get --itag=133 [URL]

    - itag:          242
      container:     webm
      quality:       426x240
      size:          22.0 MiB (23057435 bytes)
    # download-with: you-get --itag=242 [URL]

    - itag:          160
      container:     mp4
      quality:       256x144
      size:          14.6 MiB (15348909 bytes)
    # download-with: you-get --itag=160 [URL]

    - itag:          278
      container:     webm
      quality:       256x144
      size:          14.1 MiB (14782440 bytes)
    # download-with: you-get --itag=278 [URL]

    [ DEFAULT ] _________________________________
    - itag:          22
      container:     mp4
      quality:       hd720
      size:          149.4 MiB (156687935 bytes)
    # download-with: you-get --itag=22 [URL]

    - itag:          43
      container:     webm
      quality:       medium
    # download-with: you-get --itag=43 [URL]

    - itag:          18
      container:     mp4
      quality:       medium
    # download-with: you-get --itag=18 [URL]

    - itag:          36
      container:     3gp
      quality:       small
    # download-with: you-get --itag=36 [URL]

    - itag:          17
      container:     3gp
      quality:       small
    # download-with: you-get --itag=17 [URL]
```