### PR TITLE
[PPTV ERROR] download pptv error, code 403 / 405

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -10,7 +10,8 @@ from you_get.extractors import (
     acfun,
     bilibili,
     soundcloud,
-    tiktok
+    tiktok,
+    pptv
 )
 
 
@@ -63,6 +64,9 @@ class YouGetTests(unittest.TestCase):
         tiktok.download('https://t.tiktok.com/i18n/share/video/6850796940293164290/', info_only=True)
         tiktok.download('https://vt.tiktok.com/UGJR4R/', info_only=True)
 
+    def tests_pptv(self):
+        pptv.download('https://v.pptv.com/show/oYPEQicEtxgRn5U0.html', info_only=True)
+        pptv.download('https://v.pptv.com/show/1JibpJo70ZKIFgibs.html', info_only=True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Get error code 403 or 405 when download the pptv source.
`you-get https://v.pptv.com/show/ffVe3Akpl9U4th4.html --debug`
Some sample source url:  
- http://124.227.26.238/0/1bc5c8490842e346b71182868f0b893a.mp4?key=0b19f4181130f6f9cd323e90ce046167&k=c16b146264700ccec3dec6aa0862d423-f85f-1600883210%26bppcataid%3D26&fpp.ver=1.3.0.4&type=%5C
- http://124.227.26.239/60/878499ba11160321e5f6b31d1ad8fc7b.mp4?key=243c9546cfaadeb2c91224abdd49990c&k=69f20c2b563ad8d469d7da97c5fd0e31-64bd-1600933357%26bppcataid%3D26&fpp.ver=1.3.0.4&type=

