### PR TITLE
bilibili ignore SSL problem

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -2,6 +2,7 @@
 
 from ..common import *
 from ..extractor import VideoExtractor
+import ssl
 
 import hashlib
 
@@ -135,8 +136,9 @@ class Bilibili(VideoExtractor):
         self.stream_qualities = {s['quality']: s for s in self.stream_types}
 
         try:
+            ssl._create_default_https_context = ssl._create_unverified_context
             html_content = get_content(self.url, headers=self.bilibili_headers(referer=self.url))
-        except:
+        except Exception as e:
             html_content = ''  # live always returns 400 (why?)
         #self.title = match1(html_content,
         #                    r'<h1 title="([^"]+)"')


### PR DESCRIPTION
120/5000 
When I downloaded Bilibili video using you-get, an SSL error occurred in the program, possibly because Bilibili used a self-signed SSL certificate.

Operating environment: Python3.7 MacOS



Email: hyjipotou2@outlook.com