### PR TITLE
[tests] fail YouTube

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -30,6 +30,7 @@ class YouGetTests(unittest.TestCase):
             'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
             info_only=True
         )
+        youtube.download('https://www.youtube.com/watch?v=mY7zCALJ3aU', info_only=True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# you-get 'https://www.youtube.com/watch?v=MYZaXH6nSlA' --debug
[DEBUG] get_content: https://www.youtube.com/get_video_info?video_id=MYZaXH6nSlA&eurl=https%3A%2F%2Fy
[DEBUG] STATUS: ok
[DEBUG] get_content: https://www.youtube.com/watch?v=MYZaXH6nSlA
you-get: version 0.4.1302, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.youtube.com/watch?v=MYZaXH6nSlA'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "/usr/local/bin/you-get", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/usr/local/lib/python3.7/site-packages/you_get/common.py", line 1733, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/you_get/common.py", line 1621, in script_main
    **extra
  File "/usr/local/lib/python3.7/site-packages/you_get/common.py", line 1284, in download_main
    download(url, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/you_get/common.py", line 1724, in any_download
    m.download(url, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/you_get/extractor.py", line 48, in download_by_url
    self.prepare(**kwargs)
  File "/usr/local/lib/python3.7/site-packages/you_get/extractors/youtube.py", line 293, in prepare
    log.e('[Failed] %s' % player_response['playabilityStatus']['reason'], exit_code=1)
KeyError: 'reason'
