### PR TITLE
Travis CI: Add flake8 test F632 use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,20 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
-  - "nightly"
   - "pypy3"
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial
+    - python: "3.8-dev"
+      dist: xenial    
+    - python: "nightly"
+      dist: xenial    
 before_install:
   - if [[ $TRAVIS_PYTHON_VERSION != '3.2'* && $TRAVIS_PYTHON_VERSION != '3.3'* ]]; then pip install flake8; fi
 before_script:
-  - if [[ $TRAVIS_PYTHON_VERSION != '3.2'* && $TRAVIS_PYTHON_VERSION != '3.3'* ]]; then flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != '3.2'* && $TRAVIS_PYTHON_VERSION != '3.3'* ]]; then flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics; fi
 script: make test
-sudo: false
 notifications:
   webhooks:
     urls:

--- a/src/you_get/extractors/baidu.py
+++ b/src/you_get/extractors/baidu.py
@@ -38,7 +38,7 @@ def baidu_get_song_title(data):
 
 def baidu_get_song_lyric(data):
     lrc = data['lrcLink']
-    return None if lrc is '' else "http://music.baidu.com%s" % lrc
+    return "http://music.baidu.com%s" % lrc if lrc else None
 
 
 def baidu_download_song(sid, output_dir='.', merge=True, info_only=False):

--- a/src/you_get/extractors/douyutv.py
+++ b/src/you_get/extractors/douyutv.py
@@ -62,12 +62,12 @@ def douyutv_download(url, output_dir='.', merge=True, info_only=False, **kwargs)
     json_content = json.loads(content)
     data = json_content['data']
     server_status = json_content.get('error', 0)
-    if server_status is not 0:
+    if server_status != 0:
         raise ValueError("Server returned error:%s" % server_status)
 
     title = data.get('room_name')
     show_status = data.get('show_status')
-    if show_status is not "1":
+    if show_status != "1":
         raise ValueError("The live stream is not online! (Errno:%s)" % server_status)
 
     real_url = data.get('rtmp_url') + '/' + data.get('rtmp_live')

--- a/src/you_get/extractors/panda.py
+++ b/src/you_get/extractors/panda.py
@@ -15,7 +15,7 @@ def panda_download(url, output_dir = '.', merge = True, info_only = False, **kwa
     json_request_url ="http://www.panda.tv/api_room_v2?roomid={}&__plat=pc_web&_={}".format(roomid, int(time.time()))
     content = get_html(json_request_url)
     api_json = json.loads(content)
-    
+
     errno = api_json["errno"]
     errmsg = api_json["errmsg"]
     if errno:
@@ -25,7 +25,7 @@ def panda_download(url, output_dir = '.', merge = True, info_only = False, **kwa
     room_key = data["videoinfo"]["room_key"]
     plflag = data["videoinfo"]["plflag"].split("_")
     status = data["videoinfo"]["status"]
-    if status is not "2":
+    if status != "2":
         raise ValueError("The live stream is not online! (status:%s)" % status)
 
     data2 = json.loads(data["videoinfo"]["plflag_list"])
@@ -33,7 +33,7 @@ def panda_download(url, output_dir = '.', merge = True, info_only = False, **kwa
     sign = data2["auth"]["sign"]
     ts = data2["auth"]["time"]
     real_url = "http://pl{}.live.panda.tv/live_panda/{}.flv?sign={}&ts={}&rid={}".format(plflag[1], room_key, sign, ts, rid)
-    
+
     print_info(site_info, title, 'flv', float('inf'))
     if not info_only:
         download_urls([real_url], title, 'flv', None, output_dir, merge = merge)

--- a/src/you_get/extractors/zhibo.py
+++ b/src/you_get/extractors/zhibo.py
@@ -14,7 +14,7 @@ def zhibo_vedio_download(url, output_dir = '.', merge = True, info_only = False,
 
     video_html = r1(r'<script type="text/javascript">([\s\S]*)</script></head>', html)
 
-    # video_guessulike = r1(r"window.xgData =([s\S'\s\.]*)\'\;[\s\S]*window.vouchData", video_html) 
+    # video_guessulike = r1(r"window.xgData =([s\S'\s\.]*)\'\;[\s\S]*window.vouchData", video_html)
     video_url = r1(r"window.vurl = \'([s\S'\s\.]*)\'\;[\s\S]*window.imgurl", video_html)
     part_urls.append(video_url)
     ext = video_url.split('.')[-1]
@@ -34,7 +34,7 @@ def zhibo_download(url, output_dir = '.', merge = True, info_only = False, **kwa
     html = get_html(url)
     title = r1(r'<title>([\s\S]*)</title>', html)
     is_live = r1(r"window.videoIsLive=\'([s\S'\s\.]*)\'\;[\s\S]*window.resDomain", html)
-    if is_live is not "1":
+    if is_live != "1":
         raise ValueError("The live stream is not online! (Errno:%s)" % is_live)
 
     match = re.search(r"""


### PR DESCRIPTION
Also:
* Upgrade to Python 3.7 production instead of pre-release
* Upgrade to current Python nightly and 3.8-dev builds
* Remove __sudo__ tag which is now deprecated on Travis CI

[__Python < 3.5 are all end-of-life.__](https://devguide.python.org/devcycle/#end-of-life-branches)  At what point do we drop support for them?

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./src/you_get/extractors/baidu.py:41:20: F632 use ==/!= to compare str, bytes, and int literals
    return None if lrc is '' else "http://music.baidu.com%s" % lrc
                   ^
./src/you_get/extractors/zhibo.py:37:8: F632 use ==/!= to compare str, bytes, and int literals
    if is_live is not "1":
       ^
./src/you_get/extractors/douyutv.py:65:8: F632 use ==/!= to compare str, bytes, and int literals
    if server_status is not 0:
       ^
./src/you_get/extractors/douyutv.py:70:8: F632 use ==/!= to compare str, bytes, and int literals
    if show_status is not "1":
       ^
./src/you_get/extractors/panda.py:28:8: F632 use ==/!= to compare str, bytes, and int literals
    if status is not "2":
       ^
5     F632 use ==/!= to compare str, bytes, and int literals
5
```