### PR TITLE
修复快手直播无法下载的问题

### DIFF
--- a/src/you_get/extractors/kuaishou.py
+++ b/src/you_get/extractors/kuaishou.py
@@ -16,11 +16,14 @@ def kuaishou_download_by_url(url, info_only=False, **kwargs):
     # size = video_list[-1]['size']
     # result wrong size
     try:
-        og_video_url = re.search(r"<meta\s+property=\"og:video:url\"\s+content=\"(.+?)\"/>", page).group(1)
-        video_url = og_video_url
-        title = url.split('/')[-1]
+        search_result=re.search(r"\"playUrls\":\[(\{\"quality\"\:\"\w+\",\"url\":\".*?\"\})+\]", page)
+        all_video_info_str = search_result.group(1)
+        all_video_infos=re.findall(r"\{\"quality\"\:\"(\w+)\",\"url\":\"(.*?)\"\}", all_video_info_str)
+        # get the one of the best quality
+        video_url = all_video_infos[0][1].encode("utf-8").decode('unicode-escape')
+        title = re.search(r"<meta charset=UTF-8><title>(.*?)</title>", page).group(1)
         size = url_size(video_url)
-        video_format = video_url.split('.')[-1]
+        video_format = "flv"#video_url.split('.')[-1]
         print_info(site_info, title, video_format, size)
         if not info_only:
             download_urls([video_url], title, video_format, size, **kwargs)


### PR DESCRIPTION
快手似乎不把视频url放在meta标签里了, 目前直播视频url存放在网页最后的json中.
解决方法:
1. regex找到当前直播对应的视频url列表
2. 找出最高画质版本对应的url, 这里还处理url中通过utf-8编码的特殊字符
3. 查找第一个title标签找到直播标题