### PR TITLE
Fix bilibili title regex

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -130,7 +130,7 @@ class Bilibili(VideoExtractor):
         m = re.search(r'<h1.*?>(.*?)</h1>', self.page) or re.search(r'<h1 title="([^"]+)">', self.page)
         if m is not None:
             self.title = m.group(1)
-            s = re.search(r'<span>([^<]+)</span>', m.group(1))
+            s = re.search(r'<span>([^<]+)</span>', m.group(1)) or re.search(r'<span class="tit tr-fix">([^<]+)</span>', m.group(1))
             if s:
                 self.title = unescape_html(s.group(1))
         if self.title is None:

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -130,9 +130,7 @@ class Bilibili(VideoExtractor):
         m = re.search(r'<h1.*?>(.*?)</h1>', self.page) or re.search(r'<h1 title="([^"]+)">', self.page)
         if m is not None:
             self.title = m.group(1)
-            s = re.search(r'<span>([^<]+)</span>', m.group(1)) \
-                or re.search(r'<span class="tit">([^<]+)</span>', m.group(1)) \
-                or re.search(r'<span class="tit tr-fix">([^<]+)</span>', m.group(1))
+            s = re.search(r'<span.*?>([^<]+)</span>', m.group(1))
             if s:
                 self.title = unescape_html(s.group(1))
         if self.title is None:

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -130,7 +130,9 @@ class Bilibili(VideoExtractor):
         m = re.search(r'<h1.*?>(.*?)</h1>', self.page) or re.search(r'<h1 title="([^"]+)">', self.page)
         if m is not None:
             self.title = m.group(1)
-            s = re.search(r'<span>([^<]+)</span>', m.group(1)) or re.search(r'<span class="tit tr-fix">([^<]+)</span>', m.group(1))
+            s = re.search(r'<span>([^<]+)</span>', m.group(1)) \
+                or re.search(r'<span class="tit">([^<]+)</span>', m.group(1)) \
+                or re.search(r'<span class="tit tr-fix">([^<]+)</span>', m.group(1))
             if s:
                 self.title = unescape_html(s.group(1))
         if self.title is None:


### PR DESCRIPTION
old regex can only aim at this:
![48576585-e21c6500-e94f-11e8-8bae-1659a66ef758](https://user-images.githubusercontent.com/6072743/48603093-4242f380-e9b0-11e8-974b-87ddd8d39cb1.PNG)

this PR match the title pattern with html attribute like this
![48576587-e2b4fb80-e94f-11e8-8fb9-0758e8e32275](https://user-images.githubusercontent.com/6072743/48603088-4111c680-e9b0-11e8-8a6f-43a33bf6f953.PNG)

PLZ test the code using `--cookies` to login Bilbili and fetch the 2nd kind of title pattern
