### PR TITLE
fix coub ffmpeg

### DIFF
--- a/src/you_get/extractors/coub.py
+++ b/src/you_get/extractors/coub.py
@@ -25,10 +25,10 @@ def coub_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
                 loop_file_path = get_loop_file_path(title, output_dir)
                 single_file_path = audio_file_path
                 if audio_duration > video_duration:
-                    write_loop_file(int(audio_duration / video_duration), loop_file_path, video_file_name)
+                    write_loop_file(round(audio_duration / video_duration), loop_file_path, video_file_name)
                 else:
                     single_file_path = audio_file_path
-                    write_loop_file(int(video_duration / audio_duration), loop_file_path, audio_file_name)
+                    write_loop_file(round(video_duration / audio_duration), loop_file_path, audio_file_name)
 
                 ffmpeg.ffmpeg_concat_audio_and_video([loop_file_path, single_file_path], title + "_full", "mp4")
                 cleanup_files([video_file_path, audio_file_path, loop_file_path])

--- a/src/you_get/processor/ffmpeg.py
+++ b/src/you_get/processor/ffmpeg.py
@@ -267,6 +267,7 @@ def ffmpeg_concat_audio_and_video(files, output, ext):
     if has_ffmpeg_installed:
         params = [FFMPEG] + LOGLEVEL
         params.extend(['-f', 'concat'])
+        params.extend(['-safe', '0'])  # https://stackoverflow.com/questions/38996925/ffmpeg-concat-unsafe-file-name
         for file in files:
             if os.path.isfile(file):
                 params.extend(['-i', file])


### PR DESCRIPTION
Test URL:  https://coub.com/view/19cyub

1) ```params.extend(['-safe', '0'])``` fixes ```[concat @ 0x55b4c8f02980] Unsafe file name 'Test_For_The_Princess!.mp4'```
Before patch: Test_For_The_Princess!_full.mp4 is not created
After patch: Test_For_The_Princess!_full.mp4 created successfully

2) ```round``` fixes ```audio_duration 64.0 + video_duration 8.04 -> 7```
Before patch: video is freezed for last 8 second
After patch: perfect loop
