### PR TITLE
[miaopai]fix incorrect regex for url with parameter

### DIFF
--- a/src/you_get/extractors/netease.py
+++ b/src/you_get/extractors/netease.py
@@ -131,6 +131,20 @@ def netease_download(url, output_dir = '.', merge = True, info_only = False, **k
         url = get_location(url)
     if "music.163.com" in url:
         netease_cloud_music_download(url, output_dir, merge, info_only, **kwargs)
+    elif "v.ent.163.com/video" in url:
+        # Parse and download video pages like:
+        # http://v.ent.163.com/video/2017/12/9/V/VD5BG8P9V.html
+        html = get_decoded_html(url)
+
+        title = r1(r'<h1[^>]*?><span[^>]*?>([^<]*?)</span></h1>', html)
+        title = title.strip() if title else ''
+        video_url = r1(r'"url_mp4": "([^"]*?)"', html)
+        if video_url:
+            _, ext, size = url_info(video_url)
+            print_info(site_info, title, ext, size)
+
+            if not info_only:
+                download_urls([video_url], title, ext, size, output_dir=output_dir, merge=merge)
     else:
         html = get_decoded_html(url)
 

--- a/src/you_get/extractors/yixia.py
+++ b/src/you_get/extractors/yixia.py
@@ -58,7 +58,7 @@ def yixia_download(url, output_dir = '.', merge = True, info_only = False, **kwa
         elif re.match(r'https?://m.miaopai.com/show/channel/.+', url):  #Mobile
             scid = match1(url, r'https?://m.miaopai.com/show/channel/(.+)\.htm')
             if scid == None :
-                scid = match1(url, r'https?://m.miaopai.com/show/channel/(.+)')
+                scid = match1(url, r'https?://m.miaopai.com/show/channel/([^\?]+)')
 
     elif 'xiaokaxiu.com' in hostname:  #Xiaokaxiu
         yixia_download_by_scid = yixia_xiaokaxiu_download_by_scid

--- a/tests/test.py
+++ b/tests/test.py
@@ -40,6 +40,11 @@ class YouGetTests(unittest.TestCase):
             info_only=True
         )
 
+        yixia.download(
+            'http://m.miaopai.com/show/channel/RjJnaplo7c~T~1BhGrzVWUVKg3dK4A8wCy~ucg__?from=groupmessage&isappinstalled=0',  # noqa
+            info_only=True
+        )
+
     def test_bilibili(self):
         bilibili.download(
             'https://www.bilibili.com/video/av16907446/', info_only=True
@@ -53,6 +58,7 @@ class YouGetTests(unittest.TestCase):
             'http://v.ent.163.com/video/2017/12/9/V/VD5BG8P9V.html',
             info_only=True
         )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -9,6 +9,7 @@ from you_get.extractors import (
     yixia,
     bilibili,
     douyin,
+    netease,
 )
 
 
@@ -50,6 +51,12 @@ class YouGetTests(unittest.TestCase):
     def test_douyin(self):
         douyin.download(
             'https://www.douyin.com/share/video/6492273288897629454',
+            info_only=True
+        )
+
+    def test_netease(self):
+        netease.download(
+            'http://v.ent.163.com/video/2017/12/9/V/VD5BG8P9V.html',
             info_only=True
         )
 


### PR DESCRIPTION
If miaopai webpage's url contains parameter, downloading will fail, i.e.
    http://m.miaopai.com/show/channel/RjJnaplo7c~T~1BhGrzVWUVKg3dK4A8wCy~ucg__?from=groupmessage&isappinstalled=0

Cause:
    Regex incorrectly process such url:
        scid = match1(url, r'https?://m.miaopai.com/show/channel/(.+)')
    It should be:
        scid = match1(url, r'https?://m.miaopai.com/show/channel/([^\?]+)')
