### PR TITLE
cant download 365yg.com anymore ,how to fix it?

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -31,14 +31,5 @@ class YouGetTests(unittest.TestCase):
             info_only=True
         )
 
-    def test_bilibili(self):
-        bilibili.download(
-            'https://www.bilibili.com/video/av16907446/', info_only=True
-        )
-        bilibili.download(
-            'https://www.bilibili.com/video/av13228063/', info_only=True
-        )
-
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
when i download 365yg.com video(http://www.365yg.com/a6417658813411492098) , something went wrong, it seems dont support anymore ,how to fix it? with --debug option and the full output as  follows：you-get --debug http://www.365yg.com/a6417658813411492098
[DEBUG] get_response: http://www.365yg.com/a6417658813411492098
[DEBUG] get_content: http://i.snssdk.com/video/urls/v/1/toutiao/mp4/None?r=8407679973790697&s=692867348
you-get: version 0.4.1099, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['http://www.365yg.com/a6417658813411492098'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "/usr/bin/you-get", line 11, in <module>
    you_get.main(repo_path=_filepath)
  File "/opt/you-get-develop/src/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/opt/you-get-develop/src/you_get/common.py", line 1622, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/opt/you-get-develop/src/you_get/common.py", line 1510, in script_main
    **extra
  File "/opt/you-get-develop/src/you_get/common.py", line 1245, in download_main
    download(url, **kwargs)
  File "/opt/you-get-develop/src/you_get/common.py", line 1613, in any_download
    m.download(url, **kwargs)
  File "/opt/you-get-develop/src/you_get/extractors/toutiao.py", line 68, in toutiao_download
    video_file_list = get_file_by_vid(video_id)  # 调api获取视频源文件
  File "/opt/you-get-develop/src/you_get/extractors/toutiao.py", line 47, in get_file_by_vid
    vlist = ret.get('data').get('video_list')
AttributeError: 'NoneType' object has no attribute 'get'