### PR TITLE
Add an audio extraction from downloaded video option

### DIFF
--- a/src/you_get/processor/ffmpeg.py
+++ b/src/you_get/processor/ffmpeg.py
@@ -264,7 +264,7 @@ def ffmpeg_download_stream(files, title, ext, params={}, output_dir='.', stream=
 
 def ffmpeg_concat_audio_and_video(files, output, ext):
     print('Merging video and audio parts... ', end="", flush=True)
-    if has_ffmpeg_installed:
+    if has_ffmpeg_installed():
         params = [FFMPEG] + LOGLEVEL
         params.extend(['-f', 'concat'])
         params.extend(['-safe', '0'])  # https://stackoverflow.com/questions/38996925/ffmpeg-concat-unsafe-file-name
@@ -288,3 +288,25 @@ def ffprobe_get_media_duration(file):
     params.extend(['-v', 'quiet'])
     params.extend(['-of', 'csv=p=0'])
     return subprocess.check_output(params, stdin=STDIN, stderr=subprocess.STDOUT).decode().strip()
+
+
+def ffmpeg_extract_audio_from_video(video_file_path, ext='mp3'):
+    if has_ffmpeg_installed():
+        print('extracting audio from video... ', end="", flush=True)
+
+        path_without_ext = os.path.splitext(video_file_path)[0]
+        output_path = path_without_ext+"."+ ext
+
+        params = [FFMPEG] + LOGLEVEL
+        params.extend(['-i', video_file_path])
+        params.extend(['-f', ext])
+        params.append(path_without_ext+"."+ext)
+        # os.remove(video_file_path)
+        return_val = subprocess.call(params, stdin=STDIN)
+        if return_val == 0:
+            print('\nextracted into ' + output_path)
+        else:
+            print("\nextract error")
+        return
+    else:
+        raise EnvironmentError('\nNo ffmpeg found')


### PR DESCRIPTION
- option -e  :  you can extract audio from downloaded video

- option -E FORMAT :  set extacted audio format. default format is mp3


When I downloaded a video for the purpose of listening to music, I felt burdened by the additional capacity that would result from receiving the video itself other than the music.
So using one FFmpeg, which is the Prerequisites of this package, I added the option to extract sound only from downloaded videos.


-E option can determine the extension of sound extracted, but does not guarantee proper operation unless it is a sound file extension.

If the file you are trying to extract sound from is a sound file, for example, a sound file with a different extension is created, for example, from a flav file to an mp3 file.

If you want to extract sound files from an image file, it does not guarantee proper operation.


# example results 

## only option -e
![only -e](https://user-images.githubusercontent.com/36741818/70845102-141f3400-1e8e-11ea-85c0-706b5b2dc874.PNG)
![result -e](https://user-images.githubusercontent.com/36741818/70845103-171a2480-1e8e-11ea-9922-cbb5ccbbbed2.PNG)

## add option -E
![add option -E](https://user-images.githubusercontent.com/36741818/70845188-e4bcf700-1e8e-11ea-9b3e-addc89f9b484.PNG)
![add option -E result](https://user-images.githubusercontent.com/36741818/70845190-e981ab00-1e8e-11ea-8276-8c122f934327.PNG)

## extraction file (wrong extension) only downloaded vido
![error](https://user-images.githubusercontent.com/36741818/70845243-7593d280-1e8f-11ea-9f12-98161fe47235.PNG)
![error result](https://user-images.githubusercontent.com/36741818/70845244-788ec300-1e8f-11ea-9523-dd4ed360aa86.PNG)


