### PR TITLE
fix extractors\naver.py

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -66,6 +66,7 @@ SITES = {
     'iwara'            : 'iwara',
     'joy'              : 'joy',
     'kankanews'        : 'bilibili',
+    'kakao'            : 'kakao',
     'khanacademy'      : 'khan',
     'ku6'              : 'ku6',
     'kuaishou'         : 'kuaishou',
@@ -1520,7 +1521,6 @@ def script_main(download, download_playlist, **kwargs):
         '-a', '--auto-rename', action='store_true', default=False,
         help='Auto rename same name different files'
     )
-
     download_grp.add_argument(
         '-k', '--insecure', action='store_true', default=False,
         help='ignore ssl errors'
@@ -1604,7 +1604,6 @@ def script_main(download, download_playlist, **kwargs):
     if args.insecure:
         # ignore ssl
         insecure = True
-
 
     if args.no_proxy:
         set_http_proxy('')
@@ -1757,3 +1756,4 @@ def any_download_playlist(url, **kwargs):
 
 def main(**kwargs):
     script_main(any_download, any_download_playlist, **kwargs)
+

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -33,7 +33,10 @@ from .interest import *
 from .iqilu import *
 from .iqiyi import *
 from .joy import *
+from .khan import *
 from .ku6 import *
+from .kakao import *
+from .kuaishou import *
 from .kugou import *
 from .kuwo import *
 from .le import *
@@ -62,6 +65,7 @@ from .sina import *
 from .sohu import *
 from .soundcloud import *
 from .suntv import *
+from .ted import *
 from .theplatform import *
 from .tiktok import *
 from .tucao import *
@@ -81,9 +85,6 @@ from .yinyuetai import *
 from .yixia import *
 from .youku import *
 from .youtube import *
-from .ted import *
-from .khan import *
 from .zhanqi import *
-from .kuaishou import *
 from .zhibo import *
 from .zhihu import *

--- a/src/you_get/extractors/kakao.py
+++ b/src/you_get/extractors/kakao.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+from ..common import *
+from .universal import *
+
+__all__ = ['kakao_download']
+
+
+def kakao_download(url, output_dir='.', info_only=False,  **kwargs):
+    json_request_url = 'https://videofarm.daum.net/controller/api/closed/v1_2/IntegratedMovieData.json?vid={}'
+
+    # in this implementation playlist not supported so use url_without_playlist
+    # if want to support playlist need to change that
+    if re.search('playlistId', url):
+        url = re.search(r"(.+)\?.+?", url).group(1)
+
+    page = get_content(url)
+    try:
+        vid = re.search(r"<meta name=\"vid\" content=\"(.+)\">", page).group(1)
+        title = re.search(r"<meta name=\"title\" content=\"(.+)\">", page).group(1)
+
+        meta_str = get_content(json_request_url.format(vid))
+        meta_json = json.loads(meta_str)
+
+        standard_preset = meta_json['output_list']['standard_preset']
+        output_videos = meta_json['output_list']['output_list']
+        size = ''
+        for v in output_videos:
+            if v['preset'] == standard_preset:
+                size = int(v['filesize'])
+                break
+        video_url = meta_json['location']['url']
+
+        print_info(site_info, title, 'mp4', size)
+        if not info_only:
+            download_urls([video_url], title, 'mp4', size, output_dir, **kwargs)
+    except:
+        universal_download(url, output_dir, merge=kwargs['merge'], info_only=info_only, **kwargs)
+
+
+site_info = "tv.kakao.com"
+download = kakao_download
+download_playlist = playlist_not_supported('kakao')

--- a/src/you_get/extractors/naver.py
+++ b/src/you_get/extractors/naver.py
@@ -16,15 +16,8 @@ def naver_download_by_url(url, output_dir='.', merge=True, info_only=False, **kw
     ep = 'https://apis.naver.com/rmcnmv/rmcnmv/vod/play/v2.0/{}?key={}'
     page = get_content(url)
     try:
-        temp = re.search(r"<meta\s+property=\"og:video:url\"\s+content='(.+?)'>", page)
-        if temp is not None:
-            og_video_url = temp.group(1)
-            params_dict = urllib.parse.parse_qs(urllib.parse.urlparse(og_video_url).query)
-            vid = params_dict['vid'][0]
-            key = params_dict['outKey'][0]
-        else:
-            vid = re.search(r"\"videoId\"\s*:\s*\"(.+?)\"", page).group(1)
-            key = re.search(r"\"inKey\"\s*:\s*\"(.+?)\"", page).group(1)
+        vid = re.search(r"\"videoId\"\s*:\s*\"(.+?)\"", page).group(1)
+        key = re.search(r"\"inKey\"\s*:\s*\"(.+?)\"", page).group(1)
         meta_str = get_content(ep.format(vid, key))
         meta_json = json.loads(meta_str)
         if 'errorCode' in meta_json:
@@ -38,7 +31,7 @@ def naver_download_by_url(url, output_dir='.', merge=True, info_only=False, **kw
         size = url_size(video_url)
         print_info(site_info, title, 'mp4', size)
         if not info_only:
-            download_urls([video_url], title, 'mp4', size, **kwargs)
+            download_urls([video_url], title, 'mp4', size, output_dir, **kwargs)
     except:
         universal_download(url, output_dir, merge=merge, info_only=info_only, **kwargs)
 


### PR DESCRIPTION
The recent video on tv.naver was not downloaded, but only the wrong thumbnails were downloaded in the previous code. So I solved this problem by integrating the if-else statement into one.

It also resolved the problem of not being properly stored in the specified output_dir.

* example of wrong result
result of "you-get https://tv.naver.com/v/10984456"
only downloaded thumbnails no video
![thumnail](https://user-images.githubusercontent.com/36741818/69012438-2dc97a80-09b9-11ea-95e7-f3049e5f7230.JPG)


* can download this video correctly after code change
![correct](https://user-images.githubusercontent.com/36741818/69012615-1a1f1380-09bb-11ea-86fd-66e839a2971f.JPG)

