### PR TITLE
fix extractor naver.py

### DIFF
--- a/src/you_get/extractors/naver.py
+++ b/src/you_get/extractors/naver.py
@@ -16,15 +16,8 @@ def naver_download_by_url(url, output_dir='.', merge=True, info_only=False, **kw
     ep = 'https://apis.naver.com/rmcnmv/rmcnmv/vod/play/v2.0/{}?key={}'
     page = get_content(url)
     try:
-        temp = re.search(r"<meta\s+property=\"og:video:url\"\s+content='(.+?)'>", page)
-        if temp is not None:
-            og_video_url = temp.group(1)
-            params_dict = urllib.parse.parse_qs(urllib.parse.urlparse(og_video_url).query)
-            vid = params_dict['vid'][0]
-            key = params_dict['outKey'][0]
-        else:
-            vid = re.search(r"\"videoId\"\s*:\s*\"(.+?)\"", page).group(1)
-            key = re.search(r"\"inKey\"\s*:\s*\"(.+?)\"", page).group(1)
+        vid = re.search(r"\"videoId\"\s*:\s*\"(.+?)\"", page).group(1)
+        key = re.search(r"\"inKey\"\s*:\s*\"(.+?)\"", page).group(1)
         meta_str = get_content(ep.format(vid, key))
         meta_json = json.loads(meta_str)
         if 'errorCode' in meta_json:
@@ -38,7 +31,7 @@ def naver_download_by_url(url, output_dir='.', merge=True, info_only=False, **kw
         size = url_size(video_url)
         print_info(site_info, title, 'mp4', size)
         if not info_only:
-            download_urls([video_url], title, 'mp4', size, **kwargs)
+            download_urls([video_url], title, 'mp4', size, output_dir, **kwargs)
     except:
         universal_download(url, output_dir, merge=merge, info_only=info_only, **kwargs)
 


### PR DESCRIPTION
The recent video on tv.naver was not downloaded, but only the wrong thumbnails were downloaded in the previous code. So I solved this problem by integrating the if-else statement into one.

It also resolved the problem of not being properly stored in the specified output_dir.

* example of wrong result
result of "you-get https://tv.naver.com/v/10984456"
only downloaded thumbnails no video
![thumnail](https://user-images.githubusercontent.com/36741818/69012438-2dc97a80-09b9-11ea-95e7-f3049e5f7230.JPG)


* can download this video correctly after code change
![correct](https://user-images.githubusercontent.com/36741818/69012615-1a1f1380-09bb-11ea-86fd-66e839a2971f.JPG)
