### PR TITLE
fix som youku mp4 real flv,twitter mp4 real ts

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -972,9 +972,17 @@ def download_urls(
                     from .processor.ffmpeg import ffmpeg_concat_mp4_to_mp4
                     ffmpeg_concat_mp4_to_mp4(parts, output_filepath)
                 else:
-                    from .processor.join_mp4 import concat_mp4
-                    concat_mp4(parts, output_filepath)
-                print('Merged into %s' % output_filename)
+                    print('Merged into %s' % output_filename)
+                    try:
+                        from .processor.join_mp4 import concat_mp4
+                        concat_mp4(parts, output_filepath)
+                    except:
+                    	try:
+                    		from .processor.join_flv import concat_flv
+                    		concat_flv(parts, output_filepath)
+                    	except:
+                    		from .processor.join_ts import concat_ts
+                    		concat_ts(parts, output_filepath)
             except:
                 raise
             else:


### PR DESCRIPTION
没有装ffmpeg。在合并优酷的电视剧会出错，后缀名是mp4，发现其实是flv。所以使用了try except。在合并twitter视频的时候，后缀名是mp4，发现要使用ts合并