### PR TITLE
Fix downloading issue on some youtube videos (2019-12-02)

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -37,6 +37,7 @@ class YouGetTests(unittest.TestCase):
             'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
             info_only=True
         )
+        youtube.download('https://www.youtube.com/watch?v=A2mJKg2g5TY', info_only=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On the provided test case, without the provided changes, it is unable to download because of a different response format.

```
[DEBUG] get_content: https://www.youtube.com/get_video_info?video_id=A2mJKg2g5TY&eurl=https%3A%2F%2Fy
[DEBUG] STATUS: ok
[DEBUG] get_content: https://www.youtube.com/watch?v=A2mJKg2g5TY
you-get: version 0.4.1314, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.youtube.com/watch?v=A2mJKg2g5TY'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "F:\ProgramData\Anaconda3\Lib\site-packages\you_get\extractors\youtube.py", line 220, in prepare
    stream_list = ytplayer_config['args']['url_encoded_fmt_stream_map'].split(',')
KeyError: 'url_encoded_fmt_stream_map'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "F:\ProgramData\Anaconda3\Lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "F:\ProgramData\Anaconda3\Lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "F:\PROGRA~2\Anaconda3\Scripts\you-get.exe\__main__.py", line 9, in <module>
  File "F:\ProgramData\Anaconda3\Lib\site-packages\you_get\__main__.py", line 92, in main
    main(**kwargs)
  File "F:\ProgramData\Anaconda3\Lib\site-packages\you_get\common.py", line 1759, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "F:\ProgramData\Anaconda3\Lib\site-packages\you_get\common.py", line 1647, in script_main
    **extra
  File "F:\ProgramData\Anaconda3\Lib\site-packages\you_get\common.py", line 1303, in download_main
    download(url, **kwargs)
  File "F:\ProgramData\Anaconda3\Lib\site-packages\you_get\common.py", line 1750, in any_download
    m.download(url, **kwargs)
  File "F:\ProgramData\Anaconda3\Lib\site-packages\you_get\extractor.py", line 48, in download_by_url
    self.prepare(**kwargs)
  File "F:\ProgramData\Anaconda3\Lib\site-packages\you_get\extractors\youtube.py", line 223, in prepare
    stream_list = video_info['url_encoded_fmt_stream_map'][0].split(',')
KeyError: 'url_encoded_fmt_stream_map'
```

With the changes it is able to download the video.