### PR TITLE
Try to show non-dash formats for bangumi videos in bilibili

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -81,8 +81,8 @@ class Bilibili(VideoExtractor):
         return 'https://www.bilibili.com/audio/music-service-c/web/song/of-menu?sid=%s&pn=1&ps=%s' % (sid, ps)
 
     @staticmethod
-    def bilibili_bangumi_api(avid, cid, ep_id, qn=0):
-        return 'https://api.bilibili.com/pgc/player/web/playurl?avid=%s&cid=%s&qn=%s&type=&otype=json&ep_id=%s&fnver=0&fnval=16' % (avid, cid, qn, ep_id)
+    def bilibili_bangumi_api(avid, cid, ep_id, qn=0, fnval=16):
+        return 'https://api.bilibili.com/pgc/player/web/playurl?avid=%s&cid=%s&qn=%s&type=&otype=json&ep_id=%s&fnver=0&fnval=%s' % (avid, cid, qn, ep_id, fnval)
 
     @staticmethod
     def bilibili_interface_api(cid, qn=0):
@@ -316,15 +316,16 @@ class Bilibili(VideoExtractor):
                 return
             current_quality = api_playinfo['result']['quality']
             # get alternative formats from API
-            for qn in [120, 112, 80, 64, 32, 16]:
-                # automatic format for durl: qn=0
-                # for dash, qn does not matter
-                if qn != current_quality:
-                    api_url = self.bilibili_bangumi_api(avid, cid, ep_id, qn=qn)
-                    api_content = get_content(api_url, headers=self.bilibili_headers(referer=self.url))
-                    api_playinfo = json.loads(api_content)
-                    if api_playinfo['code'] == 0:  # success
-                        playinfos.append(api_playinfo)
+            for fnval in [8, 16]:
+                for qn in [120, 112, 80, 64, 32, 16]:
+                    # automatic format for durl: qn=0
+                    # for dash, qn does not matter
+                    if qn != current_quality:
+                        api_url = self.bilibili_bangumi_api(avid, cid, ep_id, qn=qn, fnval=fnval)
+                        api_content = get_content(api_url, headers=self.bilibili_headers(referer=self.url))
+                        api_playinfo = json.loads(api_content)
+                        if api_playinfo['code'] == 0:  # success
+                            playinfos.append(api_playinfo)
 
             for playinfo in playinfos:
                 if 'durl' in playinfo['result']:


### PR DESCRIPTION
For some bangumi on bilibili, only dash formats can be shown when examing formats using `you-get -i`. The expected behaviour I assume should be that both dash and non-dash formats are listed, because that's what happens when a normal bilibili video url is given.

<details>
<summary>Example</summary>

```
~ > you-get -i "https://www.bilibili.com/bangumi/play/ep84340"
you-get: This bangumi currently has 24 videos. (use --playlist to download all videos.)
site:                Bilibili
title:               某科学的超电磁炮：第1话 电击使 Electro Master
streams:             # Available quality and codecs
    [ DASH ] ____________________________________
    - format:        dash-flv
      container:     mp4
      quality:       高清 1080P
      size:          293.2 MiB (307432119 bytes)
    # download-with: you-get --format=dash-flv [URL]

    - format:        dash-flv720
      container:     mp4
      quality:       高清 720P
      size:          228.9 MiB (240056069 bytes)
    # download-with: you-get --format=dash-flv720 [URL]

    - format:        dash-flv480
      container:     mp4
      quality:       清晰 480P
      size:          128.1 MiB (134276161 bytes)
    # download-with: you-get --format=dash-flv480 [URL]

    - format:        dash-flv360
      container:     mp4
      quality:       流畅 360P
      size:          79.2 MiB (83047966 bytes)
    # download-with: you-get --format=dash-flv360 [URL]
```
</details>

It seems that when dash streams are available, the api `you-get` uses for bangumi returns only the dash streams. And after some experimenting, I found that changing the `fnval` url parameter in `bilibili_bangumi_api` (to something like `8`) could make it return default non-dash streams (but without dash streams).

So the changes I propose in this PR make the downloader try both `8` and `16` for `fnval` to gather the full list of formats (only for bangumi videos). I'm not sure if this is the best solution though, don't know what `fnval` means exactly, but it does seem to work for some limited test cases.
