### PR TITLE
Use ElementTree instead of deprecated cElementTree.

### DIFF
--- a/src/you_get/extractors/ckplayer.py
+++ b/src/you_get/extractors/ckplayer.py
@@ -6,7 +6,7 @@
 
 __all__ = ['ckplayer_download']
 
-from xml.etree import cElementTree as ET
+from xml.etree import ElementTree as ET
 from copy import copy
 from ..common import *
 #----------------------------------------------------------------------


### PR DESCRIPTION
cElementTree has been deprecated for removal and ElementTree should be used in Python 3. Reference : https://bugs.python.org/issue36543