### PR TITLE
fix ssl open url issue

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -22,6 +22,8 @@ from .util.strings import get_filename, unescape_html
 from . import json_output as json_output_
 sys.stdout = io.TextIOWrapper(sys.stdout.buffer,encoding='utf8')
 
+ssl._create_default_https_context = ssl._create_unverified_context
+
 SITES = {
     '163'              : 'netease',
     '56'               : 'w56',


### PR DESCRIPTION
我下载优酷的视频的时候得到如下错误:

> <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1076)>

经过查询可以简单修改:

> ssl._create_default_https_context = ssl._create_unverified_context

测试成功. 不过这个项目这么久了, 应该不至于ssl都没考虑到吧? 是我的环境有什么问题吗?