### PR TITLE
Update bilibili.py

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -159,6 +159,8 @@ class Bilibili(VideoExtractor):
             sort = 'vc'
         elif re.match(r'https?://(www\.)?bilibili\.com/video/av(\d+)', self.url):
             sort = 'video'
+        elif re.match(r'https?://b23\.tv/av(\%d+)', self.url):
+            sort = 'video'
         else:
             self.download_playlist_by_url(self.url, **kwargs)
             return


### PR DESCRIPTION
I made a little edit to support bilibili shortlink ('https://b23.tv/av'+avid, e.g. https://b23.tv/av13539757).
It may useless on Computer.
Currently able to use with Termux on my phone.
After Edit:
> $ ~/codesp/you-get/you-get https://b23.tv/av13539757
site:                Bilibili
title:               【超清】60fps最高画质 Daisuke 完整版
stream:
    - format:        flv
      container:     flv
      quality:       高清 1080P
      size:          63.3 MiB (66392705 bytes)
    # download-with: you-get --format=flv [URL]
>
> Downloading 【超清】60fps最高画质 Daisuke 完整版.flv ...
 100% ( 63.3/ 63.3MB) ├█████████████████████████████████████████████████████████████┤[1/1]   12 MB/s
>
>Downloading 【超清】60fps最高画质 Daisuke 完整版.cmt.xml ...