### PR TITLE
fix acfun bangumi page

### DIFF
--- a/src/you_get/extractors/acfun.py
+++ b/src/you_get/extractors/acfun.py
@@ -105,26 +105,41 @@ def acfun_download_by_vid(vid, title, output_dir='.', merge=True, info_only=Fals
             pass
 
 def acfun_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
-    assert re.match(r'http://[^\.]*\.*acfun\.[^\.]+/\D/\D\D(\d+)', url)
-    html = get_content(url)
+    assert re.match(r'http://[^\.]*\.*acfun\.[^\.]+/(\D|bangumi)/\D\D(\d+)', url)
 
-    title = r1(r'data-title="([^"]+)"', html)
+    if re.match(r'http://[^\.]*\.*acfun\.[^\.]+/\D/\D\D(\d+)', url):
+        html = get_content(url)
+        title = r1(r'data-title="([^"]+)"', html)
+        if match1(url, r'_(\d+)$'):  # current P
+            title = title + " " + r1(r'active">([^<]*)', html)
+        vid = r1('data-vid="(\d+)"', html)
+        up = r1('data-name="([^"]+)"', html)
+    # bangumi
+    elif re.match("http://[^\.]*\.*acfun\.[^\.]+/bangumi/ab(\d+)", url):
+        html = get_content(url)
+        title = match1(html, r'"newTitle"\s*:\s*"([^"]+)"')
+        if match1(url, r'_(\d+)$'):  # current P
+            title = title + " " + r1(r'active">([^<]*)', html)
+        vid = match1(html, r'videoId="(\d+)"')
+        up = "acfun"
+    else:
+        raise NotImplemented
+
+    assert title and vid
     title = unescape_html(title)
     title = escape_file_path(title)
-    assert title
-    if match1(url, r'_(\d+)$'): # current P
-        title = title + " " + r1(r'active">([^<]*)', html)
-
-    vid = r1('data-vid="(\d+)"', html)
-    up = r1('data-name="([^"]+)"', html)
     p_title = r1('active">([^<]+)', html)
     title = '%s (%s)' % (title, up)
-    if p_title: title = '%s - %s' % (title, p_title)
+    if p_title:
+        title = '%s - %s' % (title, p_title)
+
+
     acfun_download_by_vid(vid, title,
                           output_dir=output_dir,
                           merge=merge,
                           info_only=info_only,
                           **kwargs)
+
 
 site_info = "AcFun.tv"
 download = acfun_download


### PR DESCRIPTION
url pattern and html layout of acfun's bangumi page is different from other acfun page , which causes problem
this pr fixs it

~~~
you-get -i http://www.acfun.cn/bangumi/ab5022161
Site:       AcFun.tv
Title:      但是不屈不挠 SAGA (acfun)
Type:       MPEG-4 video (video/mp4)
Size:       539.6 MiB (565815129 Bytes)
~~~