### PR TITLE
add snrtv support

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -127,6 +127,7 @@ SITES = {
     'youtube'          : 'youtube',
     'zhanqi'           : 'zhanqi',
     'zhibo'            : 'zhibo',
+    'snrtv'            : 'snrtv',
 }
 
 dry_run = False

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -89,3 +89,4 @@ from .khan import *
 from .zhanqi import *
 from .kuaishou import *
 from .zhibo import *
+from .snrtv import *

--- a/src/you_get/extractors/snrtv.py
+++ b/src/you_get/extractors/snrtv.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+__all__ = ['snrtv_download']
+
+from ..common import *
+import lxml.etree
+
+
+
+def snrtv_download(url, output_dir = '.', merge = True, info_only = False, **kwargs):
+    '''
+    Two page formats have been temporarily discovered
+    http://www.snrtv.com/content/2018-07/06/content_15881533.htm
+    http://www.snrtv.com/content/2018-02/09/content_15665751.htm
+    '''
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36'
+    }
+    html = get_html(url,faker=True)
+    title = r1('<title>([.\s\S]*?)</title>', html)
+    title = title.replace(u'- 陕西网络广播电视台', '').replace('- Discover Shaanxi','').replace('- snrtv.com','')
+    title = title.strip()
+    if 'Discover Shaanxi' in html:
+        html = lxml.etree.HTML(html)
+        json_url = html.xpath('//div[@id="play_url"]/text()')
+        if not json_url:
+            return None
+        json_url = json_url[0]
+        json_str = get_html(json_url,faker=True)
+        json_str = r1('({.*})', json_str)
+        json_str = json.loads(json_str)
+        m3u8_url = parse.unquote(json_str['m3u8'])
+        urls = general_m3u8_extractor(m3u8_url,headers=headers)
+        print_info(site_info, title, 'm3u8', 0)
+        if not info_only:
+            download_urls(urls, title, 'ts', 0, output_dir=output_dir,headers=headers, merge=merge, **kwargs)
+    else:
+        real_url = r1(r'videos\s*:\s*\[{url\s*:\s*"(http.*?)"\s*,\s*delay\s*:\d+\s*}\s*\]', html)
+        type, ext, size = url_info(real_url,faker=True)
+        print_info(site_info, title, type, size)
+        if not info_only:
+            download_urls([real_url], title, ext, size, output_dir=output_dir, faker=True, headers=headers,merge=merge, **kwargs)
+
+site_info = "snrtv.com"
+download = snrtv_download
+download_playlist = playlist_not_supported('snrtv')


### PR DESCRIPTION
python you-get -d http://www.snrtv.com/content/2018-07/06/content_15881533.htm
It seems that your ffmpeg is a nightly build.
Please switch to the latest stable if merging failed.
[DEBUG] get_response: http://www.snrtv.com/content/2018-07/06/content_15881533.htm
[DEBUG] url_info: http://f2.v.cnwest.com/Asset/2018/07/06/6f6d489fac100ecd015244c6348495e2.flv
Site:       snrtv.com
Title:      百家碎戏 打工归来
Type:       Flash video (video/x-flv)
Size:       106.61 MiB (111788238 Bytes)

Downloading 百家碎戏 打工归来.flv ...
 100% (106.6/106.6MB) ├████████████████████████████████████████┤[1/1]   12 MB/s


-----------------------------------------------------------------------------------------------------------


python you-get -d http://www.snrtv.com/content/2018-02/09/content_15665751.htm
It seems that your ffmpeg is a nightly build.
Please switch to the latest stable if merging failed.
[DEBUG] get_response: http://www.snrtv.com/content/2018-02/09/content_15665751.htm
[DEBUG] get_response: http://hls.v.snrtv.com/json/2018/2018-02/snrtv_1415.js
[DEBUG] get_content: http://hls.v.snrtv.com/data/2018/2018-02/1415/snrtv_1415.m3u8
Site:       snrtv.com
Title:      The Pursuit of Art
Type:       M3U8 Playlist m3u8

Downloading The Pursuit of Art.ts ...
 100% (216.1/216.1MB) ├██████████████████████████████████████┤[33/33]   13 MB/s
Merging video parts... ffmpeg version N-91111-g380ca1bc0c Copyright (c) 2000-2018 the FFmpeg developers
  built with gcc 7.3.0 (GCC)
  configuration: --enable-gpl --enable-version3 --enable-sdl2 --enable-bzlib --enable-fontconfig --enable-gnutls --enable-iconv --enable-libass --enable-libbluray --enable-libfreetype --enable-libmp3lame
 --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libopus --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libtheora --enable-libtwolame --enable-libvpx -
-enable-libwavpack --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libzimg --enable-lzma --enable-zlib --enable-gmp --enable-libvidstab --enable-libvorbis --enable-libvo-amrw
benc --enable-libmysofa --enable-libspeex --enable-libxvid --enable-libaom --enable-libmfx --enable-amf --enable-ffnvcodec --enable-cuvid --enable-d3d11va --enable-nvenc --enable-nvdec --enable-dxva2 --e
nable-avisynth
  libavutil      56. 18.102 / 56. 18.102
  libavcodec     58. 19.102 / 58. 19.102
  libavformat    58. 13.102 / 58. 13.102
  libavdevice    58.  4.100 / 58.  4.100
  libavfilter     7. 23.100 /  7. 23.100
  libswscale      5.  2.100 /  5.  2.100
  libswresample   3.  2.100 /  3.  2.100
  libpostproc    55.  2.100 / 55.  2.100
[h264 @ 0000005230638a00] non-existing SPS 0 referenced in buffering period
[h264 @ 0000005230638a00] SPS unavailable in decode_picture_timing
[h264 @ 0000005230638a00] non-existing SPS 0 referenced in buffering period
[h264 @ 0000005230638a00] SPS unavailable in decode_picture_timing
Input #0, mpegts, from 'concat:.\The Pursuit of Art[00].ts|.\The Pursuit of Art[01].ts|.\The Pursuit of Art[02].ts|.\The Pursuit of Art[03].ts|.\The Pursuit of Art[04].ts|.\The Pursuit of Art[05].ts|.\Th
e Pursuit of Art[06].ts|.\The Pursuit of Art[07].ts|.\The Pursuit of Art[08].ts|.\The Pursuit of Art[09].ts|.\The Pursuit of Art[10].ts|.\The Pursuit of Art[11].ts|.\The Pursuit of Art[12].ts|.\The Pursu
it of Art[13].ts|.\The Pursuit of Art[14].ts|.\The Pursuit of Art[15].ts|.\The Pursuit of Art[16].ts|.\The Pursuit of Art[17].ts|.\The Pursuit of Art[18].ts|.\The Pursuit of Art[19].ts|.\The Pursuit of A
rt[20].ts|.\The Pursuit of Art[21].ts|.\The Pursuit of Art[22].ts|.\The Pursuit of Art[23].ts|.\The Pursuit of Art[24].ts|.\The Pursuit of Art[25].ts|.\The Pursuit of Art[26].ts|.\The Pursuit of Art[27].
ts|.\The Pursuit of Art[28].ts|.\The Pursuit of Art[29].ts|.\The Pursuit of Art[30].ts|.\The Pursuit of Art[31].ts|.\The Pursuit of Art[32].ts|':
  Duration: 00:05:25.70, start: 1.440000, bitrate: 5565 kb/s
  Program 1
    Metadata:
      service_name    : Service01
      service_provider: FFmpeg
    Stream #0:0[0x100]: Video: h264 (Main) ([27][0][0][0] / 0x001B), yuv420p(top first), 1920x1080 [SAR 1:1 DAR 16:9], 25 fps, 50 tbr, 90k tbn, 50 tbc
    Stream #0:1[0x101](eng): Audio: aac (LC) ([15][0][0][0] / 0x000F), 48000 Hz, stereo, fltp, 123 kb/s
Output #0, matroska, to '.\The Pursuit of Art.mkv':
  Metadata:
    encoder         : Lavf58.13.102
    Stream #0:0: Video: h264 (Main) (H264 / 0x34363248), yuv420p(top first), 1920x1080 [SAR 1:1 DAR 16:9], q=2-31, 25 fps, 50 tbr, 1k tbn, 90k tbc
    Stream #0:1(eng): Audio: aac (LC) ([255][0][0][0] / 0x00FF), 48000 Hz, stereo, fltp, 123 kb/s
Stream mapping:
  Stream #0:0 -> #0:0 (copy)
  Stream #0:1 -> #0:1 (copy)
Press [q] to stop, [?] for help
frame=16284 fps=14497 q=-1.0 Lsize=  203453kB time=00:05:25.67 bitrate=5117.6kbits/s speed= 290x
video:198100kB audio:5193kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: 0.078507%
Merged into The Pursuit of Art.mkv

