### PR TITLE
Fix AcFun Bangumi download.

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Use `--url`/`-u` to get a list of downloadable resource URLs extracted from the 
 | **niconico<br/>ニコニコ動画** | <http://www.nicovideo.jp/> |✓| | |
 | **163<br/>网易视频<br/>网易云音乐** | <http://v.163.com/><br/><http://music.163.com/> |✓| |✓|
 | 56网     | <http://www.56.com/>           |✓| | |
-| **AcFun** | <http://www.acfun.tv/>        |✓| | |
+| **AcFun** | <http://www.acfun.cn/>        |✓| | |
 | **Baidu<br/>百度贴吧** | <http://tieba.baidu.com/> |✓|✓| |
 | 爆米花网 | <http://www.baomihua.com/>     |✓| | |
 | **bilibili<br/>哔哩哔哩** | <http://www.bilibili.com/> |✓| | |

--- a/src/you_get/extractors/acfun.py
+++ b/src/you_get/extractors/acfun.py
@@ -124,10 +124,11 @@ def acfun_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
     # bangumi
     elif re.match("https?://[^\.]*\.*acfun\.[^\.]+/bangumi/ab(\d+)", url):
         html = get_content(url)
-        title = match1(html, r'"title"\s*:\s*"([^"]+)"')
-        if match1(url, r'_(\d+)$'):  # current P
-            title = title + " " + r1(r'active">([^<]*)', html)
-        vid = match1(html, r'videoId="(\d+)"')
+        tag_script = match1(html, r'<script>window\.pageInfo([^<]+)</script>')
+        json_text = tag_script[tag_script.find('{') : tag_script.find('};') + 1]
+        json_data = json.loads(json_text)
+        title = json_data['bangumiTitle'] + " " + json_data['episodeName'] + " " + json_data['title']
+        vid = str(json_data['videoId'])
         up = "acfun"
     else:
         raise NotImplemented
@@ -148,6 +149,6 @@ def acfun_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
                           **kwargs)
 
 
-site_info = "AcFun.tv"
+site_info = "AcFun.cn"
 download = acfun_download
 download_playlist = playlist_not_supported('acfun')


### PR DESCRIPTION
修复A站番剧下载，之前的方式已经不能用了。顺便改了域名`acfun.tv`→`acfun.cn`。