### PR TITLE
fix iqiyi playlist extrator

### DIFF
--- a/src/you_get/extractors/iqiyi.py
+++ b/src/you_get/extractors/iqiyi.py
@@ -119,10 +119,10 @@ class Iqiyi(VideoExtractor):
         self.url = url
 
         video_page = get_content(url)
-        videos = set(re.findall(r'<a href="(http://www\.iqiyi\.com/v_[^"]+)"', video_page))
+        videos = set(re.findall(r'<a href="(?=https?:)?(//www\.iqiyi\.com/v_[^"]+)"', video_page))
 
         for video in videos:
-            self.__class__().download_by_url(video, **kwargs)
+            self.__class__().download_by_url('https:' + video, **kwargs)
 
     def prepare(self, **kwargs):
         assert self.url or self.vid
@@ -153,7 +153,7 @@ class Iqiyi(VideoExtractor):
             except Exception as e:
                 log.i("vd: {} is not handled".format(stream['vd']))
                 log.i("info is {}".format(stream))
-    
+
 
     def download(self, **kwargs):
         """Override the original one
@@ -201,7 +201,7 @@ class Iqiyi(VideoExtractor):
             if not urls:
                 log.wtf('[Failed] Cannot extract video source.')
             # For legacy main()
-            
+
             #Here's the change!!
             download_url_ffmpeg(urls[0], self.title, 'mp4', output_dir=kwargs['output_dir'], merge=kwargs['merge'], stream=False)
 
@@ -215,7 +215,7 @@ class Iqiyi(VideoExtractor):
                 with open(os.path.join(kwargs['output_dir'], filename),
                           'w', encoding='utf-8') as x:
                     x.write(srt)
-                print('Done.')    
+                print('Done.')
 
 '''
         if info["code"] != "A000000":


### PR DESCRIPTION
iqiyi playlist urls changed from `http://www.iqiyi.com` to `//www.iqiyi.com`

extrator is changed to support all 3 kind of link format

1. `http://www.iqiyi.com`
2. `https://www.iqiyi.com`
2. `//www.iqiyi.com`