### PR TITLE
modify encoding with open cookies file

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -1317,7 +1317,7 @@ def load_cookies(cookiefile):
         cookies = cookiejar.MozillaCookieJar()
         now = time.time()
         ignore_discard, ignore_expires = False, False
-        with open(cookiefile, 'r') as f:
+        with open(cookiefile, 'r', encoding='utf-8') as f:
             for line in f:
                 # last field may be absent, so keep any trailing tab
                 if line.endswith("\n"): line = line[:-1]


### PR DESCRIPTION
fix a bug for reading cookies.txt：the UnicodeDecodeError, if cookies.txt include Chinese characters
Example：
cookies.txt include：.v.qq.com       TRUE    /       FALSE   0       ptag    www_baidu_com|movie_v3_new:img:扫毒2天地对决。
The Error：UnicodeDecodeError: 'ascii' codec can't decode byte 0xe6 in position 4935: ordinal not in range(128)
