### PR TITLE
酷狗音乐无法正常下载及解决办法

### DIFF
--- a/src/you_get/extractors/kugou.py
+++ b/src/you_get/extractors/kugou.py
@@ -8,66 +8,72 @@ from base64 import b64decode
 import re
 import hashlib
 
+
 def kugou_download(url, output_dir=".", merge=True, info_only=False, **kwargs):
-    if url.lower().find("5sing")!=-1:
-        #for 5sing.kugou.com
-        html=get_html(url)
-        ticket=r1(r'"ticket":\s*"(.*)"',html)
-        j=loads(str(b64decode(ticket),encoding="utf-8"))
-        url=j['file']
-        title=j['songName']
+    if url.lower().find("5sing") != -1:
+        # for 5sing.kugou.com
+        html = get_html(url)
+        ticket = r1(r'"ticket":\s*"(.*)"', html)
+        j = loads(str(b64decode(ticket), encoding="utf-8"))
+        url = j['file']
+        title = j['songName']
         songtype, ext, size = url_info(url)
         print_info(site_info, title, songtype, size)
         if not info_only:
             download_urls([url], title, ext, size, output_dir, merge=merge)
-    elif url.lower().find("hash")!=-1:
-        return kugou_download_by_hash(url,output_dir,merge,info_only)
+    elif url.lower().find("hash") != -1:
+        return kugou_download_by_hash(url, output_dir, merge, info_only)
     else:
-        #for the www.kugou.com/
+        # for the www.kugou.com/
         return kugou_download_playlist(url, output_dir=output_dir, merge=merge, info_only=info_only)
         # raise NotImplementedError(url)       
 
 
-def kugou_download_by_hash(url,output_dir = '.', merge = True, info_only = False):
-    #sample
-    #url_sample:http://www.kugou.com/song/#hash=93F7D2FC6E95424739448218B591AEAF&album_id=9019462
-    hash_val = match1(url,'hash=(\w+)')
-    album_id = match1(url,'album_id=(\d+)')
-    html = get_html("http://www.kugou.com/yy/index.php?r=play/getdata&hash={}&album_id={}".format(hash_val,album_id))
-    j =loads(html)
+def kugou_download_by_hash(url, output_dir='.', merge=True, info_only=False):
+    # sample
+    # url_sample:http://www.kugou.com/song/#hash=93F7D2FC6E95424739448218B591AEAF&album_id=9019462
+    hash_val = match1(url, 'hash=(\w+)')
+    album_id = match1(url, 'album_id=(\d+)')
+    if not album_id:
+        album_id = 123
+    html = get_html("http://www.kugou.com/yy/index.php?r=play/getdata&hash={}&album_id={}&mid=123".format(hash_val, album_id))
+    j = loads(html)
     url = j['data']['play_url']
     title = j['data']['audio_name']
     # some songs cann't play because of copyright protection
-    if(url == ''):
+    if (url == ''):
         return
     songtype, ext, size = url_info(url)
     print_info(site_info, title, songtype, size)
     if not info_only:
         download_urls([url], title, ext, size, output_dir, merge=merge)
 
-def kugou_download_playlist(url, output_dir = '.', merge = True, info_only = False, **kwargs):
-    urls=[]
-    
-    #download music leaderboard
-    #sample: http://www.kugou.com/yy/html/rank.html
-    if url.lower().find('rank') !=-1:
-        html=get_html(url)
+
+def kugou_download_playlist(url, output_dir='.', merge=True, info_only=False, **kwargs):
+    urls = []
+
+    # download music leaderboard
+    # sample: http://www.kugou.com/yy/html/rank.html
+    if url.lower().find('rank') != -1:
+        html = get_html(url)
         pattern = re.compile('<a href="(http://.*?)" data-active=')
         res = pattern.findall(html)
         for song in res:
             res = get_html(song)
             pattern_url = re.compile('"hash":"(\w+)".*"album_id":(\d)+')
-            hash_val,album_id= res = pattern_url.findall(res)[0]
-            urls.append('http://www.kugou.com/song/#hash=%s&album_id=%s'%(hash_val,album_id))
-    
+            hash_val, album_id = res = pattern_url.findall(res)[0]
+            if not album_id:
+                album_id = 123
+            urls.append('http://www.kugou.com/song/#hash=%s&album_id=%s' % (hash_val, album_id))
+
     # download album
     # album sample:   http://www.kugou.com/yy/album/single/1645030.html
-    elif url.lower().find('album')!=-1:
+    elif url.lower().find('album') != -1:
         html = get_html(url)
         pattern = re.compile('var data=(\[.*?\]);')
         res = pattern.findall(html)[0]
         for v in json.loads(res):
-            urls.append('http://www.kugou.com/song/#hash=%s&album_id=%s'%(v['hash'],v['album_id']))
+            urls.append('http://www.kugou.com/song/#hash=%s&album_id=%s' % (v['hash'], v['album_id']))
 
     # download the playlist        
     # playlist sample:http://www.kugou.com/yy/special/single/487279.html
@@ -75,16 +81,15 @@ def kugou_download_playlist(url, output_dir = '.', merge = True, info_only = Fal
         html = get_html(url)
         pattern = re.compile('data="(\w+)\|(\d+)"')
         for v in pattern.findall(html):
-            urls.append('http://www.kugou.com/song/#hash=%s&album_id=%s'%(v[0],v[1]))
-            print('http://www.kugou.com/song/#hash=%s&album_id=%s'%(v[0],v[1]))
+            urls.append('http://www.kugou.com/song/#hash=%s&album_id=%s' % (v[0], v[1]))
+            print('http://www.kugou.com/song/#hash=%s&album_id=%s' % (v[0], v[1]))
 
-    #download the list by hash
+    # download the list by hash
     for url in urls:
-        kugou_download_by_hash(url,output_dir,merge,info_only)
+        kugou_download_by_hash(url, output_dir, merge, info_only)
 
-                
 
 site_info = "kugou.com"
 download = kugou_download
 # download_playlist = playlist_not_supported("kugou")
-download_playlist=kugou_download_playlist
+download_playlist = kugou_download_playlist

--- a/src/you_get/extractors/le.py
+++ b/src/you_get/extractors/le.py
@@ -2,20 +2,23 @@
 
 __all__ = ['letv_download', 'letvcloud_download', 'letvcloud_download_by_vu']
 
-import json
+import base64
+import hashlib
 import random
-import xml.etree.ElementTree as ET
-import base64, hashlib, urllib, time, re
+import urllib
 
 from ..common import *
 
-#@DEPRECATED
+
+# @DEPRECATED
 def get_timestamp():
     tn = random.random()
     url = 'http://api.letv.com/time?tn={}'.format(tn)
     result = get_content(url)
     return json.loads(result)['stime']
-#@DEPRECATED
+
+
+# @DEPRECATED
 def get_key(t):
     for s in range(0, 8):
         e = 1 & t
@@ -24,41 +27,39 @@ def get_key(t):
         t += e
     return t ^ 185025305
 
+
 def calcTimeKey(t):
-    ror = lambda val, r_bits, : ((val & (2**32-1)) >> r_bits%32) |  (val << (32-(r_bits%32)) & (2**32-1))
+    ror = lambda val, r_bits,: ((val & (2 ** 32 - 1)) >> r_bits % 32) | (val << (32 - (r_bits % 32)) & (2 ** 32 - 1))
     magic = 185025305
     return ror(t, magic % 17) ^ magic
-    #return ror(ror(t,773625421%13)^773625421,773625421%17)
+    # return ror(ror(t,773625421%13)^773625421,773625421%17)
 
 
 def decode(data):
     version = data[0:5]
     if version.lower() == b'vc_01':
-        #get real m3u8
+        # get real m3u8
         loc2 = data[5:]
         length = len(loc2)
-        loc4 = [0]*(2*length)
+        loc4 = [0] * (2 * length)
         for i in range(length):
-            loc4[2*i] = loc2[i] >> 4
-            loc4[2*i+1]= loc2[i] & 15;
-        loc6 = loc4[len(loc4)-11:]+loc4[:len(loc4)-11]
-        loc7 = [0]*length
+            loc4[2 * i] = loc2[i] >> 4
+            loc4[2 * i + 1] = loc2[i] & 15;
+        loc6 = loc4[len(loc4) - 11:] + loc4[:len(loc4) - 11]
+        loc7 = [0] * length
         for i in range(length):
-            loc7[i] = (loc6[2 * i] << 4) +loc6[2*i+1]
+            loc7[i] = (loc6[2 * i] << 4) + loc6[2 * i + 1]
         return ''.join([chr(i) for i in loc7])
     else:
         # directly return
-        return data
+        return str(data)
 
 
-
-
-def video_info(vid,**kwargs):
-    url = 'http://player-pc.le.com/mms/out/video/playJson?id={}&platid=1&splatid=101&format=1&tkey={}&domain=www.le.com&region=cn&source=1000&accesyx=1'.format(vid,calcTimeKey(int(time.time())))
+def video_info(vid, **kwargs):
+    url = 'http://player-pc.le.com/mms/out/video/playJson?id={}&platid=1&splatid=105&format=1&tkey={}&domain=www.le.com&region=cn&source=1000&accesyx=1'.format(vid, calcTimeKey(int(time.time())))
     r = get_content(url, decoded=False)
-    info=json.loads(str(r,"utf-8"))
+    info = json.loads(str(r, "utf-8"))
     info = info['msgs']
-
 
     stream_id = None
     support_stream_id = info["playurl"]["dispatch"].keys()
@@ -70,27 +71,28 @@ def video_info(vid,**kwargs):
         elif "720p" in support_stream_id:
             stream_id = '720p'
         else:
-            stream_id =sorted(support_stream_id,key= lambda i: int(i[1:]))[-1]
+            stream_id = sorted(support_stream_id, key=lambda i: int(i[1:]))[-1]
 
-    url =info["playurl"]["domain"][0]+info["playurl"]["dispatch"][stream_id][0]
+    url = info["playurl"]["domain"][0] + info["playurl"]["dispatch"][stream_id][0]
     uuid = hashlib.sha1(url.encode('utf8')).hexdigest() + '_0'
     ext = info["playurl"]["dispatch"][stream_id][1].split('.')[-1]
     url = url.replace('tss=0', 'tss=ios')
-    url+="&m3v=1&termid=1&format=1&hwtype=un&ostype=MacOS10.12.4&p1=1&p2=10&p3=-&expect=3&tn={}&vid={}&uuid={}&sign=letv".format(random.random(), vid, uuid)
+    url += "&m3v=1&termid=1&format=1&hwtype=un&ostype=MacOS10.12.4&p1=1&p2=10&p3=-&expect=3&tn={}&vid={}&uuid={}&sign=letv".format(random.random(), vid, uuid)
 
-    r2=get_content(url,decoded=False)
-    info2=json.loads(str(r2,"utf-8"))
+    r2 = get_content(url, decoded=False)
+    info2 = json.loads(str(r2, "utf-8"))
 
     # hold on ! more things to do
     # to decode m3u8 (encoded)
     suffix = '&r=' + str(int(time.time() * 1000)) + '&appid=500'
-    m3u8 = get_content(info2["location"]+suffix,decoded=False)
+    m3u8 = get_content(info2["location"] + suffix, decoded=False)
     m3u8_list = decode(m3u8)
-    urls = re.findall(r'^[^#][^\r]*',m3u8_list,re.MULTILINE)
-    return ext,urls
+    urls = re.findall(r'(http.*?)#', m3u8_list, re.MULTILINE)
+    return ext, urls
 
-def letv_download_by_vid(vid,title, output_dir='.', merge=True, info_only=False,**kwargs):
-    ext , urls = video_info(vid,**kwargs)
+
+def letv_download_by_vid(vid, title, output_dir='.', merge=True, info_only=False, **kwargs):
+    ext, urls = video_info(vid, **kwargs)
     size = 0
     for i in urls:
         _, _, tmp = url_info(i)
@@ -100,26 +102,28 @@ def letv_download_by_vid(vid,title, output_dir='.', merge=True, info_only=False,
     if not info_only:
         download_urls(urls, title, ext, size, output_dir=output_dir, merge=merge)
 
+
 def letvcloud_download_by_vu(vu, uu, title=None, output_dir='.', merge=True, info_only=False):
-    #ran = float('0.' + str(random.randint(0, 9999999999999999))) # For ver 2.1
-    #str2Hash = 'cfflashformatjsonran{ran}uu{uu}ver2.2vu{vu}bie^#@(%27eib58'.format(vu = vu, uu = uu, ran = ran)  #Magic!/ In ver 2.1
-    argumet_dict ={'cf' : 'flash', 'format': 'json', 'ran': str(int(time.time())), 'uu': str(uu),'ver': '2.2', 'vu': str(vu), }
-    sign_key = '2f9d6924b33a165a6d8b5d3d42f4f987'  #ALL YOUR BASE ARE BELONG TO US
+    # ran = float('0.' + str(random.randint(0, 9999999999999999))) # For ver 2.1
+    # str2Hash = 'cfflashformatjsonran{ran}uu{uu}ver2.2vu{vu}bie^#@(%27eib58'.format(vu = vu, uu = uu, ran = ran)  #Magic!/ In ver 2.1
+    argumet_dict = {'cf': 'flash', 'format': 'json', 'ran': str(int(time.time())), 'uu': str(uu), 'ver': '2.2', 'vu': str(vu), }
+    sign_key = '2f9d6924b33a165a6d8b5d3d42f4f987'  # ALL YOUR BASE ARE BELONG TO US
     str2Hash = ''.join([i + argumet_dict[i] for i in sorted(argumet_dict)]) + sign_key
     sign = hashlib.md5(str2Hash.encode('utf-8')).hexdigest()
-    request_info = urllib.request.Request('http://api.letvcloud.com/gpc.php?' + '&'.join([i + '=' + argumet_dict[i] for i in argumet_dict]) + '&sign={sign}'.format(sign = sign))
+    request_info = urllib.request.Request('http://api.letvcloud.com/gpc.php?' + '&'.join([i + '=' + argumet_dict[i] for i in argumet_dict]) + '&sign={sign}'.format(sign=sign))
     response = urllib.request.urlopen(request_info)
     data = response.read()
     info = json.loads(data.decode('utf-8'))
     type_available = []
     for video_type in info['data']['video_info']['media']:
         type_available.append({'video_url': info['data']['video_info']['media'][video_type]['play_url']['main_url'], 'video_quality': int(info['data']['video_info']['media'][video_type]['play_url']['vtype'])})
-    urls = [base64.b64decode(sorted(type_available, key = lambda x:x['video_quality'])[-1]['video_url']).decode("utf-8")]
+    urls = [base64.b64decode(sorted(type_available, key=lambda x: x['video_quality'])[-1]['video_url']).decode("utf-8")]
     size = urls_size(urls)
     ext = 'mp4'
     print_info(site_info, title, ext, size)
     if not info_only:
         download_urls(urls, title, ext, size, output_dir=output_dir, merge=merge)
+
 
 def letvcloud_download(url, output_dir='.', merge=True, info_only=False):
     qs = parse.urlparse(url).query
@@ -128,7 +132,8 @@ def letvcloud_download(url, output_dir='.', merge=True, info_only=False):
     title = "LETV-%s" % vu
     letvcloud_download_by_vu(vu, uu, title=title, output_dir=output_dir, merge=merge, info_only=info_only)
 
-def letv_download(url, output_dir='.', merge=True, info_only=False ,**kwargs):
+
+def letv_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
     url = url_locations([url])[0]
     if re.match(r'http://yuntv.letv.com/', url):
         letvcloud_download(url, output_dir=output_dir, merge=merge, info_only=info_only)
@@ -136,14 +141,15 @@ def letv_download(url, output_dir='.', merge=True, info_only=False ,**kwargs):
         html = get_content(url)
         vid = match1(url, r'video/(\d+)\.html')
         title = match1(html, r'<h2 class="title">([^<]+)</h2>')
-        letv_download_by_vid(vid, title=title, output_dir=output_dir, merge=merge, info_only=info_only,**kwargs)
+        letv_download_by_vid(vid, title=title, output_dir=output_dir, merge=merge, info_only=info_only, **kwargs)
     else:
         html = get_content(url)
         vid = match1(url, r'http://www.letv.com/ptv/vplay/(\d+).html') or \
-            match1(url, r'http://www.le.com/ptv/vplay/(\d+).html') or \
-            match1(html, r'vid="(\d+)"')
-        title = match1(html,r'name="irTitle" content="(.*?)"')
-        letv_download_by_vid(vid, title=title, output_dir=output_dir, merge=merge, info_only=info_only,**kwargs)
+              match1(url, r'http://www.le.com/ptv/vplay/(\d+).html') or \
+              match1(html, r'vid="(\d+)"')
+        title = match1(html, r'name="irTitle" content="(.*?)"')
+        letv_download_by_vid(vid, title=title, output_dir=output_dir, merge=merge, info_only=info_only, **kwargs)
+
 
 site_info = "Le.com"
 download = letv_download


### PR DESCRIPTION
kugou downloading is not working, it shows
you-get -d http://www.kugou.com/song/#hash=529A30C3F0111E54B6D3F900A313E5EF&
album_id=21010416
[DEBUG] get_response: http://www.kugou.com/yy/index.php?r=play/getdata&hash=529A
30C3F0111E54B6D3F900A313E5EF&album_id=None
you-get: version 0.4.1314, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['http://www.kugou.com/song/#hash=529A30C3F0111E54B6D3F90
0A313E5EF'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None,
force=False, format=None, help=False, http_proxy=None, info=False, input_file=No
ne, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_
proxy=False, output_dir='.', output_filename=None, password=None, player=None, p
laylist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=Non
e, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "e:\ruanjian2\python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "e:\ruanjian2\python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "E:\ruanjian2\python37\Scripts\you-get.exe\__main__.py", line 9, in <modu
le>
  File "e:\ruanjian2\python37\lib\site-packages\you_get\__main__.py", line 92, i
n main
    main(**kwargs)
  File "e:\ruanjian2\python37\lib\site-packages\you_get\common.py", line 1759, i
n main
    script_main(any_download, any_download_playlist, **kwargs)
  File "e:\ruanjian2\python37\lib\site-packages\you_get\common.py", line 1647, i
n script_main
    **extra
  File "e:\ruanjian2\python37\lib\site-packages\you_get\common.py", line 1303, i
n download_main
    download(url, **kwargs)
  File "e:\ruanjian2\python37\lib\site-packages\you_get\common.py", line 1750, i
n any_download
    m.download(url, **kwargs)
  File "e:\ruanjian2\python37\lib\site-packages\you_get\extractors\kugou.py", li
ne 24, in kugou_download
    return kugou_download_by_hash(url,output_dir,merge,info_only)
  File "e:\ruanjian2\python37\lib\site-packages\you_get\extractors\kugou.py", li
ne 38, in kugou_download_by_hash
    url = j['data']['play_url']
TypeError: list indices must be integers or slices, not str
'album_id' 不是内部或外部命令，也不是可运行的程序
或批处理文件。

问题原因:
1. 获取音视频及相关数据接口的参数中缺少参数mid
2. 通过you-get命令请求时参数URL需要加入引号，否则&及后面的内容会被注释掉,以酷狗音乐为例, album_id参数会被注释掉

解决方法及作出的修改:
1. 经过测试, 接口中的mid及album_id参数在后台校验时只检查了是否存在该参数, 不会校验该参数是否正确， 故给出一个默认值来获取数据
2. 修正代码规范
3. 修正letv中重复导入的模块

经测试修改后酷狗音乐已经可以正常下载