### PR TITLE
YouTube with --json argument failed

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -32,6 +32,7 @@ class YouGetTests(unittest.TestCase):
         youtube.download(
             'http://www.youtube.com/watch?v=pzKerr0JIPA', info_only=True
         )
+        youtube.download('http://www.youtube.com/watch?v=pzKerr0JIPA', json_output=True) # json_output will be failed
         youtube.download('http://youtu.be/pzKerr0JIPA', info_only=True)
         youtube.download(
             'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa


### PR DESCRIPTION
```
$ you-get --debug --json 'http://www.youtube.com/watch?v=pzKerr0JIPA'

[DEBUG] get_content: https://www.youtube.com/get_video_info?video_id=pzKerr0JIPA&eurl=https%3A%2F%2Fy
[DEBUG] STATUS: ok
[DEBUG] get_content: https://www.youtube.com/watch?v=pzKerr0JIPA
[DEBUG] get_content: https://www.youtube.com/yts/jsbin/player_ias-vflbDJ8ds/en_US/base.js
you-get: version 0.4.1403, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['http://www.youtube.com/watch?v=pzKerr0JIPA'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=True, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "/home/etiv/.local/bin/you-get", line 11, in <module>
    sys.exit(main())
  File "/home/etiv/.local/lib/python3.6/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/home/etiv/.local/lib/python3.6/site-packages/you_get/common.py", line 1766, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/home/etiv/.local/lib/python3.6/site-packages/you_get/common.py", line 1654, in script_main
    **extra
  File "/home/etiv/.local/lib/python3.6/site-packages/you_get/common.py", line 1310, in download_main
    download(url, **kwargs)
  File "/home/etiv/.local/lib/python3.6/site-packages/you_get/common.py", line 1757, in any_download
    m.download(url, **kwargs)
  File "/home/etiv/.local/lib/python3.6/site-packages/you_get/extractor.py", line 61, in download_by_url
    self.download(**kwargs)
  File "/home/etiv/.local/lib/python3.6/site-packages/you_get/extractor.py", line 181, in download
    json_output.output(self)
  File "/home/etiv/.local/lib/python3.6/site-packages/you_get/json_output.py", line 32, in output
    print(json.dumps(out, indent=4, sort_keys=True, ensure_ascii=False))
  File "/home/etiv/.pyenv/versions/3.6.0/lib/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/home/etiv/.pyenv/versions/3.6.0/lib/python3.6/json/encoder.py", line 201, in encode
    chunks = list(chunks)
  File "/home/etiv/.pyenv/versions/3.6.0/lib/python3.6/json/encoder.py", line 430, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/home/etiv/.pyenv/versions/3.6.0/lib/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/home/etiv/.pyenv/versions/3.6.0/lib/python3.6/json/encoder.py", line 353, in _iterencode_dict
    items = sorted(dct.items(), key=lambda kv: kv[0])
TypeError: '<' not supported between instances of 'str' and 'int'
```

----

It seems that the issue is about [Line #32 of json_output.py][json_output_32].
When I modified the argument `sort_keys` from `True` to `False`, `you-get` can output the correct contents.

>  问题疑似出现在 [json_output.py 第 32 行][json_output_32] 的 `sort_keys=True`，因为我把这里的参数改为 False 后，是可以正确输出内容的。
> （我不是很懂 Python，最深追查到了这里）


[json_output_32]: https://github.com/soimort/you-get/blob/develop/src/you_get/json_output.py#L32