### PR TITLE
use new bilibili live api, fix None Content-Type

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -429,7 +429,7 @@ def get_content(url, headers={}, decoded=True):
     # Decode the response body
     if decoded:
         charset = match1(
-            response.getheader('Content-Type'), r'charset=([\w-]+)'
+            response.getheader('Content-Type', ''), r'charset=([\w-]+)'
         )
         if charset is not None:
             data = data.decode(charset)

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -22,7 +22,7 @@ from .youku import youku_download_by_vid
 
 class Bilibili(VideoExtractor):
     name = 'Bilibili'
-    live_api = 'http://live.bilibili.com/api/playurl?cid={}&otype=json'
+    live_api = 'https://api.live.bilibili.com/room/v1/Room/playUrl?cid={}&quality=0&platform=web'
     api_url = 'http://interface.bilibili.com/v2/playurl?'
     bangumi_api_url = 'http://bangumi.bilibili.com/player/web_api/playurl?'
     live_room_init_api_url = 'https://api.live.bilibili.com/room/v1/Room/room_init?id={}'
@@ -233,7 +233,7 @@ class Bilibili(VideoExtractor):
 
         api_url = self.live_api.format(self.room_id)
         json_data = json.loads(get_content(api_url))
-        urls = [json_data['durl'][0]['url']]
+        urls = [json_data['data']['durl'][0]['url']]
 
         self.streams['live'] = {}
         self.streams['live']['src'] = urls


### PR DESCRIPTION
Use new API: `https://api.live.bilibili.com/room/v1/Room/playUrl?cid={}&quality=0&platform=web` to get .flv url

And sometimes, response.headers['Content-Type'] is None, fix the `None` to `''`