### PR TITLE
Use copy when merging audio and video

### DIFF
--- a/src/you_get/processor/ffmpeg.py
+++ b/src/you_get/processor/ffmpeg.py
@@ -59,12 +59,7 @@ def ffmpeg_concat_av(files, output, ext):
     params = [FFMPEG] + LOGLEVEL
     for file in files:
         if os.path.isfile(file): params.extend(['-i', file])
-    params.extend(['-c:v', 'copy'])
-    if ext == 'mp4':
-        params.extend(['-c:a', 'aac'])
-    elif ext == 'webm':
-        params.extend(['-c:a', 'vorbis'])
-    params.extend(['-strict', 'experimental'])
+    params.extend(['-c', 'copy'])
     params.append(output)
     return subprocess.call(params, stdin=STDIN)
 


### PR DESCRIPTION
Currently `you-get` is re-encoding the audio using aac when merging audio and video tracks. This is a waste of time and will degrade the quality of audio. This PR changes the codec for audio to copy.

Further more, the `-strict experimental` option is only necessary when using the aac codec and has already been deprecated in 2015. This PR also removes this option.