### PR TITLE
new extractor: giphy.com

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -25,6 +25,7 @@ SITES = {
     'freesound'        : 'freesound',
     'fun'              : 'funshion',
     'google'           : 'google',
+    'giphy'            : 'giphy',
     'heavy-music'      : 'heavymusic',
     'huaban'           : 'huaban',
     'huomao'           : 'huomaotv',

--- a/src/you_get/extractors/giphy.py
+++ b/src/you_get/extractors/giphy.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+__all__ = ['giphy_download']
+
+from ..common import *
+import json
+
+def giphy_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
+    html = get_html(url)
+
+    url = list(set([
+        unicodize(str.replace(i, '\\/', '/'))
+        for i in re.findall(r'<meta property="og:video:secure_url" content="(.*?)">', html)
+    ]))
+
+    title = r1(r'<meta property="og:title" content="(.*?)">', html)
+
+    if title is None:
+      title = url[0]
+
+    type, ext, size = url_info(url[0], True)
+    size = urls_size(url)
+
+    type = "video/mp4"
+    ext = "mp4"
+
+    print_info(site_info, title, type, size)
+    if not info_only:
+        download_urls(url, title, ext, size, output_dir, merge=False)
+
+site_info = "Giphy.com"
+download = giphy_download
+download_playlist = playlist_not_supported('giphy')


### PR DESCRIPTION
### Giphy extractor

[Giphy.com](https://giphy.com) converts gifs into some formats, `mp4` is one of them.

`you-get https://giphy.com/gifs/MTVU-relax-chill-26n6UOQke3xCpsbWo`

Will download: [https://media.giphy.com/media/26n6UOQke3xCpsbWo/giphy.mp4](https://media.giphy.com/media/26n6UOQke3xCpsbWo/giphy.mp4)

I hope it's all ok for merge. Let me know if it needs changes. :)