### PR TITLE
fixed coub_data regex

### DIFF
--- a/src/you_get/extractors/coub.py
+++ b/src/you_get/extractors/coub.py
@@ -79,7 +79,7 @@ def get_title_and_urls(json_data):
 
 
 def get_coub_data(html):
-    coub_data = r1(r'<script id=\'coubPageCoubJson\' type=\'text/json\'>([^<]+)</script>', html)
+    coub_data = r1(r'<script id=\'coubPageCoubJson\' type=\'text/json\'>([\w\W]+?(?=</script>))</script>', html)
     json_data = json.loads(coub_data)
     return json_data
 


### PR DESCRIPTION
Some videos e.g. [https://coub.com/view/286qqx](https://coub.com/view/286qqx) contain `<` characters belonging to tags nested inside
`<script id='coubPageCoubJson' type='text/json'>`.

They get matched early by the regex resulting in an empty variable coub_data.

`Error while downloading files. the JSON object must be str, bytes or bytearray, not NoneType`

Fixed so it matches everything until the closing `</script>` tag.