### PR TITLE
[bilibili] fix title regex

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -125,7 +125,7 @@ class Bilibili(VideoExtractor):
         self.referer = self.url
         self.page = get_content(self.url)
 
-        m = re.search(r'<h1\s*title="([^"]+)"', self.page)
+        m = re.search(r'<h1.*?>(.*?)</h1>', self.page)
         if m is not None:
             self.title = m.group(1)
         if self.title is None:

--- a/tests/test.py
+++ b/tests/test.py
@@ -2,25 +2,50 @@
 
 import unittest
 
-from you_get.extractors import *
+from you_get.extractors import (
+    imgur,
+    magisto,
+    youtube,
+    yixia,
+    bilibili,
+)
 
 
 class YouGetTests(unittest.TestCase):
     def test_imgur(self):
-        imgur.download("http://imgur.com/WVLk5nD", info_only=True)
-        imgur.download("http://imgur.com/gallery/WVLk5nD", info_only=True)
+        imgur.download('http://imgur.com/WVLk5nD', info_only=True)
+        imgur.download('http://imgur.com/gallery/WVLk5nD', info_only=True)
 
     def test_magisto(self):
-        magisto.download("http://www.magisto.com/album/video/f3x9AAQORAkfDnIFDA", info_only=True)
+        magisto.download(
+            'http://www.magisto.com/album/video/f3x9AAQORAkfDnIFDA',
+            info_only=True
+        )
 
     def test_youtube(self):
-        youtube.download("http://www.youtube.com/watch?v=pzKerr0JIPA", info_only=True)
-        youtube.download("http://youtu.be/pzKerr0JIPA", info_only=True)
-        youtube.download("http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare",
-                         info_only=True)
+        youtube.download(
+            'http://www.youtube.com/watch?v=pzKerr0JIPA', info_only=True
+        )
+        youtube.download('http://youtu.be/pzKerr0JIPA', info_only=True)
+        youtube.download(
+            'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
+            info_only=True
+        )
 
     def test_yixia(self):
-        yixia_download("http://m.miaopai.com/show/channel/vlvreCo4OZiNdk5Jn1WvdopmAvdIJwi8", info_only=True)
+        yixia.download(
+            'http://m.miaopai.com/show/channel/vlvreCo4OZiNdk5Jn1WvdopmAvdIJwi8',  # noqa
+            info_only=True
+        )
+
+    def test_bilibili(self):
+        bilibili.download(
+            'https://www.bilibili.com/video/av16907446/', info_only=True
+        )
+        bilibili.download(
+            'https://www.bilibili.com/video/av13228063/', info_only=True
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
bilibili got a weird page([https://www.bilibili.com/video/av16907446/](https://www.bilibili.com/video/av16907446/)), there is no `=` between the `title` property and it's value.
![1512636559107](https://user-images.githubusercontent.com/9134003/33706293-9e288e36-db6e-11e7-8ba7-c0a713b4d75b.jpg)
So I changed the regular expression, now it directly matches the contents of the `h1`.

I also updated the unit test.