### PR TITLE
[douyin] add support

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ Use `--url`/`-u` to get a list of downloadable resource URLs extracted from the 
 | 全民直播 | <http://www.quanmin.tv/>       |✓| | |
 | 阳光宽频网 | <http://www.365yg.com/>      |✓| | |
 | 西瓜视频 | <https://www.ixigua.com/>      |✓| | |
+| 抖音 | <https://www.douyin.com/>      |✓| | |
 
 For all other sites not on the list, the universal extractor will take care of finding and downloading interesting resources from the page.
 

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -38,6 +38,7 @@ SITES = {
     'dailymotion'      : 'dailymotion',
     'dilidili'         : 'dilidili',
     'douban'           : 'douban',
+    'douyin'           : 'douyin',
     'douyu'            : 'douyutv',
     'ehow'             : 'ehow',
     'facebook'         : 'facebook',

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -15,6 +15,7 @@ from .coub import *
 from .dailymotion import *
 from .dilidili import *
 from .douban import *
+from .douyin import *
 from .douyutv import *
 from .ehow import *
 from .facebook import *

--- a/src/you_get/extractors/douyin.py
+++ b/src/you_get/extractors/douyin.py
@@ -1,0 +1,38 @@
+# coding=utf-8
+
+import re
+import json
+
+from ..common import (
+    url_size,
+    print_info,
+    get_content,
+    download_urls,
+    playlist_not_supported,
+)
+
+
+__all__ = ['douyin_download_by_url']
+
+
+def douyin_download_by_url(url, **kwargs):
+    page_content = get_content(url)
+    match_rule = re.compile(r'var data = \[(.*?)\];')
+    video_info = json.loads(match_rule.findall(page_content)[0])
+    video_url = video_info['video']['play_addr']['url_list'][0]
+    title = video_info['cha_list'][0]['cha_name']
+    video_format = 'mp4'
+    size = url_size(video_url)
+    print_info(
+        site_info='douyin.com', title=title,
+        type=video_format, size=size
+    )
+    if not kwargs['info_only']:
+        download_urls(
+            urls=[video_url], title=title, ext=video_format, total_size=size,
+            **kwargs
+        )
+
+
+download = douyin_download_by_url
+download_playlist = playlist_not_supported('douyin')

--- a/tests/test.py
+++ b/tests/test.py
@@ -8,6 +8,7 @@ from you_get.extractors import (
     youtube,
     yixia,
     bilibili,
+    douyin,
 )
 
 
@@ -44,6 +45,12 @@ class YouGetTests(unittest.TestCase):
         )
         bilibili.download(
             'https://www.bilibili.com/video/av13228063/', info_only=True
+        )
+
+    def test_douyin(self):
+        douyin.download(
+            'https://www.douyin.com/share/video/6492273288897629454',
+            info_only=True
         )
 
 


### PR DESCRIPTION
Add support for [抖音](https://www.douyin.com/)

```console
$ you-get https://www.douyin.com/share/video/6492273288897629454

It seems that your ffmpeg is a nightly build.
Please switch to the latest stable if merging failed.
Site:       douyin.com
Title:      请欣赏关了美颜的我🙂
Type:       MPEG-4 video (video/mp4)
Size:       3.14 MiB (3294451 Bytes)

Downloading 请欣赏关了美颜的我🙂.mp4 ...
 100% (  3.1/  3.1MB) ├████████████████████████████████████████┤[1/1]    3 MB/s
```