### PR TITLE
[ixigua] Fix error of matching title

### DIFF
--- a/src/you_get/extractors/ixigua.py
+++ b/src/you_get/extractors/ixigua.py
@@ -82,7 +82,7 @@ def ixigua_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
     # example url: https://www.ixigua.com/i6631065141750268420/#mid=63024814422
     html = get_html(url, faker=True)
     video_id = match1(html, r"\"vid\":\"([^\"]+)")
-    title = match1(html, r"\"player__videoTitle\"><h1>(.*)<\/h1><\/div>")
+    title = match1(html, r"\"player__videoTitle\">.*?<h1.*?>(.*)<\/h1><\/div>")
     if not video_id:
         log.e("video_id not found, url:{}".format(url))
         return


### PR DESCRIPTION
The ixigua downloading fails now:
```
$ you-get "https://www.ixigua.com/i6631065141750268420/\#mid\=63024814422"  --debug
[DEBUG] get_response: https://www.ixigua.com/i6631065141750268420/\#mid\=63024814422
[DEBUG] get_content: https://ib.365yg.com/video/urls/v/1/toutiao/mp4/v02004ad0000bg3477ik781ngjvbjbs0?r=32159770337169047&s=462489322
you-get: version 0.4.1347, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.ixigua.com/i6631065141750268420/\\#mid\\=63024814422'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Site:       ixigua.com
Traceback (most recent call last):
  File "/usr/local/bin/you-get", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/usr/local/lib/python3.7/site-packages/you_get/common.py", line 1758, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/you_get/common.py", line 1646, in script_main
    **extra
  File "/usr/local/lib/python3.7/site-packages/you_get/common.py", line 1302, in download_main
    download(url, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/you_get/common.py", line 1749, in any_download
    m.download(url, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/you_get/extractors/ixigua.py", line 108, in ixigua_download
    print_info(site_info=site_info, title=title, type="mp4", size=size)  # 该网站只有mp4类型文件
  File "/usr/local/lib/python3.7/site-packages/you_get/common.py", line 1209, in print_info
    maybe_print('Title:     ', unescape_html(tr(title)))
  File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/html/__init__.py", line 130, in unescape
    if '&' not in s:
TypeError: argument of type 'NoneType' is not iterable
```
The html content has changed, so fix the regex matching the title.
Test case: 
``` 
you-get https://www.ixigua.com/i6631065141750268420/\#mid\=63024814422 --debug
you-get https://www.ixigua.com/i6735756721496523272/  --debug
```
