### PR TITLE
[bilibili] support bilibili audio

### DIFF
--- a/src/you_get/extractor.py
+++ b/src/you_get/extractor.py
@@ -211,7 +211,7 @@ class VideoExtractor():
                 ext = self.dash_streams[stream_id]['container']
                 total_size = self.dash_streams[stream_id]['size']
 
-            if ext == 'm3u8':
+            if ext == 'm3u8' or ext == 'm4a':
                 ext = 'mp4'
 
             if not urls:


### PR DESCRIPTION
support 3 types of url:
1. one piece of music
e.g. `https://www.bilibili.com/audio/au639116` 
2. playlist
e.g. `https://www.bilibili.com/audio/am10624?type=2` need --playlist
3. favlist
e.g. `https://www.bilibili.com/audio/mycollection/16803087` need --playlist

have tested on these three types of urls
```
  you-get git:(develop) ./you-get https://www.bilibili.com/audio/mycollection/16803087 --playlist
Start downloading music  负面扩张
site:                Bilibili
title:               负面扩张
stream:
    - format:        mp4
      container:     m4a
      size:          3.5 MiB (3648595 bytes)
    # download-with: you-get --format=mp4 [URL]

Downloading 负面扩张.mp4 ...
 100% (  3.5/  3.5MB) ├████████████████████████████████████████┤[1/1]  820 kB/s

Start downloading music  谁杀死了知更鸟（小少年·童谣ver）
site:                Bilibili
title:               谁杀死了知更鸟（小少年·童谣ver）
stream:
    - format:        mp4
      container:     m4a
      size:          7.6 MiB (8018692 bytes)
    # download-with: you-get --format=mp4 [URL]

Downloading 谁杀死了知更鸟（小少年·童谣ver）.mp4 ...
 100% (  7.6/  7.6MB) ├████████████████████████████████████████┤[1/1]    2 MB/s
```