### PR TITLE
fix bar display under windows terminal

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -643,7 +643,7 @@ class SimpleProgressBar:
         # 38 is the size of all statically known size in self.bar
         total_str = '%5s' % round(self.total_size / 1048576, 1)
         total_str_width = max(len(total_str), 5)
-        self.bar_size = self.term_size - 27 - 2*total_pieces_len - 2*total_str_width
+        self.bar_size = self.term_size - 28 - 2*total_pieces_len - 2*total_str_width
         self.bar = '{:>4}%% ({:>%s}/%sMB) ├{:─<%s}┤[{:>%s}/{:>%s}] {}' % (
             total_str_width, total_str, self.bar_size, total_pieces_len, total_pieces_len)
 


### PR DESCRIPTION
现在的进度条显示，在windows下会因为多算了一个字符的宽度，导致\r不生效，仍然出现换行显示的行为，多减去一个字符即可修复

![image](https://user-images.githubusercontent.com/406779/31750190-06102ac0-b4b1-11e7-8a24-1a6e3e25f1e4.png)
