### PR TITLE
Enhancements to urlopen_with_retry

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -421,6 +421,8 @@ def urlopen_with_retry(*args, **kwargs):
             if i + 1 == retry_time:
                 raise url_error
 
+        time.sleep(5)
+
 
 def get_content(url, headers={}, decoded=True):
     """Gets the content of a URL via sending a HTTP GET request.

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -137,6 +137,7 @@ cookies = None
 output_filename = None
 auto_rename = False
 insecure = False
+retry_time = 3
 
 fake_headers = {
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',  # noqa
@@ -396,7 +397,6 @@ def get_location(url, headers=None, get_method='HEAD'):
 
 
 def urlopen_with_retry(*args, **kwargs):
-    retry_time = 3
     for i in range(retry_time):
         try:
             if insecure:
@@ -1531,6 +1531,11 @@ def script_main(download, download_playlist, **kwargs):
         help='ignore ssl errors'
     )
 
+    download_grp.add_argument(
+        '-r', '--retry', metavar="RETRY_TIME", type=int, default=3,
+        help='Set the limit of retrying download'
+    )
+
     proxy_grp = parser.add_argument_group('Proxy options')
     proxy_grp = proxy_grp.add_mutually_exclusive_group()
     proxy_grp.add_argument(
@@ -1577,6 +1582,8 @@ def script_main(download, download_playlist, **kwargs):
     global output_filename
     global auto_rename
     global insecure
+    global retry_time
+
     output_filename = args.output_filename
     extractor_proxy = args.extractor_proxy
 
@@ -1610,6 +1617,8 @@ def script_main(download, download_playlist, **kwargs):
         # ignore ssl
         insecure = True
 
+    if args.retry:
+        retry_time = args.retry
 
     if args.no_proxy:
         set_http_proxy('')

--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -416,6 +416,10 @@ def urlopen_with_retry(*args, **kwargs):
             logging.debug('HTTP Error with code{}'.format(http_error.code))
             if i + 1 == retry_time:
                 raise http_error
+        except error.URLError as url_error:
+            logging.debug('URL Error: {}'.format(url_error))
+            if i + 1 == retry_time:
+                raise url_error
 
 
 def get_content(url, headers={}, decoded=True):


### PR DESCRIPTION
This pull request contains several enhancements to `urlopen_with_retry`:

* Allow the users to specify `retry_time` through command line arguments
* Sleep for an interval before retrying to avoid flooding the server when `retry_time` is set to a high value
* Catch `URLError` as well since some network failures like "Connection Refused" also fall into this category