### PR TITLE
Added test case for bilibili nonetype error

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -31,5 +31,8 @@ class YouGetTests(unittest.TestCase):
             info_only=True
         )
 
+    def test_bilibili_nonetype_error(self):
+        bilibili.download('https://www.bilibili.com/video/av22195308/?p=3', playlist=True, output_dir='test_output', merge=True)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
You-get returned this error when I am trying to download video.
```
Traceback (most recent call last):
  File "tests/test.py", line 35, in test_bilibili_nonetype_error
    bilibili.download('https://www.bilibili.com/video/av22195308/?p=3', playlist=True, output_dir='test_output', merge=True)
  File "/usr/lib/python3.7/site-packages/you_get/extractor.py", line 59, in download_by_url
    self.download(**kwargs)
  File "/usr/lib/python3.7/site-packages/you_get/extractor.py", line 201, in download
    self.p(stream_id)
  File "/usr/lib/python3.7/site-packages/you_get/extractor.py", line 139, in p
    self.p_stream(stream_id)
  File "/usr/lib/python3.7/site-packages/you_get/extractor.py", line 108, in p_stream
    if 'size' in stream and stream['container'].lower() != 'm3u8':
AttributeError: 'NoneType' object has no attribute 'lower'
```
Test is made based on the latest develop branch and the error remains.  

Test case is added to the test.py