### PR TITLE
Fix playback of VideoExtractor.dash_streams

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -272,15 +272,21 @@ def matchall(text, patterns):
 def launch_player(player, urls):
     import subprocess
     import shlex
+    urls = list(urls)
+    for url in urls.copy():
+        if type(url) is list:
+            urls.extend(url)
+    urls = [url for url in urls if type(url) is str]
+    assert urls
     if (sys.version_info >= (3, 3)):
         import shutil
         exefile=shlex.split(player)[0]
         if shutil.which(exefile) is not None:
-            subprocess.call(shlex.split(player) + list(urls))
+            subprocess.call(shlex.split(player) + urls)
         else:
             log.wtf('[Failed] Cannot find player "%s"' % exefile)
     else:
-        subprocess.call(shlex.split(player) + list(urls))
+        subprocess.call(shlex.split(player) + urls)
 
 
 def parse_query_param(url, param):


### PR DESCRIPTION
- Playing dash_streams is impossible since launch_player is expecting `List[str]`, while VideoExtractor.dash_streams has a type of `List[List[str]]`.  
- This patch should fix that problem and allow dash_streams to be played.