### PR TITLE
腾讯视频的水印问题

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -8,6 +8,7 @@ from you_get.extractors import (
     youtube,
     bilibili,
     toutiao,
+    qq
 )
 
 
@@ -31,6 +32,9 @@ class YouGetTests(unittest.TestCase):
             'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
             info_only=True
         )
+
+    def test_qq_watermark(self):
+        qq.download('https://v.qq.com/x/cover/er0k7wjhbw8f4vj/u0032d5jt2i.html',info_only=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
例如：https://v.qq.com/x/cover/er0k7wjhbw8f4vj/u0032d5jt2i.html
我在Chrome里找TS流链接下载到的是没有水印的视频，但是用you-get下载到的就是有水印的（视频右上角有腾讯视频的Logo），有没有办法下载到不带水印的版本？