### PR TITLE
fix bilibili title regex

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -130,7 +130,7 @@ class Bilibili(VideoExtractor):
         m = re.search(r'<h1.*?>(.*?)</h1>', self.page) or re.search(r'<h1 title="([^"]+)">', self.page)
         if m is not None:
             self.title = m.group(1)
-            s = re.search(r'<span>([^<]+)</span>', m.group(1))
+            s = re.search(r'<span>([^<]+)</span>', m.group(1)) or re.search(r'<span class="tit tr-fix">([^<]+)</span>', m.group(1))
             if s:
                 self.title = unescape_html(s.group(1))
         if self.title is None:


### PR DESCRIPTION
this PR fix the title regex problem under  `--cookies` . 

normally the title extractor regex is aiming at this line:
![2](https://user-images.githubusercontent.com/6072743/48576585-e21c6500-e94f-11e8-8bae-1659a66ef758.PNG)

but if use `--cookies` arg to log in, the title line become:
![1](https://user-images.githubusercontent.com/6072743/48576587-e2b4fb80-e94f-11e8-8fb9-0758e8e32275.PNG)


