### PR TITLE
fix toutiao errors

### DIFF
--- a/src/you_get/extractors/toutiao.py
+++ b/src/you_get/extractors/toutiao.py
@@ -1,27 +1,36 @@
 #!/usr/bin/env python
-import base64
-
 import binascii
-
-from ..common import *
 import random
 from json import loads
+from urllib.parse import urlparse
+
+from ..common import *
+
+try:
+    from base64 import decodebytes
+except ImportError:
+    from base64 import decodestring
+
+    decodebytes = decodestring
 
 __all__ = ['toutiao_download', ]
 
 
+def random_with_n_digits(n):
+    return random.randint(10 ** (n - 1), (10 ** n) - 1)
+
+
 def sign_video_url(vid):
-    # some code from http://codecloud.net/110854.html
-    r = str(random.random())[2:]
+    r = str(random_with_n_digits(16))
 
-    def right_shift(val, n):
-        return val >> n if val >= 0 else (val + 0x100000000) >> n
-
-    url = 'http://i.snssdk.com/video/urls/v/1/toutiao/mp4/%s' % vid
-    n = url.replace("http://i.snssdk.com", "")+ '?r=' + r
-    c = binascii.crc32(n.encode("ascii"))
-    s = right_shift(c, 0)
-    return url + '?r=%s&s=%s' % (r, s)
+    url = 'https://ib.365yg.com/video/urls/v/1/toutiao/mp4/{vid}'.format(vid=vid)
+    n = urlparse(url).path + '?r=' + r
+    b_n = bytes(n, encoding="utf-8")
+    s = binascii.crc32(b_n)
+    aid = 1364
+    ts = int(time.time() * 1000)
+    return url + '?r={r}&s={s}&aid={aid}&vfrom=xgplayer&callback=axiosJsonpCallback1&_={ts}'.format(r=r, s=s, aid=aid,
+                                                                                                    ts=ts)
 
 
 class ToutiaoVideoInfo(object):
@@ -43,12 +52,12 @@ def get_file_by_vid(video_id):
     vRet = []
     url = sign_video_url(video_id)
     ret = get_content(url)
-    ret = loads(ret)
+    ret = loads(ret[20:-1])
     vlist = ret.get('data').get('video_list')
     if len(vlist) > 0:
         vInfo = vlist.get(sorted(vlist.keys(), reverse=True)[0])
         vUrl = vInfo.get('main_url')
-        vUrl = base64.decodestring(vUrl.encode('ascii')).decode('ascii')
+        vUrl = decodebytes(vUrl.encode('ascii')).decode('ascii')
         videoInfo = ToutiaoVideoInfo()
         videoInfo.bitrate = vInfo.get('bitrate')
         videoInfo.definition = vInfo.get('definition')
@@ -63,8 +72,8 @@ def get_file_by_vid(video_id):
 
 def toutiao_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
     html = get_html(url, faker=True)
-    video_id = match1(html, r"videoid\s*:\s*'([^']+)',\n")
-    title = match1(html, r"title: '([^']+)'.replace")
+    video_id = match1(html, r".*?videoId: '(?P<vid>.*)'")
+    title = match1(html, '.*?<title>(?P<title>.*?)</title>')
     video_file_list = get_file_by_vid(video_id)  # 调api获取视频源文件
     type, ext, size = url_info(video_file_list[0].url, faker=True)
     print_info(site_info=site_info, title=title, type=type, size=size)

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,6 +7,7 @@ from you_get.extractors import (
     magisto,
     youtube,
     bilibili,
+    toutiao,
 )
 
 
@@ -30,6 +31,10 @@ class YouGetTests(unittest.TestCase):
             'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
             info_only=True
         )
+
+    def test_toutiao(self):
+        toutiao.download('https://www.365yg.com/i6640053613567675662/#mid=1611922564114440', info_only=True)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
```
[DEBUG] get_response: https://www.365yg.com/i6640053613567675662/#mid=1611922564114440
[DEBUG] get_content: http://i.snssdk.com/video/urls/v/1/toutiao/mp4/None?r=1644525832427347&s=244466975
you-get: version 0.4.1270, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.365yg.com/i6640053613567675662/#mid=1611922564114440'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "/home/jason/.venv/venv3.6/bin/you-get", line 10, in <module>
    sys.exit(main())
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/you_get/common.py", line 1714, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/you_get/common.py", line 1602, in script_main
    **extra
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/you_get/common.py", line 1275, in download_main
    download(url, **kwargs)
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/you_get/common.py", line 1705, in any_download
    m.download(url, **kwargs)
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/you_get/extractors/toutiao.py", line 68, in toutiao_download
    video_file_list = get_file_by_vid(video_id)  # 调api获取视频源文件
  File "/home/jason/.venv/venv3.6/lib/python3.6/site-packages/you_get/extractors/toutiao.py", line 47, in get_file_by_vid
    vlist = ret.get('data').get('video_list')
AttributeError: 'NoneType' object has no attribute 'get'
```