### PR TITLE
The request problems in debug mode are displayed, which is convenient…

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -416,6 +416,8 @@ def urlopen_with_retry(*args, **kwargs):
             logging.debug('HTTP Error with code{}'.format(http_error.code))
             if i + 1 == retry_time:
                 raise http_error
+        except Exception  as else_error:
+            logging.debug(else_error)
 
 
 def get_content(url, headers={}, decoded=True):


### PR DESCRIPTION
… for users to add parameters。

经debug模式下出现的请求问题显示出来，方便用户增加参数使用
Case 场景：
1. Appear directly using the command line 直接使用命令行出现：
you-get: [error] oops, something went wrong.
……
you-get:   (4) Run the command with '--debug' option,

2. Run the command with '--debug' option增加—debug 选项出现：

TypeError: the JSON object must be str, bytes or bytearray, not NoneType
But the error is not the problem here. It's the problem in the request.
但错误并不是此处问题，而是请求时出现了问题。
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1076)

In order to prevent other problems and not affect the execution of subsequent programs, other exception displays requested in debug mode are added here.
为防止其他问题出现，不影响后续程序的执行，在此增加了debug模式下请求的其他异常显示。

Note: the solution can also use the -k option
注：解决方案也可使用 -k 选项