### PR TITLE
A request

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -30,6 +30,7 @@ class YouGetTests(unittest.TestCase):
         youtube.download(
             'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
             info_only=True
+        youtube.download('https://www.youtube.com/watch?v=bIa_KngQB1s&pbjreload=10', info_only=True)    
         )
 
 


### PR DESCRIPTION
I have a small request:
  Can we just download videos like this , for example    `you-get https://www.youtube.com`
  Instead of `you-get 'https://www.youtube.com'`
Can we remove the `' ' `here ?
Because when I want to download a video , I would copy from browser and just paste behind `you-get`, and it would not be convenient if I add `' '`
Thanks