### PR TITLE
fix urlopen_with_retry may return None

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -342,14 +342,19 @@ def get_location(url):
     return response.geturl()
 
 def urlopen_with_retry(*args, **kwargs):
-    for i in range(2):
+    retry_time = 3
+    for i in range(retry_time):
         try:
             return request.urlopen(*args, **kwargs)
-        except socket.timeout:
+        except socket.timeout as e:
             logging.debug('request attempt %s timeout' % str(i + 1))
+            if i + 1 == retry_time:
+                raise e
 # try to tackle youku CDN fails
         except error.HTTPError as http_error:
             logging.debug('HTTP Error with code{}'.format(http_error.code))
+            if i + 1 == retry_time:
+                raise http_error
 
 def get_content(url, headers={}, decoded=True):
     """Gets the content of a URL via sending a HTTP GET request.


### PR DESCRIPTION
当三次重试都失败时，该函数实际会返回None，而不是抛出最后一个异常，导致流程异常进行下去，最终造成NoneType系列的异常，而不是真实的网络异常