### PR TITLE
Fails silently on haokan.baidu.com

### DIFF
--- a/src/you_get/extractors/baidu.py
+++ b/src/you_get/extractors/baidu.py
@@ -160,6 +160,8 @@ def baidu_download(url, output_dir='.', stream_type=None, merge=True, info_only=
             if not info_only:
                 download_urls(urls, title, ext, size,
                               output_dir=output_dir, merge=False)
+    else:
+        raise NotImplementedError("Unknown baidu URL " + url)
 
 
 def baidu_pan_download(url):

--- a/tests/test.py
+++ b/tests/test.py
@@ -8,7 +8,8 @@ from you_get.extractors import (
     youtube,
     missevan,
     acfun,
-    bilibili
+    bilibili,
+    baidu
 )
 
 
@@ -45,5 +46,11 @@ class YouGetTests(unittest.TestCase):
         bilibili.download(
             "https://www.bilibili.com/watchlater/#/av74906671/p6", info_only=True
         )
+
+    def test_baidu_haokan(self):
+        baidu.download(
+            'https://haokan.baidu.com/v?vid=6794443542184039159&pd=bjh&fr=bjhauthor&type=video', info_only=True
+        )
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently, the Baidu downloader simply fails silently when it encounters a URL it doesn't understand. Therefore, this PR both modifies the Baidu downloader to properly generate an error in this case, and adds a test for a particular URL that doesn't work.