### PR TITLE
Solve filename is too short under Linux systems

### DIFF
--- a/src/you_get/util/fs.py
+++ b/src/you_get/util/fs.py
@@ -31,6 +31,7 @@ def legitimize(text, os=detect_os()):
             ord(']'): ')',
             ord('\t'): ' ',
         })
+        text = text[:80] # Trim to 82 Unicode characters long
     else:
         # *nix
         if os == 'mac':
@@ -42,6 +43,6 @@ def legitimize(text, os=detect_os()):
         # Remove leading .
         if text.startswith("."):
             text = text[1:]
-
-    text = text[:80] # Trim to 82 Unicode characters long
+    
+    # Only trim to 82 Unicode characters long at windows systems
     return text


### PR DESCRIPTION
似乎是为了某些平台上的文件名字符串长度的限制，所以默认压缩到８０个Unicode长度的字符串，但对于某些过于从网站上下载的视频，由于有过多的前缀就会导致真正用于区分的文件名字的信息在非常的后面，这个时候截断就不太合理了。

目前知道的是在Linux系统上，并不存在这个长度的限制，所以将文件名trim这个过程先移动到非*nux系统上了。