### PR TITLE
Fix bug: unable get video title

### DIFF
--- a/src/you_get/extractors/youtube.py
+++ b/src/you_get/extractors/youtube.py
@@ -207,8 +207,7 @@ class YouTube(VideoExtractor):
             raise
         elif video_info['status'] == ['ok']:
             if 'use_cipher_signature' not in video_info or video_info['use_cipher_signature'] == ['False']:
-                self.title = parse.unquote_plus(video_info['title'][0])
-
+                self.title = parse.unquote_plus(json.loads(video_info["player_response"][0])["videoDetails"]["title"])
                 # Parse video page (for DASH)
                 video_page = get_content('https://www.youtube.com/watch?v=%s' % self.vid)
                 try:
@@ -229,7 +228,7 @@ class YouTube(VideoExtractor):
                 video_page = get_content('https://www.youtube.com/watch?v=%s' % self.vid)
                 ytplayer_config = json.loads(re.search('ytplayer.config\s*=\s*([^\n]+?});', video_page).group(1))
 
-                self.title = ytplayer_config['args']['title']
+                self.title = json.loads(ytplayer_config["args"]["player_response"])["videoDetails"]["title"]
                 self.html5player = 'https://www.youtube.com' + ytplayer_config['assets']['js']
                 stream_list = ytplayer_config['args']['url_encoded_fmt_stream_map'].split(',')
 


### PR DESCRIPTION
[DEBUG] get_content: https://www.youtube.com/get_video_info?video_id=ZTwBlWGHRRE&eurl=https%3A%2F%2Fy
[DEBUG] STATUS: ok
you-get: version 0.4.1314, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.youtube.com/watch?v=ZTwBlWGHRRE'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "/Users/mingjun.luo/anaconda3/bin/you-get", line 10, in <module>
    sys.exit(main())
  File "/Users/mingjun.luo/anaconda3/lib/python3.7/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/Users/mingjun.luo/anaconda3/lib/python3.7/site-packages/you_get/common.py", line 1759, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/Users/mingjun.luo/anaconda3/lib/python3.7/site-packages/you_get/common.py", line 1647, in script_main
    **extra
  File "/Users/mingjun.luo/anaconda3/lib/python3.7/site-packages/you_get/common.py", line 1303, in download_main
    download(url, **kwargs)
  File "/Users/mingjun.luo/anaconda3/lib/python3.7/site-packages/you_get/common.py", line 1750, in any_download
    m.download(url, **kwargs)
  File "/Users/mingjun.luo/anaconda3/lib/python3.7/site-packages/you_get/extractor.py", line 48, in download_by_url
    self.prepare(**kwargs)
  File "/Users/mingjun.luo/anaconda3/lib/python3.7/site-packages/you_get/extractors/youtube.py", line 210, in prepare
    self.title = parse.unquote_plus(video_info['title'][0])
KeyError: 'title'