### PR TITLE
HTTP Error 477 when downloading from PPTV

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -7,6 +7,7 @@ from you_get.extractors import (
     magisto,
     youtube,
     bilibili,
+    pptv,
 )
 
 
@@ -39,6 +40,8 @@ class YouGetTests(unittest.TestCase):
             'https://www.bilibili.com/video/av13228063/', info_only=True
         )
 
+    def test_pptv(self):
+        pptv.download('http://v.pptv.com/show/2wkRjlOgS4nsatI.html', info_only=True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
HTTP Error 477 when downloading PPTV videos. Adding PPTV into test.py.
```
> you-get --debug http://v.pptv.com/show/2wkRjlOgS4nsatI.html
[DEBUG] get_content: http://v.pptv.com/show/2wkRjlOgS4nsatI.html
[DEBUG] HTTP Error with code477
[DEBUG] HTTP Error with code477
[DEBUG] HTTP Error with code477
you-get: version 0.4.1040, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['http://v.pptv.com/show/2wkRjlOgS4nsatI.html'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "...\appdata\local\programs\python\python36\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "...\appdata\local\programs\python\python36\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "...\AppData\Local\Programs\Python\Python36\Scripts\you-get.exe\__main__.py", line 9, in <module>
  File "...\appdata\local\programs\python\python36\lib\site-packages\you_get\__main__.py", line 92, in main
    main(**kwargs)
  File "...\appdata\local\programs\python\python36\lib\site-packages\you_get\common.py", line 1617, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "...\appdata\local\programs\python\python36\lib\site-packages\you_get\common.py", line 1506, in script_main
    **extra
  File "...\appdata\local\programs\python\python36\lib\site-packages\you_get\common.py", line 1241, in download_main
    download(url, **kwargs)
  File "...\appdata\local\programs\python\python36\lib\site-packages\you_get\common.py", line 1608, in any_download
    m.download(url, **kwargs)
  File "...\appdata\local\programs\python\python36\lib\site-packages\you_get\extractor.py", line 46, in download_by_url
    self.prepare(**kwargs)
  File "...\appdata\local\programs\python\python36\lib\site-packages\you_get\extractors\pptv.py", line 195, in prepare
    page_content = get_content(self.url)
  File "...\appdata\local\programs\python\python36\lib\site-packages\you_get\common.py", line 415, in get_content
    response = urlopen_with_retry(req)
  File "...\appdata\local\programs\python\python36\lib\site-packages\you_get\common.py", line 393, in urlopen_with_retry
    raise http_error
  File "...\appdata\local\programs\python\python36\lib\site-packages\you_get\common.py", line 384, in urlopen_with_retry
    return request.urlopen(*args, **kwargs)
  File "...\appdata\local\programs\python\python36\lib\urllib\request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "...\appdata\local\programs\python\python36\lib\urllib\request.py", line 532, in open
    response = meth(req, response)
  File "...\appdata\local\programs\python\python36\lib\urllib\request.py", line 642, in http_response
    'http', request, response, code, msg, hdrs)
  File "...\appdata\local\programs\python\python36\lib\urllib\request.py", line 570, in error
    return self._call_chain(*args)
  File "...\appdata\local\programs\python\python36\lib\urllib\request.py", line 504, in _call_chain
    result = func(*args)
  File "...\appdata\local\programs\python\python36\lib\urllib\request.py", line 650, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 477:
```