### PR TITLE
改进B站获取title的逻辑

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -123,13 +123,17 @@ class Bilibili(VideoExtractor):
                 self.url = 'http://www.bilibili.com/video/av{}/index_{}.html'.format(aid, page)
         self.referer = self.url
         self.page = get_content(self.url)
-        try:
-            self.title = re.search(r'<h1\s*title="([^"]+)"', self.page).group(1)
-            if 'subtitle' in kwargs:
-                subtitle = kwargs['subtitle']
-                self.title = '{} {}'.format(self.title, subtitle)
-        except Exception:
-            pass
+
+        m = re.search(r'<h1\s*title="([^"]+)"', self.page)
+        if m is not None:
+            self.title = m.group(1)
+        if self.title is None:
+            m = re.search(r'<meta property="og:title" content="([^"]+)">', self.page)
+            if m is not None:
+                self.title = m.group(1)
+        if 'subtitle' in kwargs:
+            subtitle = kwargs['subtitle']
+            self.title = '{} {}'.format(self.title, subtitle)
 
         if 'bangumi.bilibili.com/movie' in self.url:
             self.movie_entry(**kwargs)


### PR DESCRIPTION
现在这个逻辑，在结合`-l`获取某个list的时候，list的title会变成None，因为已有的正则匹配失败了。

翻了下B站的前端，新增了一个meta标签，里面有视频列表的title，因此在原有正则获取不到title的情况下，再从meta标签尝试获取一次