### PR TITLE
add --skip-ignore-size function to skip the file size check

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -131,7 +131,7 @@ SITES = {
 dry_run = False
 json_output = False
 force = False
-skip_ignore_size = False
+skip_existing_file_size_check = False
 player = None
 extractor_proxy = None
 cookies = None
@@ -634,11 +634,11 @@ def url_save(
     while continue_renameing:
         continue_renameing = False
         if os.path.exists(filepath):
-            if not force and (file_size == os.path.getsize(filepath) or skip_ignore_size):
+            if not force and (file_size == os.path.getsize(filepath) or skip_existing_file_size_check):
                 if not is_part:
                     if bar:
                         bar.done()
-                    if skip_ignore_size:
+                    if skip_existing_file_size_check:
                         log.w(
                             'Skipping {} without checking size: file already exists'.format(
                                 tr(os.path.basename(filepath))
@@ -954,8 +954,8 @@ def download_urls(
     if total_size:
         if not force and os.path.exists(output_filepath) and not auto_rename\
                 and (os.path.getsize(output_filepath) >= total_size * 0.9\
-                or skip_ignore_size):
-            if skip_ignore_size:
+                or skip_existing_file_size_check):
+            if skip_existing_file_size_check:
                 log.w('Skipping %s without checking size: file already exists' % output_filepath)
             else:
                 log.w('Skipping %s: file already exists' % output_filepath)
@@ -1468,7 +1468,7 @@ def script_main(download, download_playlist, **kwargs):
         help='Force overwriting existing files'
     )
     download_grp.add_argument(
-        '--skip-ignore-size', action='store_true', default=False,
+        '--skip-existing-file-size-check', action='store_true', default=False,
         help='Skip existing file without checking file size'
     )
     download_grp.add_argument(
@@ -1557,7 +1557,7 @@ def script_main(download, download_playlist, **kwargs):
         logging.getLogger().setLevel(logging.DEBUG)
 
     global force
-    global skip_ignore_size
+    global skip_existing_file_size_check
     global dry_run
     global json_output
     global player
@@ -1571,8 +1571,8 @@ def script_main(download, download_playlist, **kwargs):
     info_only = args.info
     if args.force:
         force = True
-    if args.skip_ignore_size:
-        skip_ignore_size = True
+    if args.skip_existing_file_size_check:
+        skip_existing_file_size_check = True
     if args.auto_rename:
         auto_rename = True
     if args.url:


### PR DESCRIPTION
Hi,

Issue and Usage Scenarios:

Due to ffmpeg version and different format of downloaded parts, sometimes the merge of video parts can fail. This will result in 0 bytes merged files. 

When running you-get again, you-get will check the merged file. Although the merged file exists, it's length is 0 bytes and you-get will try to re-download the video parts and re-merge the file. This is for fault tolerance and continues downloading feature, but sometimes, this can be inconvenient.

For example:

I am trying to download 10000+ videos from YouTube. I need to download as many as possible. But the network is not stable and my ffmpeg fails to merge some of the videos. So I run you-get with the 10000+ URLs and get some successfully merged files, some failed merged files and some partially downloaded video parts.

After the first run, I need to continue to download the partially downloaded videos and skip the failed merge ones. But you-get will still try to re-download the failed merge ones.

Solution:

Added an option argument: --skip-ignore-size. When using this argument, you-get will skip the existing files without checking the file size.

Thank you.

您好，

问题描述：

有时由于ffmpeg版本问题或者下载视频的格式问题，最后的合并过程会失败。这会产生一个大小为0字节的结果文件。
如果这时重新运行you-get，you-get可以检查到结果文件已存在，但是由于文件大小为0字节，you-get依然会尝试去重新下载、重新合并文件。这是为了错误容忍和断点续传功能，但有时有一点不方便。

比如：
我最近需要从YouTube下载10000+的视频。只需要下载尽量多的视频就可以。但我的网络不是很稳定，而且由于ffmpeg的问题，有些视频会合并失败。当我对10000+的视频url执行一遍you-get后，产生了三种结果：一些视频成功了，一些合并失败了，一些由于网络原因只下载了一部分。这时我又运行了第二遍you-get，you-get依然会尝试下载、合并那些由于ffmpeg而合并失败的视频。

解决方案：

增加了一个 --skip-ignore-size参数，当设置这个选项时，you-get会跳过检查文件的步骤，直接通过文件是否存在来判断是否跳过下载过程。

谢谢。