### PR TITLE
Bilibili - Failed to download all videos from one channel

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -7,11 +7,9 @@ from you_get.extractors import (
 )
 
 
-class YouGetTests(unittest.TestCase):	
-    def test_bilibili(self):
-
-        bilibili.download('https://space.bilibili.com/19111402/video', info_only=True)
-        youtube.download('https://space.bilibili.com/19111402/video', info_only=True)
+class YouGetTests(unittest.TestCase):
+        def test_bilibili(self):
+            bilibili.download('https://space.bilibili.com/19111402/video', info_only=True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,33 +3,15 @@
 import unittest
 
 from you_get.extractors import (
-    imgur,
-    magisto,
-    youtube,
     bilibili,
 )
 
 
-class YouGetTests(unittest.TestCase):
-    def test_imgur(self):
-        imgur.download('http://imgur.com/WVLk5nD', info_only=True)
-        imgur.download('http://imgur.com/gallery/WVLk5nD', info_only=True)
+class YouGetTests(unittest.TestCase):	
+    def test_bilibili(self):
 
-    def test_magisto(self):
-        magisto.download(
-            'http://www.magisto.com/album/video/f3x9AAQORAkfDnIFDA',
-            info_only=True
-        )
-
-    def test_youtube(self):
-        youtube.download(
-            'http://www.youtube.com/watch?v=pzKerr0JIPA', info_only=True
-        )
-        youtube.download('http://youtu.be/pzKerr0JIPA', info_only=True)
-        youtube.download(
-            'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
-            info_only=True
-        )
+        bilibili.download('https://space.bilibili.com/19111402/video', info_only=True)
+        youtube.download('https://space.bilibili.com/19111402/video', info_only=True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In the case when there are more than 100 videos uploaded by one Bilibili user, running "you-get [URL]" or "you-get -l [URL]" will only download the latest 100 videos.

Debug shows that the refactor turns to url (https://space.bilibili.com/ajax/member/getSubmitVideos?mid=19111402&page=1&pagesize=100&order=0&jsonp=jsonp) .
Looked into source codes. The value of page=1 and pagesize=100 are somewhat hard-coded. Tried changing pagesize to 200 returns an error. 
Possible approach is 1)to somehow fix the error and allow it to download all videos from the up-loader no matter how many they are, or 2)add a command line option/parameter for user to specify the page that he's trying to start downloading from.

Test case:
you-get https://space.bilibili.com/19111402/video
you-get -l https://space.bilibili.com/19111402/video