### PR TITLE
wanmen download error (2019/07/16)

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -8,6 +8,7 @@ from you_get.extractors import (
     youtube,
     bilibili,
     toutiao,
+    wanmen,
 )
 
 
@@ -30,6 +31,10 @@ class YouGetTests(unittest.TestCase):
         youtube.download(
             'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
             info_only=True
+        )
+
+    def test_wanmen(self):
+        wanmen.download('https://www.wanmen.org/courses/594a394da576087ecbe5ccd6/lectures/596f0b58c4e8e41da1410f47', info_only=True)
         )
 
 


### PR DESCRIPTION
Debug information is here.

```
>you-get https://www.wanmen.org/courses/594a394da576087ecbe5ccd6/lectures/596f0b58c4e8e41da1410f47 --debug
you-get: version 0.4.1314, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.wanmen.org/courses/594a394da576087ecbe5ccd6/lectures/596f0b58c4e8e41da1410f47'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "c:\users\shin\appdata\local\programs\python\python36\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\users\shin\appdata\local\programs\python\python36\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\Shin\AppData\Local\Programs\Python\Python36\Scripts\you-get.exe\__main__.py", line 9, in <module>
  File "c:\users\shin\appdata\local\programs\python\python36\lib\site-packages\you_get\__main__.py", line 92, in main
    main(**kwargs)
  File "c:\users\shin\appdata\local\programs\python\python36\lib\site-packages\you_get\common.py", line 1759, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "c:\users\shin\appdata\local\programs\python\python36\lib\site-packages\you_get\common.py", line 1647, in script_main
    **extra
  File "c:\users\shin\appdata\local\programs\python\python36\lib\site-packages\you_get\common.py", line 1303, in download_main
    download(url, **kwargs)
  File "c:\users\shin\appdata\local\programs\python\python36\lib\site-packages\you_get\common.py", line 1750, in any_download
    m.download(url, **kwargs)
  File "c:\users\shin\appdata\local\programs\python\python36\lib\site-packages\you_get\extractors\wanmen.py", line 94, in wanmen_download
    courseID = int(match1(url, r'course\/(\d+)'))
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'

```