### PR TITLE
youku下载残缺

### DIFF
--- a/src/you_get/extractors/douyutv.py
+++ b/src/you_get/extractors/douyutv.py
@@ -73,7 +73,7 @@ def douyutv_download(url, output_dir = '.', merge = True, info_only = False, **k
 
     print_info(site_info, title, 'flv', float('inf'))
     if not info_only:
-        download_url_ffmpeg(real_url, title, 'flv', None, output_dir = output_dir, merge = merge)
+        download_url_ffmpeg(real_url, title, 'flv', params={}, output_dir = output_dir, merge = merge)
 
 site_info = "douyu.com"
 download = douyutv_download

--- a/src/you_get/extractors/quanmin.py
+++ b/src/you_get/extractors/quanmin.py
@@ -4,7 +4,6 @@ __all__ = ['quanmin_download']
 
 from ..common import *
 import json
-import time
 
 def quanmin_download(url, output_dir = '.', merge = True, info_only = False, **kwargs):
     roomid = url.split('/')[3].split('?')[0]
@@ -17,7 +16,8 @@ def quanmin_download(url, output_dir = '.', merge = True, info_only = False, **k
 
     if not data["play_status"]:
         raise ValueError("The live stream is not online!")
-    real_url = "http://flv.quanmin.tv/live/{}.flv".format(roomid)
+        
+    real_url = data["live"]["ws"]["flv"]["5"]["src"]
 
     print_info(site_info, title, 'flv', float('inf'))
     if not info_only:


### PR DESCRIPTION
你好
我使用you-get在我的raspberry pi上下载youku的视频，但往往进度条只走了三分之一就开始 尝试合并，导致最后的视频是残缺的，我是从GitHub上clone下来的，这个问题同样发生在我的DebianX64上。
#!/usr/bin/env python

import unittest

from you_get.extractors import (
    imgur,
    magisto,
    youtube,
    bilibili,
)


class YouGetTests(unittest.TestCase):
    def test_imgur(self):
        imgur.download('http://imgur.com/WVLk5nD', info_only=True)
        imgur.download('http://imgur.com/gallery/WVLk5nD', info_only=True)

    def test_magisto(self):
        magisto.download(
            'http://www.magisto.com/album/video/f3x9AAQORAkfDnIFDA',
            info_only=True
        )

    def test_youtube(self):
        youtube.download(
            'http://www.youtube.com/watch?v=pzKerr0JIPA', info_only=True
        )
        youtube.download('http://youtu.be/pzKerr0JIPA', info_only=True)
        youtube.download(
            'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
            info_only=True
        )

    def test_bilibili(self):
        bilibili.download(
            'https://www.bilibili.com/video/av16907446/', info_only=True
        )
        bilibili.download(
            'https://www.bilibili.com/video/av13228063/', info_only=True
        )


if __name__ == '__main__':
    unittest.main()