### PR TITLE
修复搜狐号的视频不能下载的问题

### DIFF
--- a/src/you_get/extractors/sohu.py
+++ b/src/you_get/extractors/sohu.py
@@ -26,7 +26,7 @@ def sohu_download(url, output_dir='.', merge=True, info_only=False, extractor_pr
         vid = r1('id=(\d+)', url)
     else:
         html = get_html(url)
-        vid = r1(r'\Wvid\s*[\:=]\s*[\'"]?(\d+)[\'"]?', html)
+        vid = r1(r'\Wvid\s*[\:=]\s*[\'"]?(\d+)[\'"]?', html) or r1(r'bid:\'(\d+)\',', html)
     assert vid
 
     if extractor_proxy:


### PR DESCRIPTION
针对搜狐号下的视频无法下载的修复
测试链接：https://www.sohu.com/a/365052095_100182082?spm=smpc.author.fd-d.1.1578455373074zxRVlfV
搜狐号下作者不能进行下载的视频列表：https://mp.sohu.com/profile?xpt=OTk4NTg3MDk2MDczNzA3NTIwQHNvaHUuY29t&spm=smpc.vd-land.info.1.1578463489230sivA5hm