### PR TITLE
Added an auto rename option and fixed the force option

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -622,10 +622,13 @@ def url_save(
                         bar.done()
                     if not force and auto_rename:
                         path, ext = os.path.basename(filepath).rsplit('.', 1)
-                        if (re.compile(' \(\d\)').match(path[-4:]) is None):
+                        finder = re.compile(' \([1-9]\d*?\)$')
+                        if (finder.search(path) is None):
                             thisfile = path + ' (1).' + ext
                         else:
-                            thisfile = path[:-2] + str(int(path[-2]) + 1) + ').' + ext 
+                            def numreturn(a):
+                                return ' (' + str(int(a.group()[2:-1]) + 1) + ').'
+                            thisfile = finder.sub(numreturn, path) + ext
                         filepath = os.path.join(os.path.dirname(filepath), thisfile)
                         print('Changing name to %s' % tr(os.path.basename(filepath)), '...')
                         continue_renameing = True


### PR DESCRIPTION
- [x] Add -a to your you-get code to auto-rename your file.
- [x] Fixed -f (force)

I've noticed that if I download two videos with same names from youtube (e.g. https://www.youtube.com/watch?v=606hmlA_nxw and https://www.youtube.com/watch?v=CLrXTnggUeY), 
only one of them will be saved (usually the bigger one according to the original script `os.path.getsize(output_filepath) >= total_size * 0.9`). However, I want them both while preserving their names from youtube. It looks like there are a lot of changes, but I just added an indent and everything changed.
Also, I've noticed that "force" is not working at all. I fixed that issue.

I'm quite new to coding... Any feedback is appreciated!

not working -f (old version):
![not working force (old version)](https://user-images.githubusercontent.com/35967907/36509822-c0ff91a6-1715-11e8-8e5e-9146ee7af8db.PNG)

fixed -f : (-a does not matter here)
![fixed force](https://user-images.githubusercontent.com/35967907/36509849-d5ab743a-1715-11e8-811c-121936ee2ede.PNG)

without this new option:
![without this new option](https://user-images.githubusercontent.com/35967907/36509887-f1c8bda8-1715-11e8-9949-b2d70b63eaee.PNG)

with this new option:
![with this new option](https://user-images.githubusercontent.com/35967907/36509928-1edbd438-1716-11e8-85c2-7c16512325d7.PNG)