### PR TITLE
fix bilibili download fail

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -23,7 +23,7 @@ from .youku import youku_download_by_vid
 class Bilibili(VideoExtractor):
     name = 'Bilibili'
     live_api = 'http://live.bilibili.com/api/playurl?cid={}&otype=json'
-    api_url = 'http://interface.bilibili.com/playurl?'
+    api_url = 'http://interface.bilibili.com/v2/playurl?'
     bangumi_api_url = 'http://bangumi.bilibili.com/player/web_api/playurl?'
     live_room_init_api_url = 'https://api.live.bilibili.com/room/v1/Room/room_init?id={}'
     live_room_info_api_url = 'https://api.live.bilibili.com/room/v1/Room/get_info?room_id={}'


### PR DESCRIPTION
the interface  of bilibili interface has changed 

https://www.bilibili.com/video/av20349144/
"https://interface.bilibili.com/v2/playurl?cid=33250486&appkey=84956560bc028eb7&otype=json&type=&quality=0&qn=0&sign=a1b0401c8bf70d676bab133fa032469f"
