### PR TITLE
[tests] fail bilibili

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -31,6 +31,7 @@ class YouGetTests(unittest.TestCase):
             'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
             info_only=True
         )
+        youtube.download('https://www.youtube.com/watch?v=ijUnCjqYiqk', info_only=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
os-version `mac os high sierra 10.13.6`
python3 `python3
Python 3.6.0 (v3.6.0:41df79263a11, Dec 22 2016, 17:23:13)
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin`
you-get version `you-get -V
you-get: version 0.4.1432, a tiny downloader that scrapes the web`

command `you-get 'https://www.bilibili.com/video/BV1CW411A7Ak' --debug`


output info: 
`[DEBUG] get_content: https://www.bilibili.com/video/BV1CW411A7Ak
you-get: version 0.4.1432, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.bilibili.com/video/BV1CW411A7Ak'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.6/bin/you-get", line 11, in <module>
    load_entry_point('you-get==0.4.1432', 'console_scripts', 'you-get')()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/you_get-0.4.1432-py3.6.egg/you_get/__main__.py", line 92, in main
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/you_get-0.4.1432-py3.6.egg/you_get/common.py", line 1764, in main
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/you_get-0.4.1432-py3.6.egg/you_get/common.py", line 1652, in script_main
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/you_get-0.4.1432-py3.6.egg/you_get/common.py", line 1308, in download_main
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/you_get-0.4.1432-py3.6.egg/you_get/common.py", line 1755, in any_download
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/you_get-0.4.1432-py3.6.egg/you_get/extractor.py", line 48, in download_by_url
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/you_get-0.4.1432-py3.6.egg/you_get/extractors/bilibili.py", line 183, in prepare
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/__init__.py", line 348, in loads
    'not {!r}'.format(s.__class__.__name__))
TypeError: the JSON object must be str, bytes or byte array, not 'NoneType' `