### PR TITLE
Fix miaopai download failed

### DIFF
--- a/src/you_get/extractors/yixia.py
+++ b/src/you_get/extractors/yixia.py
@@ -51,14 +51,14 @@ def yixia_download(url, output_dir = '.', merge = True, info_only = False, **kwa
         yixia_download_by_scid = yixia_miaopai_download_by_scid
         site_info = "Yixia Miaopai"
         
-        if re.match(r'http://www.miaopai.com/show/channel/.+', url):  #PC
-            scid = match1(url, r'http://www.miaopai.com/show/channel/(.+)\.htm')
-        elif re.match(r'http://www.miaopai.com/show/.+', url):  #PC
-            scid = match1(url, r'http://www.miaopai.com/show/(.+)\.htm')
-        elif re.match(r'http://m.miaopai.com/show/channel/.+', url):  #Mobile
-            scid = match1(url, r'http://m.miaopai.com/show/channel/(.+)\.htm')
+        if re.match(r'https?://www.miaopai.com/show/channel/.+', url):  #PC
+            scid = match1(url, r'https?://www.miaopai.com/show/channel/(.+)\.htm')
+        elif re.match(r'https?://www.miaopai.com/show/.+', url):  #PC
+            scid = match1(url, r'https?://www.miaopai.com/show/(.+)\.htm')
+        elif re.match(r'https?://m.miaopai.com/show/channel/.+', url):  #Mobile
+            scid = match1(url, r'https?://m.miaopai.com/show/channel/(.+)\.htm')
             if scid == None :
-                scid = match1(url, r'http://m.miaopai.com/show/channel/(.+)')
+                scid = match1(url, r'https?://m.miaopai.com/show/channel/(.+)')
 
     elif 'xiaokaxiu.com' in hostname:  #Xiaokaxiu
         yixia_download_by_scid = yixia_xiaokaxiu_download_by_scid


### PR DESCRIPTION
Miaopai is using https now. Fix url pattern when download miaopai videos

```
./you-get -di "https://www.miaopai.com/show/i8xTI~lQ~M1z0oXazPj0Zi0cLvoov~HBYf1A~Q__.htm"
you-get: version 0.4.939, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.miaopai.com/show/i8xTI~lQ~M1z0oXazPj0Zi0cLvoov~HBYf1A~Q__.htm'], cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=True, input_file=None, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "./you-get", line 11, in <module>
    you_get.main(repo_path=_filepath)
  File "/home/mi/wjw/you-get/src/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/home/mi/wjw/you-get/src/you_get/common.py", line 1368, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/home/mi/wjw/you-get/src/you_get/common.py", line 1276, in script_main
    **extra
  File "/home/mi/wjw/you-get/src/you_get/common.py", line 1078, in download_main
    download(url, **kwargs)
  File "/home/mi/wjw/you-get/src/you_get/common.py", line 1361, in any_download
    m.download(url, **kwargs)
  File "/home/mi/wjw/you-get/src/you_get/extractors/yixia.py", line 75, in yixia_download
    yixia_download_by_scid(scid, output_dir, merge, info_only)
UnboundLocalError: local variable 'scid' referenced before assignment
```


