### PR TITLE
Facebook extrator won't detect title for some videos and you-get brea…

### DIFF
--- a/src/you_get/extractors/facebook.py
+++ b/src/you_get/extractors/facebook.py
@@ -9,6 +9,10 @@ def facebook_download(url, output_dir='.', merge=True, info_only=False, **kwargs
     html = get_html(url)
 
     title = r1(r'<title id="pageTitle">(.+)</title>', html)
+
+    if title is None:
+      title = url
+
     sd_urls = list(set([
         unicodize(str.replace(i, '\\/', '/'))
         for i in re.findall(r'sd_src_no_ratelimit:"([^"]*)"', html)


### PR DESCRIPTION
Some Facebook videos won't download because the get_html() couldn't get the title, example with the `develop` branch:

```
~/temp/you-get % ./you-get https://www.facebook.com/1493888437544322/videos/1942648829334945/ --debug                                                        (git)-[develop] 
[DEBUG] get_response: https://www.facebook.com/1493888437544322/videos/1942648829334945/
[DEBUG] url_info: https://video.fbfh3-1.fna.fbcdn.net/v/t43.1792-2/20957748_112863729412175_7749554219685773312_n.mp4?efg=eyJ2ZW5jb2RlX3RhZyI6InN2ZV9oZCJ9&oh=81fd0a348aa6f8164ff944a5934b5504&oe=59A0C863
Site:       Facebook.com
you-get: version 0.4.803, a tiny downloader that scrapes the web.
you-get: ['https://www.facebook.com/1493888437544322/videos/1942648829334945/']
Traceback (most recent call last):
  File "./you-get", line 11, in <module>
    you_get.main(repo_path=_filepath)
  File "/Users/rs/temp/you-get/src/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/Users/rs/temp/you-get/src/you_get/common.py", line 1361, in main
    script_main('you-get', any_download, any_download_playlist, **kwargs)
  File "/Users/rs/temp/you-get/src/you_get/common.py", line 1268, in script_main
    download_main(download, download_playlist, args, playlist, output_dir=output_dir, merge=merge, info_only=info_only, json_output=json_output, caption=caption)
  File "/Users/rs/temp/you-get/src/you_get/common.py", line 1066, in download_main
    download(url, **kwargs)
  File "/Users/rs/temp/you-get/src/you_get/common.py", line 1354, in any_download
    m.download(url, **kwargs)
  File "/Users/rs/temp/you-get/src/you_get/extractors/facebook.py", line 25, in facebook_download
    print_info(site_info, title, type, size)
  File "/Users/rs/temp/you-get/src/you_get/common.py", line 985, in print_info
    maybe_print("Title:     ", unescape_html(tr(title)))
  File "/usr/local/Cellar/python3/3.6.1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/html/__init__.py", line 130, in unescape
    if '&' not in s:
TypeError: argument of type 'NoneType' is not iterable
```
`unescape()` receives a `None` type and breaks.

I don't know what is the "right way" to fix this. But I could get it working changing the Facebook extractor. Example:

```
~/temp/you-get % ./you-get https://www.facebook.com/1493888437544322/videos/1942648829334945/ --debug                                   (git)-[facebook-extractor-when-no-title] 
[DEBUG] get_response: https://www.facebook.com/1493888437544322/videos/1942648829334945/
[DEBUG] url_info: https://video.fbfh3-1.fna.fbcdn.net/v/t43.1792-2/20957748_112863729412175_7749554219685773312_n.mp4?efg=eyJ2ZW5jb2RlX3RhZyI6InN2ZV9oZCJ9&oh=81fd0a348aa6f8164ff944a5934b5504&oe=59A0C863
Site:       Facebook.com
Title:      https://www.facebook.com/1493888437544322/videos/1942648829334945/
Type:       MPEG-4 video (video/mp4)
Size:       11.98 MiB (12565730 Bytes)

Downloading https---www.facebook.com-1493888437544322-videos-1942648829334945-.mp4 ...
 100% ( 12.0/ 12.0MB) ├███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████┤[1/1]    7 MB/s
```

The fix is a simple `if is None` in the Facebook extractor. Hope it's ok to do this way.

And thanks for this great software. 👍 