### PR TITLE
biliili failing to download vip-only bangumis

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -12,26 +12,8 @@ from you_get.extractors import (
 
 
 class YouGetTests(unittest.TestCase):
-    def test_imgur(self):
-        imgur.download('http://imgur.com/WVLk5nD', info_only=True)
-        imgur.download('http://imgur.com/gallery/WVLk5nD', info_only=True)
-
-    def test_magisto(self):
-        magisto.download(
-            'http://www.magisto.com/album/video/f3x9AAQORAkfDnIFDA',
-            info_only=True
-        )
-
-    def test_youtube(self):
-        youtube.download(
-            'http://www.youtube.com/watch?v=pzKerr0JIPA', info_only=True
-        )
-        youtube.download('http://youtu.be/pzKerr0JIPA', info_only=True)
-        youtube.download(
-            'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
-            info_only=True
-        )
-
+    def test_bilibili(self):
+        bilibili.download('https://www.bilibili.com/bangumi/play/ep259653/',info_only=True)#未加入cookie，但即使加入cookie效果也一样
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
我在下载b站上仅限大会员的番剧时出现了错误，输出如下
```
you-get https://www.bilibili.com/bangumi/play/ep259654 -i -c cookies-bilibili-com.txt --debug
[DEBUG] get_content: https://www.bilibili.com/bangumi/play/ep259654
you-get: This bangumi currently has 13 videos. (use --playlist to download all videos.)
[DEBUG] get_content: https://api.bilibili.com/pgc/player/web/playurl?avid=40813785&cid=71685308&qn=0&type=&otype=json&ep_id=259654&fnver=0&fnval=16
you-get: 大会员专享限制
site:                Bilibili
title:               天使降临到我身边：第2话 超级无敌可爱
streams:             # Available quality and codecs
```
同时通过同样的cookie我却可以下载1080p+画质的视频，因此我认为我执行上述命令时使用的cookie有效。即使我在日常使用的浏览器上带着登录大会员的cookie访问debug信息中的api链接，也仍然收到了错误提示，json内容如下，且这则提示的出现似乎与浏览器是否带有已登录的cookie无关。
```
{"code":-10403,"message":"大会员专享限制"}
```
也许是解析器调用的api出现了一些变化，但我没有能力去修改代码修复。
