### PR TITLE
del \t symbol of youku title

### DIFF
--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -189,7 +189,7 @@ class Youku(VideoExtractor):
             else:
                 log.wtf('Unknown error')
 
-        self.title = self.api_data['video']['title']
+        self.title = self.api_data['video']['title'].replace('\t', '')
         stream_types = dict([(i['id'], i) for i in self.stream_types])
         audio_lang = self.api_data['stream'][0]['audio_lang']
 


### PR DESCRIPTION
Sometimes youku video with \t symbol in title, such as this http://v.youku.com/v_show/id_XNzA5ODMxMzY0.html
```
you-get -c yk.txt http://v.youku.com/v_show/id_XNzA5ODMxMzY0.html

It seems that your ffmpeg is a nightly build.
Please switch to the latest stable if merging failed.
you-get: Found cna in imported cookies. Use it
site:                优酷 (Youku)
title:               第四集 家常        地道泡菜鱼搭配泡菜的专属美味
stream:
    - format:        mp4hd3
      container:     mp4
      video-profile: 1080P
      size:          1097.0 MiB (1150336001 bytes)
      m3u8_url:      http://pl-ali.youku.com/playlist/m3u8?vid=XNzA5ODMxMzY0&type=mp4hd3v3&ups_client_netip=78ef1e87&utid=f8UgFN
m1QwUCAXjvHpl1RBOF&ccode=0502&psid=e1274aee11e234d95cd45f2a5fb85fb1&ups_userid=1543367023&ups_ytid=1543367023&duration=2879&expi
re=18000&drm_type=1&drm_device=7&ups_ts=1538973785&onOff=0&encr=0&ups_key=ef05286120117fd61607778974b1c098
    # download-with: you-get --format=mp4hd3 [URL]

Downloading 第四集 家常         地道泡菜鱼搭配泡菜的专属美味.mp4 ...
 0.0% (   0.0/1097.0MB) ├────────────────────────────────────┤[ 1/21] you-get: [error] oop
s, something went wrong.
you-get: don't panic, c'est la vie. please try the following steps:
you-get:   (1) Rule out any network problem.
you-get:   (2) Make sure you-get is up-to-date.
you-get:   (3) Check if the issue is already known, on
you-get:         https://github.com/soimort/you-get/wiki/Known-Bugs
you-get:         https://github.com/soimort/you-get/issues
you-get:   (4) Run the command with '--debug' option,
you-get:       and report this issue with the full output.
```