### PR TITLE
fixed kugou download failure

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -144,6 +144,7 @@ fake_headers = {
     'Accept-Charset': 'UTF-8,*;q=0.5',
     'Accept-Encoding': 'gzip,deflate,sdch',
     'Accept-Language': 'en-US,en;q=0.8',
+    'Cookie': 'kg_mid=6b51749a6a9be5b85f19623d46ea8c0b;',
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:60.0) Gecko/20100101 Firefox/60.0',  # noqa
 }
 

--- a/src/you_get/extractors/kugou.py
+++ b/src/you_get/extractors/kugou.py
@@ -33,7 +33,7 @@ def kugou_download_by_hash(url,output_dir = '.', merge = True, info_only = False
     #url_sample:http://www.kugou.com/song/#hash=93F7D2FC6E95424739448218B591AEAF&album_id=9019462
     hash_val = match1(url,'hash=(\w+)')
     album_id = match1(url,'album_id=(\d+)')
-    html = get_html("http://www.kugou.com/yy/index.php?r=play/getdata&hash={}&album_id={}".format(hash_val,album_id))
+    html = get_html("http://www.kugou.com/yy/index.php?r=play/getdata&hash={}&album_id={}".format(hash_val,album_id), None, True)
     j =loads(html)
     url = j['data']['play_url']
     title = j['data']['audio_name']

--- a/tests/test.py
+++ b/tests/test.py
@@ -8,6 +8,7 @@ from you_get.extractors import (
     youtube,
     bilibili,
     toutiao,
+    kugou,
 )
 
 
@@ -29,6 +30,11 @@ class YouGetTests(unittest.TestCase):
         youtube.download('http://youtu.be/pzKerr0JIPA', info_only=True)
         youtube.download(
             'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
+            info_only=True
+        )
+    def test_kugou(self):
+        kugou.download(
+            'http://www.kugou.com/song/#hash=7841D696F28B57B3BA91CB23BC080A24&album_id=566329',  # noqa
             info_only=True
         )
 


### PR DESCRIPTION
kugou downloading is not working, it shows
`you-get -d 'http://www.kugou.com/song/#hash=529A30C3F0111E54B6D3F900A313E5EF&album_id=21010416'
[DEBUG] get_response: http://www.kugou.com/yy/index.php?r=play/getdata&hash=529A30C3F0111E54B6D3F900A313E5EF&album_id=21010416
you-get: version 0.4.1270, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['http://www.kugou.com/song/#hash=529A30C3F0111E54B6D3F900A313E5EF&album_id=21010416'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "/usr/local/bin/you-get", line 11, in <module>
    load_entry_point('you-get==0.4.1270', 'console_scripts', 'you-get')()
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/common.py", line 1714, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/common.py", line 1602, in script_main
    **extra
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/common.py", line 1275, in download_main
    download(url, **kwargs)
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/common.py", line 1705, in any_download
    m.download(url, **kwargs)
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/extractors/kugou.py", line 24, in kugou_download
    return kugou_download_by_hash(url,output_dir,merge,info_only)
  File "/usr/local/Cellar/you-get/0.4.1270/libexec/lib/python3.7/site-packages/you_get/extractors/kugou.py", line 38, in kugou_download_by_hash
    url = j['data']['play_url']
TypeError: list indices must be integers or slices, not str`

解决方法是在fake_headers里边添加
'Cookie': 'kg_mid=6b51749a6a9be5b85f19623d46ea8c0b;',
kg_mid可以是任意值
然后带上header来调用kugou的api