### PR TITLE
[real PR not issue]fix downloading of bilibili space videos

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -114,7 +114,7 @@ class Bilibili(VideoExtractor):
 
     @staticmethod
     def bilibili_space_video_api(mid, pn=1, ps=100):
-        return 'https://space.bilibili.com/ajax/member/getSubmitVideos?mid=%s&page=%s&pagesize=%s&order=0&jsonp=jsonp' % (mid, pn, ps)
+        return "https://api.bilibili.com/x/space/arc/search?mid=%s&pn=%s&ps=%s&tid=0&keyword=&order=pubdate&jsonp=jsonp" % (mid, pn, ps)
 
     @staticmethod
     def bilibili_vc_api(video_id):
@@ -734,15 +734,15 @@ class Bilibili(VideoExtractor):
             api_url = self.bilibili_space_video_api(mid)
             api_content = get_content(api_url, headers=self.bilibili_headers())
             videos_info = json.loads(api_content)
-            pc = videos_info['data']['pages']
+            pc = videos_info['data']['page']['count'] // videos_info['data']['page']['ps']
 
             for pn in range(1, pc + 1):
                 api_url = self.bilibili_space_video_api(mid, pn=pn)
                 api_content = get_content(api_url, headers=self.bilibili_headers())
                 videos_info = json.loads(api_content)
 
-                epn, i = len(videos_info['data']['vlist']), 0
-                for video in videos_info['data']['vlist']:
+                epn, i = len(videos_info['data']['list']['vlist']), 0
+                for video in videos_info['data']['list']['vlist']:
                     i += 1; log.w('Extracting %s of %s videos ...' % (i, epn))
                     url = 'https://www.bilibili.com/video/av%s' % video['aid']
                     self.__class__().download_playlist_by_url(url, **kwargs)


### PR DESCRIPTION
### testcase

`you-get -i  https://space.bilibili.com/404193666/video`

### traceback

```
[DEBUG] get_content: https://space.bilibili.com/404193666/video
[DEBUG] get_content: https://space.bilibili.com/404193666/video
[DEBUG] get_content: https://space.bilibili.com/ajax/member/getSubmitVideos?mid=404193666&page=1&pagesize=100&order=0&jsonp=jsonp
you-get: version 0.4.1456, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://space.bilibili.com/404193666/video'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=True, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "/home/pi/.local/bin/you-get", line 10, in <module>
    sys.exit(main())
  File "/home/pi/.local/lib/python3.7/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/home/pi/.local/lib/python3.7/site-packages/you_get/common.py", line 1784, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/home/pi/.local/lib/python3.7/site-packages/you_get/common.py", line 1672, in script_main
    **extra
  File "/home/pi/.local/lib/python3.7/site-packages/you_get/common.py", line 1328, in download_main
    download(url, **kwargs)
  File "/home/pi/.local/lib/python3.7/site-packages/you_get/common.py", line 1775, in any_download
    m.download(url, **kwargs)
  File "/home/pi/.local/lib/python3.7/site-packages/you_get/extractor.py", line 48, in download_by_url
    self.prepare(**kwargs)
  File "/home/pi/.local/lib/python3.7/site-packages/you_get/extractors/bilibili.py", line 177, in prepare
    self.download_playlist_by_url(self.url, **kwargs)
  File "/home/pi/.local/lib/python3.7/site-packages/you_get/extractors/bilibili.py", line 737, in download_playlist_by_url
    pc = videos_info['data']['pages']
TypeError: string indices must be integers
```

### reason
The api used currently is outage.
