### PR TITLE
Fix parsing irregular episode index

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -245,7 +245,7 @@ def fetch_sid(cid, aid):
 
 def collect_bangumi_epids(json_data):
     eps = json_data['result']['episodes']
-    eps = sorted(eps, key=lambda item: float(item['index']))
+    eps = sorted(eps, key=lambda item: float(item['index'].split('-')[0].split('+')[0]))
     result = []
     for ep in eps:
         result.append(ep['episode_id'])


### PR DESCRIPTION
Some episode indices are not purely numbers, causing `ValueError` during converting index from string to float.  For example, some indices are like `1-2` or `20+21` in [http://bangumi.bilibili.com/anime/5707](http://bangumi.bilibili.com/anime/5707).

The following is an error example from the current version.
```
[Movies] $> you-get --debug "http://bangumi.bilibili.com/anime/5707/play#113765"
[DEBUG] url_locations: http://bangumi.bilibili.com/anime/5707/play#113765
[DEBUG] get_content: http://bangumi.bilibili.com/anime/5707/play#113765
[DEBUG] get_content: http://bangumi.bilibili.com/jsonp/seasoninfo/5707.ver?callback=seasonListCallback&jsonp=jsonp&_=1501492179929
you-get: version 0.4.803, a tiny downloader that scrapes the web.
you-get: ['http://bangumi.bilibili.com/anime/5707/play#113765']
Traceback (most recent call last):
  File "/usr/local/bin/you-get", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/usr/local/lib/python3.6/site-packages/you_get/common.py", line 1472, in main
    script_main('you-get', any_download, any_download_playlist, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/you_get/common.py", line 1383, in script_main
    download_main(download, download_playlist, args, playlist, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output, caption=caption)
  File "/usr/local/lib/python3.6/site-packages/you_get/common.py", line 1181, in download_main
    download(url, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/you_get/common.py", line 1465, in any_download
    m.download(url, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/you_get/extractor.py", line 46, in download_by_url
    self.prepare(**kwargs)
  File "/usr/local/lib/python3.6/site-packages/you_get/extractors/bilibili.py", line 127, in prepare
    self.bangumi_entry(**kwargs)
  File "/usr/local/lib/python3.6/site-packages/you_get/extractors/bilibili.py", line 191, in bangumi_entry
    ep_ids = collect_bangumi_epids(bangumi_data)
  File "/usr/local/lib/python3.6/site-packages/you_get/extractors/bilibili.py", line 248, in collect_bangumi_epids
    eps = sorted(eps, key=lambda item: float(item['index']))
  File "/usr/local/lib/python3.6/site-packages/you_get/extractors/bilibili.py", line 248, in <lambda>
    eps = sorted(eps, key=lambda item: float(item['index']))
ValueError: could not convert string to float: '20+21'
```