### PR TITLE
fixed kugou mp3 download failed

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -894,7 +894,7 @@ def get_output_filename(urls, title, ext, output_dir, merge, **kwargs):
         if kwargs.get('part', -1) >= 0:
             result = '%s[%02d]' % (result, kwargs.get('part'))
         if ext:
-            result = result + '.' + ext
+            result = '%s.%s' % (result, ext)
         return result
 
     merged_ext = ext
@@ -912,7 +912,11 @@ def get_output_filename(urls, title, ext, output_dir, merge, **kwargs):
                 merged_ext = 'mkv'
             else:
                 merged_ext = 'ts'
-    return '%s.%s' % (title, merged_ext)
+    result = title
+    if kwargs.get('part', -1) >= 0:
+        result = '%s[%02d]' % (result, kwargs.get('part'))
+    result = '%s.%s' % (result, merged_ext)
+    return result
 
 def print_user_agent(faker=False):
     urllib_default_user_agent = 'Python-urllib/%d.%d' % sys.version_info[:2]

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -878,13 +878,16 @@ class DummyProgressBar:
         pass
 
 
-def get_output_filename(urls, title, ext, output_dir, merge):
+def get_output_filename(urls, title, ext, output_dir, merge, **kwargs):
     # lame hack for the --output-filename option
     global output_filename
     if output_filename:
+        result = output_filename
+        if kwargs.get('part', -1) >= 0:
+            result = '%s[%02d]' % (result, kwargs.get('part'))
         if ext:
-            return output_filename + '.' + ext
-        return output_filename
+            result = result + '.' + ext
+        return result
 
     merged_ext = ext
     if (len(urls) > 1) and merge:
@@ -964,16 +967,16 @@ def download_urls(
         bar.done()
     else:
         parts = []
-        print('Downloading %s.%s ...' % (tr(title), ext))
+        print('Downloading %s ...' % tr(output_filename))
         bar.update()
         for i, url in enumerate(urls):
-            filename = '%s[%02d].%s' % (title, i, ext)
-            filepath = os.path.join(output_dir, filename)
-            parts.append(filepath)
+            output_filename_i = get_output_filename(urls, title, ext, output_dir, merge, part=i)
+            output_filepath_i = os.path.join(output_dir, output_filename_i)
+            parts.append(output_filepath_i)
             # print 'Downloading %s [%s/%s]...' % (tr(filename), i + 1, len(urls))
             bar.update_piece(i + 1)
             url_save(
-                url, filepath, bar, refer=refer, is_part=True, faker=faker,
+                url, output_filepath_i, bar, refer=refer, is_part=True, faker=faker,
                 headers=headers, **kwargs
             )
         bar.done()

--- a/src/you_get/extractors/acfun.py
+++ b/src/you_get/extractors/acfun.py
@@ -109,9 +109,9 @@ def acfun_download_by_vid(vid, title, output_dir='.', merge=True, info_only=Fals
             pass
 
 def acfun_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
-    assert re.match(r'http://[^\.]*\.*acfun\.[^\.]+/(\D|bangumi)/\D\D(\d+)', url)
+    assert re.match(r'https?://[^\.]*\.*acfun\.[^\.]+/(\D|bangumi)/\D\D(\d+)', url)
 
-    if re.match(r'http://[^\.]*\.*acfun\.[^\.]+/\D/\D\D(\d+)', url):
+    if re.match(r'https?://[^\.]*\.*acfun\.[^\.]+/\D/\D\D(\d+)', url):
         html = get_content(url)
         title = r1(r'data-title="([^"]+)"', html)
         if match1(url, r'_(\d+)$'):  # current P
@@ -119,7 +119,7 @@ def acfun_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
         vid = r1('data-vid="(\d+)"', html)
         up = r1('data-name="([^"]+)"', html)
     # bangumi
-    elif re.match("http://[^\.]*\.*acfun\.[^\.]+/bangumi/ab(\d+)", url):
+    elif re.match("https?://[^\.]*\.*acfun\.[^\.]+/bangumi/ab(\d+)", url):
         html = get_content(url)
         title = match1(html, r'"title"\s*:\s*"([^"]+)"')
         if match1(url, r'_(\d+)$'):  # current P


### PR DESCRIPTION
下载 kugou mp3失败，加上 -d 开关，显示

you-get -d 'http://www.kugou.com/song/#hash=529A30C3F0111E54B6D3F900A313E5EF&album_id=21010416'
[DEBUG] get_response: http://www.kugou.com/yy/index.php?r=play/getdata&hash=529A30C3F0111E54B6D3F900A313E5EF&album_id=21010416
you-get: version 0.4.1270, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['http://www.kugou.com/song/#hash=529A30C3F0111E54B6D3F900A313E5EF&album_id=21010416'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "/usr/local/bin/you-get", line 11, in <module>
    load_entry_point('you-get==0.4.1270', 'console_scripts', 'you-get')()
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/common.py", line 1714, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/common.py", line 1602, in script_main
    **extra
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/common.py", line 1275, in download_main
    download(url, **kwargs)
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/common.py", line 1705, in any_download
    m.download(url, **kwargs)
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/extractors/kugou.py", line 24, in kugou_download
    return kugou_download_by_hash(url,output_dir,merge,info_only)
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/extractors/kugou.py", line 38, in kugou_download_by_hash
    url = j['data']['play_url']
TypeError: list indices must be integers or slices, not str