### PR TITLE
Fix the problem "urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1045)>"

### DIFF
--- a/src/you_get/__main__.py
+++ b/src/you_get/__main__.py
@@ -4,8 +4,12 @@ import getopt
 import os
 import platform
 import sys
+import ssl
 from .version import script_name, __version__
 from .util import git, log
+
+
+ssl._create_default_https_context = ssl._create_unverified_context
 
 _options = [
     'help',


### PR DESCRIPTION
## Fix Problem
I found this problem when i using this command `you-get -i 'https://www.youtube.com/watch?v=jNQXAC9IVRw' --debug` 
Here is the wrong information:
```python
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1045)>
```
## Solution
Close the global SSL certificate verify in `/you-get/src/you_get/__main__.py`