### PR TITLE
Update the regex for mgtv extractor, adapt to https

### DIFF
--- a/src/you_get/extractors/mgtv.py
+++ b/src/you_get/extractors/mgtv.py
@@ -27,9 +27,9 @@ class MGTV(VideoExtractor):
     def get_vid_from_url(url):
         """Extracts video ID from URL.
         """
-        vid = match1(url, 'http://www.mgtv.com/(?:b|l)/\d+/(\d+).html')
+        vid = match1(url, 'https?://www.mgtv.com/(?:b|l)/\d+/(\d+).html')
         if not vid:
-            vid = match1(url, 'http://www.mgtv.com/hz/bdpz/\d+/(\d+).html')
+            vid = match1(url, 'https?://www.mgtv.com/hz/bdpz/\d+/(\d+).html')
         return vid
     
     #----------------------------------------------------------------------


### PR DESCRIPTION
Mgtv extractor failed with `https` link, this pull request has fix the problem. Now it works on my mac both `http` and `https` links.