### PR TITLE
Youku downloading error for longer videos

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -3,33 +3,15 @@
 import unittest
 
 from you_get.extractors import (
-    imgur,
-    magisto,
-    youtube,
-    bilibili,
+    youku,
 )
 
 
 class YouGetTests(unittest.TestCase):
-    def test_imgur(self):
-        imgur.download('http://imgur.com/WVLk5nD', info_only=True)
-        imgur.download('http://imgur.com/gallery/WVLk5nD', info_only=True)
-
-    def test_magisto(self):
-        magisto.download(
-            'http://www.magisto.com/album/video/f3x9AAQORAkfDnIFDA',
-            info_only=True
-        )
-
-    def test_youtube(self):
-        youtube.download(
-            'http://www.youtube.com/watch?v=pzKerr0JIPA', info_only=True
-        )
-        youtube.download('http://youtu.be/pzKerr0JIPA', info_only=True)
-        youtube.download(
-            'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
-            info_only=True
-        )
+    def test_youku(self):
+        youku.download('https://v.youku.com/v_show/id_XNDAwMjkxNTU2NA==.html', info_only=True)
+        youtube.download('https://v.youku.com/v_show/id_XNDAwMjkxMDM0MA==.html', info_only=True)
+        youtube.download('https://v.youku.com/v_show/id_XNDAwMjkxMzcwNA==.html', info_only=True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When downloading longer videos from Youku, the file only contains the first 6 minutes.

`user2$ you-get https://v.youku.com/v_show/id_XNDAwMjkxNTU2NA==.html` gives the following:

<img width="597" alt="screen shot 2019-02-11 at 11 17 07 pm" src="https://user-images.githubusercontent.com/47149156/52611338-30f47080-2e53-11e9-8778-9dc4267487fb.png">

The downloader stops at this point and merges files after only a portion are downloaded, and I cannot find a way to download content beyond this timestamp.

I get the same results with different Youku links:
https://v.youku.com/v_show/id_XNDAwMjkxMDM0MA==.html
https://v.youku.com/v_show/id_XNDAwMjkxMzcwNA==.html

Please let me know if there is any other information I can provide, as this is my first time submitting a pull request. Thank you!