### PR TITLE
Fixed title issues with some bilibili videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ _*
 /.idea
 *.m4a
 *.DS_Store
+.vscode

--- a/src/you_get/extractor.py
+++ b/src/you_get/extractor.py
@@ -4,7 +4,9 @@ from .common import match1, maybe_print, download_urls, get_filename, parse_host
 from .common import print_more_compatible as print
 from .util import log
 from . import json_output
+from subprocess import DEVNULL
 import os
+import subprocess
 
 class Extractor():
     def __init__(self, *args):
@@ -242,6 +244,8 @@ class VideoExtractor():
                 print('Downloading {} ...\n'.format(filename))
                 with open(os.path.join(kwargs['output_dir'], filename), 'w', encoding='utf8') as fp:
                     fp.write(self.danmuku)
+                output = get_filename(self.title)
+                subprocess.check_call(['danmaku2ass', '-o', output + '.ass', '-s', '1920x1080', '-fn', 'MS PGothic', '-fs', '48', '-a', '0.8', '-dm', '15', '-ds', '10', output + '.cmt.xml'], stdin=DEVNULL);
 
             # For main_dev()
             #download_urls(urls, self.title, self.streams[stream_id]['container'], self.streams[stream_id]['size'])

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -125,7 +125,7 @@ class Bilibili(VideoExtractor):
         self.referer = self.url
         self.page = get_content(self.url)
 
-        m = re.search(r'<h1.*?>(.*?)</h1>', self.page)
+        m = re.search(r'<h1.*?>(?:<!-+>)?[\n ]*(.*?)[\n ]*</h1>', self.page, flags=re.DOTALL)
         if m is not None:
             self.title = m.group(1)
         if self.title is None:
@@ -135,7 +135,7 @@ class Bilibili(VideoExtractor):
         if 'subtitle' in kwargs:
             subtitle = kwargs['subtitle']
             self.title = '{} {}'.format(self.title, subtitle)
-
+            
         if 'bangumi.bilibili.com/movie' in self.url:
             self.movie_entry(**kwargs)
         elif 'bangumi.bilibili.com' in self.url:


### PR DESCRIPTION
The origin regex expression cannot recognize video title properly when the tags and text are in different lines. Like this:
```
<h1><!---->
Long title blahblah
</h1>
```
This small fix can solve the problem.