### PR TITLE
Parameter type error

### DIFF
--- a/src/you_get/extractors/douyutv.py
+++ b/src/you_get/extractors/douyutv.py
@@ -73,7 +73,7 @@ def douyutv_download(url, output_dir = '.', merge = True, info_only = False, **k
 
     print_info(site_info, title, 'flv', float('inf'))
     if not info_only:
-        download_url_ffmpeg(real_url, title, 'flv', None, output_dir = output_dir, merge = merge)
+        download_url_ffmpeg(real_url, title, 'flv', params={}, output_dir = output_dir, merge = merge)
 
 site_info = "douyu.com"
 download = douyutv_download


### PR DESCRIPTION
#you-get -du https://www.douyu.com/lpl
[DEBUG] get_content: https://m.douyu.com/lpl
...
Traceback (most recent call last):
...
 File "/usr/local/lib/python3.5/dist-packages/you_get/common.py", line 1574, in any_download
    m.download(url, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/you_get/extractors/douyutv.py", line 81, in douyutv_download
    download_url_ffmpeg(real_url, title, 'flv', None, output_dir = output_dir, merge = merge)
  File "/usr/local/lib/python3.5/dist-packages/you_get/common.py", line 1013, in download_url_ffmpeg
    if params.get('-y', False):  # None or unset ->False
AttributeError: 'NoneType' object has no attribute 'get'