### PR TITLE
fix acfun download fail

### DIFF
--- a/src/you_get/extractors/acfun.py
+++ b/src/you_get/extractors/acfun.py
@@ -111,6 +111,18 @@ def acfun_download_by_vid(vid, title, output_dir='.', merge=True, info_only=Fals
 def acfun_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
     assert re.match(r'https?://[^\.]*\.*acfun\.[^\.]+/(\D|bangumi)/\D\D(\d+)', url)
 
+    def getM3u8UrlFromCurrentVideoInfo(currentVideoInfo):
+        if 'playInfos' in currentVideoInfo:
+            return currentVideoInfo['playInfos'][0]['playUrls'][0]
+        elif 'ksPlayJson' in currentVideoInfo:
+            ksPlayJson = json.loads( currentVideoInfo['ksPlayJson'] )
+            representation = ksPlayJson.get('adaptationSet')[0].get('representation')
+            reps = []
+            for one in representation:
+                reps.append( (one['width']* one['height'], one['url'], one['backupUrl']) )
+            return max(reps)[1]
+
+
     if re.match(r'https?://[^\.]*\.*acfun\.[^\.]+/\D/\D\D(\d+)', url):
         html = get_content(url, headers=fake_headers)
         json_text = match1(html, r"(?s)videoInfo\s*=\s*(\{.*?\});")
@@ -122,37 +134,18 @@ def acfun_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
         if len(video_list) > 1:
             title += " - " + [p.get('title') for p in video_list if p.get('id') == vid][0]
         currentVideoInfo = json_data.get('currentVideoInfo')
-        if 'playInfos' in currentVideoInfo:
-            m3u8_url = currentVideoInfo['playInfos'][0]['playUrls'][0]
-        elif 'ksPlayJson' in currentVideoInfo:
-            ksPlayJson = json.loads( currentVideoInfo['ksPlayJson'] )
-            representation = ksPlayJson.get('adaptationSet').get('representation')
-            reps = []
-            for one in representation:
-                reps.append( (one['width']* one['height'], one['url'], one['backupUrl']) )
-            m3u8_url = max(reps)[1]
-
+        m3u8_url = getM3u8UrlFromCurrentVideoInfo(currentVideoInfo)
     elif re.match("https?://[^\.]*\.*acfun\.[^\.]+/bangumi/aa(\d+)", url):
         html = get_content(url, headers=fake_headers)
-        tag_script = match1(html, r'<script>window\.pageInfo([^<]+)</script>')
+        tag_script = match1(html, r'<script>\s*window\.pageInfo([^<]+)</script>')
         json_text = tag_script[tag_script.find('{') : tag_script.find('};') + 1]
         json_data = json.loads(json_text)
         title = json_data['bangumiTitle'] + " " + json_data['episodeName'] + " " + json_data['title']
         vid = str(json_data['videoId'])
         up = "acfun"
 
-        play_info = get_content("https://www.acfun.cn/rest/pc-direct/play/playInfo/m3u8Auto?videoId=" + vid, headers=fake_headers)
-        play_url = json.loads(play_info)['playInfo']['streams'][0]['playUrls'][0]
-        m3u8_all_qualities_file = get_content(play_url)
-        m3u8_all_qualities_lines = m3u8_all_qualities_file.split('#EXT-X-STREAM-INF:')[1:]
-        highest_quality_line = m3u8_all_qualities_lines[0]
-        for line in m3u8_all_qualities_lines:
-            bandwith = int(match1(line, r'BANDWIDTH=(\d+)'))
-            if bandwith > int(match1(highest_quality_line, r'BANDWIDTH=(\d+)')):
-                highest_quality_line = line
-        #TODO: 应由用户指定清晰度
-        m3u8_url = match1(highest_quality_line, r'\n([^#\n]+)$')
-        m3u8_url = play_url[:play_url.rfind("/")+1] + m3u8_url
+        currentVideoInfo = json_data.get('currentVideoInfo')
+        m3u8_url = getM3u8UrlFromCurrentVideoInfo(currentVideoInfo)
 
     else:
         raise NotImplemented

--- a/tests/test.py
+++ b/tests/test.py
@@ -39,6 +39,7 @@ class YouGetTests(unittest.TestCase):
 
     def test_acfun(self):
         acfun.download('https://www.acfun.cn/v/ac11701912', info_only=True)
+        acfun.download('https://www.acfun.cn/bangumi/aa6002986', info_only=True)
 
     def test_bilibil(self):
         bilibili.download(


### PR DESCRIPTION
Should related to #2820 .
I didn't check the download options or all the video types, but this should work.
API `https://www.acfun.cn/rest/pc-direct/play/playInfo/m3u8Auto?videoId=` is not working now(404 NOT FOUND).

```python
[17:16:58] mmmartt:you-get git:(develop) $ you-get -d https://www.acfun.cn/bangumi/aa6002986
[DEBUG] get_content: https://www.acfun.cn/bangumi/aa6002986
you-get: version 0.4.1456, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.acfun.cn/bangumi/aa6002986'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "you-get", line 11, in <module>
    you_get.main(repo_path=_filepath)
  File "/Users/mmmartt/Files/projects/you-get/src/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/Users/mmmartt/Files/projects/you-get/src/you_get/common.py", line 1784, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/Users/mmmartt/Files/projects/you-get/src/you_get/common.py", line 1672, in script_main
    **extra
  File "/Users/mmmartt/Files/projects/you-get/src/you_get/common.py", line 1328, in download_main
    download(url, **kwargs)
  File "/Users/mmmartt/Files/projects/you-get/src/you_get/common.py", line 1775, in any_download
    m.download(url, **kwargs)
  File "/Users/mmmartt/Files/projects/you-get/src/you_get/extractors/acfun.py", line 138, in acfun_download
    json_text = tag_script[tag_script.find('{') : tag_script.find('};') + 1]
AttributeError: 'NoneType' object has no attribute 'find'
[17:17:02] mmmartt:you-get git:(develop) $ you-get -d https://www.acfun.cn/v/ac17413277
[DEBUG] get_content: https://www.acfun.cn/v/ac17413277
you-get: version 0.4.1456, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.acfun.cn/v/ac17413277'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "you-get", line 11, in <module>
    you_get.main(repo_path=_filepath)
  File "/Users/mmmartt/Files/projects/you-get/src/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/Users/mmmartt/Files/projects/you-get/src/you_get/common.py", line 1784, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/Users/mmmartt/Files/projects/you-get/src/you_get/common.py", line 1672, in script_main
    **extra
  File "/Users/mmmartt/Files/projects/you-get/src/you_get/common.py", line 1328, in download_main
    download(url, **kwargs)
  File "/Users/mmmartt/Files/projects/you-get/src/you_get/common.py", line 1775, in any_download
    m.download(url, **kwargs)
  File "/Users/mmmartt/Files/projects/you-get/src/you_get/extractors/acfun.py", line 129, in acfun_download
    representation = ksPlayJson.get('adaptationSet').get('representation')
AttributeError: 'list' object has no attribute 'get'
```