### PR TITLE
acfun bangumi can't download

### DIFF
--- a/src/you_get/extractors/acfun.py
+++ b/src/you_get/extractors/acfun.py
@@ -132,7 +132,7 @@ def acfun_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
                 reps.append( (one['width']* one['height'], one['url'], one['backupUrl']) )
             m3u8_url = max(reps)[1]
             
-    elif re.match("https?://[^\.]*\.*acfun\.[^\.]+/bangumi/ab(\d+)", url):
+    elif re.match("https?://[^\.]*\.*acfun\.[^\.]+/bangumi/aa(\d+)", url):
         html = get_content(url, headers=fake_headers)
         tag_script = match1(html, r'<script>window\.pageInfo([^<]+)</script>')
         json_text = tag_script[tag_script.find('{') : tag_script.find('};') + 1]


### PR DESCRIPTION
I changed a small part but didn't fix the problem. 
Just a beginner.

C:\Users\Administrator>you-get -d https://www.acfun.cn/bangumi/aa6002986
[DEBUG] get_content: https://www.acfun.cn/bangumi/aa6002986
you-get: version 0.4.1432, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.acfun.cn/bangumi/aa6002986'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "e:\python\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "e:\python\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "E:\Python\Scripts\you-get.exe\__main__.py", line 7, in <module>
  File "e:\python\lib\site-packages\you_get\__main__.py", line 92, in main
    main(**kwargs)
  File "e:\python\lib\site-packages\you_get\common.py", line 1763, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "e:\python\lib\site-packages\you_get\common.py", line 1651, in script_main
    **extra
  File "e:\python\lib\site-packages\you_get\common.py", line 1307, in download_main
    download(url, **kwargs)
  File "e:\python\lib\site-packages\you_get\common.py", line 1754, in any_download
    m.download(url, **kwargs)
  File "e:\python\lib\site-packages\you_get\extractors\acfun.py", line 142, in acfun_download
    json_text = tag_script[tag_script.find('{') : tag_script.find('};') + 1]
AttributeError: 'NoneType' object has no attribute 'find'