### PR TITLE
[FIX] Fix bilibili download

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -123,7 +123,7 @@ class Bilibili(VideoExtractor):
                 aid = re.search(r'av(\d+)', self.url).group(1)
                 self.url = 'http://www.bilibili.com/video/av{}/index_{}.html'.format(aid, page)
         self.referer = self.url
-        self.page = get_content(self.url)
+        self.page = get_content(self.url, headers={'referer': self.url, 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.84 Safari/537.36'})
 
         m = re.search(r'<h1.*?>(.*?)</h1>', self.page) or re.search(r'<h1 title="([^"]+)">', self.page)
         if m is not None:

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -99,7 +99,10 @@ class Bilibili(VideoExtractor):
         info_only = kwargs.get('info_only')
         for qlt in range(4, -1, -1):
             api_xml = self.api_req(cid, qlt, bangumi, **kwargs)
-            self.parse_bili_xml(api_xml)
+            try:
+                self.parse_bili_xml(api_xml)
+            except IndexError as e:
+                pass # url = urls[0]: list index out of range; try next
         if not info_only or stream_id:
             self.danmuku = get_danmuku_xml(cid)
 


### PR DESCRIPTION
The two patches are both related to Bilibili download, so I didn't split them.

The first patch adds the missing User-Agent in request header, to prevent the remote side from returning nothing due to the empty User-Agent.

The second patch handles index out of range failure and continue to try other qualities, instead of abortting.