### PR TITLE
fix acfun bangumi title

### DIFF
--- a/src/you_get/extractors/acfun.py
+++ b/src/you_get/extractors/acfun.py
@@ -121,7 +121,7 @@ def acfun_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
     # bangumi
     elif re.match("http://[^\.]*\.*acfun\.[^\.]+/bangumi/ab(\d+)", url):
         html = get_content(url)
-        title = match1(html, r'"newTitle"\s*:\s*"([^"]+)"')
+        title = match1(html, r'"title"\s*:\s*"([^"]+)"')
         if match1(url, r'_(\d+)$'):  # current P
             title = title + " " + r1(r'active">([^<]*)', html)
         vid = match1(html, r'videoId="(\d+)"')


### PR DESCRIPTION
Correct the title of the file from "早上好 佐贺 早上好 佐贺 (acfun) - 早上好 佐贺" to "佐贺偶像是传奇 早上好 佐贺 (acfun) - 早上好 佐贺".
And also support videos like `http://www.acfun.cn/bangumi/ab5024113_33351_311321`.
