### PR TITLE
Danmaku file is ignoring --output-filename

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
+import os
 import unittest
+from tempfile import TemporaryDirectory
 
+import you_get.common
 from you_get.extractors import (
     imgur,
     magisto,
@@ -45,5 +48,21 @@ class YouGetTests(unittest.TestCase):
         bilibili.download(
             "https://www.bilibili.com/watchlater/#/av74906671/p6", info_only=True
         )
+        with TemporaryDirectory() as temp_dir:
+            output_filename_bak = you_get.common.output_filename
+            try:
+                you_get.common.output_filename = 'cat'  # Simulate argument "--output-filename cat"
+                bilibili.download(
+                    'https://www.bilibili.com/video/BV1jJ411x724',  # A very short video
+                    output_dir=temp_dir,
+                    merge=True,
+                    caption=True,  # We want danmaku file
+                )
+                self.assertTrue(os.path.isfile(os.path.join(temp_dir, 'cat.mp4')))
+                self.assertTrue(os.path.isfile(os.path.join(temp_dir, 'cat.cmt.xml')))
+            finally:
+                you_get.common.output_filename = output_filename_bak  # Restore side-effect
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I want to download videos and danmaku with designated names so that my other scripts can easily use them. However, the danmaku file downloaded by you-get does not follow the `--output-filename` argument, which makes it difficult for other scripts to determine its corresponding video file.

e.g.
```commandline
D:\Temp>you-get -O cat https://www.bilibili.com/video/BV1jJ411x724
site:                Bilibili
title:               Im. Scatman 3D/DANCE?
stream:
    - format:        dash-flv480
      container:     mp4
      quality:       清晰 480P
      size:          3.2 MiB (3369584 bytes)
    # download-with: you-get --format=dash-flv480 [URL]

Downloading cat.mp4 ...
 100% (  3.2/  3.2MB) ├████████████████████████████████████████┤[2/2]   10 MB/s
Merging video parts... Merged into cat.mp4

Downloading Im. Scatman 3D-DANCE-.cmt.xml ...
```

The video file has been renamed, but the danmaku file has not changed. The expected danmaku filename is `cat.cmt.xml`.

---

I have a naive solution that is to change [this line](https://github.com/soimort/you-get/blob/07417e6ef15de6236827ab2ecffaea59a19ad9cb/src/you_get/extractor.py#L257) from

```python
filename = '{}.cmt.xml'.format(get_filename(self.title))
```

to

```python
from .common import output_filename
...
filename = '{}.cmt.xml'.format(get_filename(output_filename or self.title))
```

But I am not sure if it is completely correct.