### PR TITLE
fix bilibili bangumi page

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -284,12 +284,6 @@ class Bilibili(VideoExtractor):
         self.streams['vc']['size'] = int(item['video_size'])
 
     def bangumi_entry(self, **kwargs):
-        bangumi_id = re.search(r'(\d+)', self.url).group(1)
-        frag = urllib.parse.urlparse(self.url).fragment
-        if frag:
-            episode_id = frag
-        else:
-            episode_id = re.search(r'first_ep_id\s*=\s*"(\d+)"', self.page) or re.search(r'\/ep(\d+)', self.url).group(1)
         data = json.loads(re.search(r'__INITIAL_STATE__=(.+);\(function', self.page).group(1))
         cid = data['epInfo']['cid']
         # index_title = data['epInfo']['index_title']


### PR DESCRIPTION
delete useless old regex which sometimes cause error

~~~
you-get --debug  https://www.bilibili.com/bangumi/play/ss25681/?spm_id_from=333.
334.b_62696c695f62616e67756d69.5
......
 File "c:\users\fengl\appdata\local\programs\python\python36\lib\site-packages\you_get\extractors\bilibili.py", line 267, in bangumi_entry
    episode_id = re.search(r'first_ep_id\s*=\s*"(\d+)"', self.page) or re.search(r'\/ep(\d+)', self.url).group(1)
AttributeError: 'NoneType' object has no attribute 'group'
~~~