### PR TITLE
support bilibili watchlater url

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -104,6 +104,12 @@ class Bilibili(VideoExtractor):
                 self.parse_bili_xml(api_xml)
 
     def prepare(self, **kwargs):
+        m = re.match(r"http(?:s)?://www.bilibili.com/watchlater/#/av(\d+)(?:/p(\d+))?", self.url, re.I)
+        if m is not None:
+            self.url = 'http://www.bilibili.com/video/av{}'.format(m.group(1))
+            if m.group(2) is not None:
+                self.url += "/index_{}.html".format(m.group(2))
+
         if socket.getdefaulttimeout() == 600: # no timeout specified
             socket.setdefaulttimeout(2) # fail fast, very speedy!
 


### PR DESCRIPTION
B站的“稍候再看”里提供的url不是B站标准的url，使用you-get来下载时还需要人肉转换一下比较别扭，这里用个正则在you-get里尝试做一下自动转换