### PR TITLE
[Bilibili] Download decoding of Bilibili should be updated

### DIFF
--- a/试验/test.py
+++ b/试验/test.py
@@ -7,7 +7,8 @@ from you_get.extractors import (
     magisto,
     youtube,
     missevan,
-    acfun
+    acfun,
+    bilibili
 )
 
 
@@ -36,6 +37,9 @@ class YouGetTests(unittest.TestCase):
 
     def test_acfun(self):
         acfun.download('https://www.acfun.cn/v/ac11701912', info_only=True)
+    
+    def test_bilibili(self):
+        bilibili.download('https://www.bilibili.com/video/BV1L741127bu', info_only=True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The video IDs of Bilibili have been **upgraded** from AV to BV. Reference: https://www.bilibili.com/read/cv5167957.
We can download it normally with the old AV ID, **BUT** we can't download it with the new BV ID.
`$ you-get https://www.acfun.cn/v/ac11701912`
`you-get: [Error] Unsupported URL pattern.`
And we can use the browser's  **Developer Tool** - **Console** and code **window.aid** to get the old AV ID.
I recommend updating **the part of download from bilibilibili** based on this.