### PR TITLE
Simplest working cookie for downloading from Youku (VIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ Use `--url`/`-u` to get a list of downloadable resource URLs extracted from the 
 | 火猫TV   | <http://www.huomao.com/>       |✓| | |
 | 阳光宽频网 | <http://www.365yg.com/>      |✓| | |
 | 西瓜视频 | <https://www.ixigua.com/>      |✓| | |
+| 新片场 | <https://www.xinpianchang.com//>      |✓| | |
 | 快手 | <https://www.kuaishou.com/>      |✓|✓| |
 | 抖音 | <https://www.douyin.com/>      |✓| | |
 | TikTok | <https://www.tiktok.com/>      |✓| | |

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -116,6 +116,7 @@ SITES = {
     'xiaokaxiu'        : 'yixia',
     'xiaojiadianvideo' : 'fc2video',
     'ximalaya'         : 'ximalaya',
+    'xinpianchang'     : 'xinpianchang',
     'yinyuetai'        : 'yinyuetai',
     'yizhibo'          : 'yizhibo',
     'youku'            : 'youku',

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -79,6 +79,7 @@ from .vk import *
 from .w56 import *
 from .wanmen import *
 from .xiami import *
+from .xinpianchang import *
 from .yinyuetai import *
 from .yixia import *
 from .youku import *

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -10,6 +10,8 @@ class Bilibili(VideoExtractor):
 
     # Bilibili media encoding options, in descending quality order.
     stream_types = [
+        {'id': 'hdflv2_4k', 'quality': 120, 'audio_quality': 30280,
+         'container': 'FLV', 'video_resolution': '2160p', 'desc': '超清 4K'},
         {'id': 'flv_p60', 'quality': 116, 'audio_quality': 30280,
          'container': 'FLV', 'video_resolution': '1080p', 'desc': '高清 1080P60'},
         {'id': 'hdflv2', 'quality': 112, 'audio_quality': 30280,
@@ -42,8 +44,10 @@ class Bilibili(VideoExtractor):
             return 64
         elif height <= 1080 and qn <= 80:
             return 80
-        else:
+        elif height <= 1080 and qn <= 112:
             return 112
+        else:
+            return 120
 
     @staticmethod
     def bilibili_headers(referer=None, cookie=None):
@@ -213,7 +217,7 @@ class Bilibili(VideoExtractor):
             if playinfo_ is not None:
                 playinfos.append(playinfo_)
             # get alternative formats from API
-            for qn in [112, 80, 64, 32, 16]:
+            for qn in [120, 112, 80, 64, 32, 16]:
                 # automatic format for durl: qn=0
                 # for dash, qn does not matter
                 if current_quality is None or qn < current_quality:
@@ -312,7 +316,7 @@ class Bilibili(VideoExtractor):
                 return
             current_quality = api_playinfo['result']['quality']
             # get alternative formats from API
-            for qn in [112, 80, 64, 32, 16]:
+            for qn in [120, 112, 80, 64, 32, 16]:
                 # automatic format for durl: qn=0
                 # for dash, qn does not matter
                 if qn != current_quality:

--- a/src/you_get/extractors/cntv.py
+++ b/src/you_get/extractors/cntv.py
@@ -44,12 +44,12 @@ def cntv_download_by_id(rid, **kwargs):
 def cntv_download(url, **kwargs):
     if re.match(r'http://tv\.cntv\.cn/video/(\w+)/(\w+)', url):
         rid = match1(url, r'http://tv\.cntv\.cn/video/\w+/(\w+)')
-    elif re.match(r'http://tv\.cctv\.com/\d+/\d+/\d+/\w+.shtml', url):
+    elif re.match(r'http(s)?://tv\.cctv\.com/\d+/\d+/\d+/\w+.shtml', url):
         rid = r1(r'var guid = "(\w+)"', get_content(url))
     elif re.match(r'http://\w+\.cntv\.cn/(\w+/\w+/(classpage/video/)?)?\d+/\d+\.shtml', url) or \
          re.match(r'http://\w+.cntv.cn/(\w+/)*VIDE\d+.shtml', url) or \
          re.match(r'http://(\w+).cntv.cn/(\w+)/classpage/video/(\d+)/(\d+).shtml', url) or \
-         re.match(r'http://\w+.cctv.com/\d+/\d+/\d+/\w+.shtml', url) or \
+         re.match(r'http(s)?://\w+.cctv.com/\d+/\d+/\d+/\w+.shtml', url) or \
          re.match(r'http://\w+.cntv.cn/\d+/\d+/\d+/\w+.shtml', url): 
         page = get_content(url)
         rid = r1(r'videoCenterId","(\w+)"', page)

--- a/src/you_get/extractors/universal.py
+++ b/src/you_get/extractors/universal.py
@@ -107,6 +107,11 @@ def universal_download(url, output_dir='.', merge=True, info_only=False, **kwarg
         for rel_url in rel_urls:
             urls += [ r1(r'(https?://[^/]+)', url) + rel_url ]
 
+        # sometimes naive
+        urls += re.findall(r'data-original="(https?://[^"]+\.jpe?g)"', page, re.I)
+        urls += re.findall(r'data-original="(https?://[^"]+\.png)"', page, re.I)
+        urls += re.findall(r'data-original="(https?://[^"]+\.gif)"', page, re.I)
+
         # MPEG-DASH MPD
         mpd_urls = re.findall(r'src="(https?://[^"]+\.mpd)"', page)
         for mpd_url in mpd_urls:

--- a/src/you_get/extractors/universal.py
+++ b/src/you_get/extractors/universal.py
@@ -99,6 +99,14 @@ def universal_download(url, output_dir='.', merge=True, info_only=False, **kwarg
         for rel_url in rel_urls:
             urls += [ r1(r'(.*/)', url) + rel_url ]
 
+        # site-relative path
+        rel_urls = []
+        rel_urls += re.findall(r'href="(/[^"]+\.jpe?g)"', page, re.I)
+        rel_urls += re.findall(r'href="(/[^"]+\.png)"', page, re.I)
+        rel_urls += re.findall(r'href="(/[^"]+\.gif)"', page, re.I)
+        for rel_url in rel_urls:
+            urls += [ r1(r'(https?://[^/]+)', url) + rel_url ]
+
         # MPEG-DASH MPD
         mpd_urls = re.findall(r'src="(https?://[^"]+\.mpd)"', page)
         for mpd_url in mpd_urls:

--- a/src/you_get/extractors/xinpianchang.py
+++ b/src/you_get/extractors/xinpianchang.py
@@ -38,7 +38,6 @@ class Xinpianchang(VideoExtractor):
             stype = [st for st in self.__class__.stream_types if st['video_profile'] == profile][0]
 
             stream_data = dict(src=[url], size=size, container='mp4', quality=stype['quality'])
-            print(stream_data)
             self.streams[stype['id']] = stream_data
 
 

--- a/src/you_get/extractors/xinpianchang.py
+++ b/src/you_get/extractors/xinpianchang.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+import re
+import json
+from ..extractor import VideoExtractor
+from ..common import get_content, playlist_not_supported
+
+
+class Xinpianchang(VideoExtractor):
+    stream_types = [
+        {'id': '4K', 'quality': '超清 4K', 'video_profile': 'mp4-4K'},
+        {'id': '2K', 'quality': '超清 2K', 'video_profile': 'mp4-2K'},
+        {'id': '1080', 'quality': '高清 1080P', 'video_profile': 'mp4-FHD'},
+        {'id': '720', 'quality': '高清 720P', 'video_profile': 'mp4-HD'},
+        {'id': '540', 'quality': '清晰 540P', 'video_profile': 'mp4-SD'},
+        {'id': '360', 'quality': '流畅 360P', 'video_profile': 'mp4-LD'}
+    ]
+
+    name = 'xinpianchang'
+
+    def prepare(self, **kwargs):
+        # find key
+        page_content = get_content(self.url)
+        match_rule = r"vid: \"(.+?)\","
+        key = re.findall(match_rule, page_content)[0]
+
+        # get videos info
+        video_url = 'https://openapi-vtom.vmovier.com/v3/video/' + key + '?expand=resource'
+        data = json.loads(get_content(video_url))
+        self.title = data["data"]["video"]["title"]
+        video_info = data["data"]["resource"]["progressive"]
+
+        # set streams dict
+        for video in video_info:
+            url = video["https_url"]
+            size = video["filesize"]
+            profile = video["profile_code"]
+            stype = [st for st in self.__class__.stream_types if st['video_profile'] == profile][0]
+
+            stream_data = dict(src=[url], size=size, container='mp4', quality=stype['quality'])
+            print(stream_data)
+            self.streams[stype['id']] = stream_data
+
+
+download = Xinpianchang().download_by_url
+download_playlist = playlist_not_supported('xinpianchang')

--- a/src/you_get/extractors/xinpianchang.py
+++ b/src/you_get/extractors/xinpianchang.py
@@ -7,6 +7,7 @@ from ..common import get_content, playlist_not_supported
 
 
 class Xinpianchang(VideoExtractor):
+    name = 'xinpianchang'
     stream_types = [
         {'id': '4K', 'quality': '超清 4K', 'video_profile': 'mp4-4K'},
         {'id': '2K', 'quality': '超清 2K', 'video_profile': 'mp4-2K'},
@@ -15,8 +16,6 @@ class Xinpianchang(VideoExtractor):
         {'id': '540', 'quality': '清晰 540P', 'video_profile': 'mp4-SD'},
         {'id': '360', 'quality': '流畅 360P', 'video_profile': 'mp4-LD'}
     ]
-
-    name = 'xinpianchang'
 
     def prepare(self, **kwargs):
         # find key

--- a/tests/test.py
+++ b/tests/test.py
@@ -8,8 +8,7 @@ from you_get.extractors import (
     youtube,
     missevan,
     acfun,
-    bilibili,
-    xinpianchang
+    bilibili
 )
 
 
@@ -46,9 +45,5 @@ class YouGetTests(unittest.TestCase):
         bilibili.download(
             "https://www.bilibili.com/watchlater/#/av74906671/p6", info_only=True
         )
-
-    def test_xinpianchang(self):
-        xinpianchang.download('https://www.xinpianchang.com/a10673220', info_only=True)
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -8,7 +8,8 @@ from you_get.extractors import (
     youtube,
     missevan,
     acfun,
-    bilibili
+    bilibili,
+    xinpianchang
 )
 
 
@@ -45,5 +46,9 @@ class YouGetTests(unittest.TestCase):
         bilibili.download(
             "https://www.bilibili.com/watchlater/#/av74906671/p6", info_only=True
         )
+
+    def test_xinpianchang(self):
+        imgur.download('https://www.xinpianchang.com/a10673220', info_only=True)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -48,7 +48,7 @@ class YouGetTests(unittest.TestCase):
         )
 
     def test_xinpianchang(self):
-        imgur.download('https://www.xinpianchang.com/a10673220', info_only=True)
+        xinpianchang.download('https://www.xinpianchang.com/a10673220', info_only=True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Usage test:
```
you-get -c "cookie.txt" https://v.youku.com/v_show/id_XMTgwNjc4NjEy.html
```
Or other sources from: https://home.vip.youku.com/
<br/>
[cookie.txt](https://github.com/soimort/you-get/files/4613285/cookie.txt):
```
# HTTP Cookie File
.youku.com	TRUE	/	FALSE	2147483647	P_pck_rm	%2FLK6dd49b4461a4e8a45d1ZBx%2B1CPQP2he2Uq0aCWQsBuZIEAG3%2Bx51j9wYQr50SprdbZQD%2FF1XSqNUod311PHYjLHuMtTOg9AzkCCuvR3KVxknkEPBJ5rPZUCrZjDKiCJKRAoo3n6vElLZhk%2BKw%2F23L8L4l76Nwmz4zLA%3D%3D%5FV2

```
* Cookie param expiration: 168 h+ (N/A?)
* VIP expiration: 2020-06-01 23:04:01 (UTC)
<br/>

Also note:
>## [Cookie file format](https://curl.haxx.se/docs/http-cookies.html)
>
>The cookie file format is text based and stores one cookie per line. Lines that start with `#` are treated as comments.
>
>Each line that each specifies a single cookie consists of seven text fields separated with TAB characters. A valid line must end with a newline character.
>
>### Fields in the file
>
>Field number, what type and example data and the meaning of it:
>1. string `example.com` - the domain name
>2. boolean `FALSE` - include subdomains
>3. string `/foobar/` - path
>4. boolean `TRUE` - send/receive over HTTPS only
>5. number `1462299217` - expires at - seconds since Jan 1st 1970, or 0
>6. string `person` - name of the cookie
>7. string `daniel` - value of the cookie

>### [How do I pass cookies to youtube-dl?](https://github.com/ytdl-org/youtube-dl/blob/master/README.md#how-do-i-pass-cookies-to-youtube-dl)
>
>Use the `--cookies` option, for example `--cookies /path/to/cookies/file.txt`.
>
>In order to extract cookies from browser use any conforming browser extension for exporting cookies. For example, [cookies.txt](https://chrome.google.com/webstore/detail/cookiestxt/njabckikapfpffapmjgojcnbfjonfjfg) (for Chrome) or [cookies.txt](https://addons.mozilla.org/en-US/firefox/addon/cookies-txt/) (for Firefox).
>
>Note that the cookies file must be in Mozilla/Netscape format and the first line of the cookies file must be either `# HTTP Cookie File` or `# Netscape HTTP Cookie File`. Make sure you have correct [newline format](https://en.wikipedia.org/wiki/Newline) in the cookies file and convert newlines if necessary to correspond with your OS, namely `CRLF` (`\r\n`) for Windows and `LF` (`\n`) for Unix and Unix-like systems (Linux, macOS, etc.). `HTTP Error 400: Bad Request` when using `--cookies` is a good sign of invalid newline format.
>
>Passing cookies to youtube-dl is a good way to workaround login when a particular extractor does not implement it explicitly. Another use case is working around [CAPTCHA](https://en.wikipedia.org/wiki/CAPTCHA) some websites require you to solve in particular cases in order to get access (e.g. YouTube, CloudFlare).