### PR TITLE
Cannot Download Past Streams on BiliBili

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -15,53 +15,8 @@ from you_get.extractors import (
 
 
 class YouGetTests(unittest.TestCase):
-    def test_imgur(self):
-        imgur.download('http://imgur.com/WVLk5nD', info_only=True)
-
-    def test_magisto(self):
-        magisto.download(
-            'http://www.magisto.com/album/video/f3x9AAQORAkfDnIFDA',
-            info_only=True
-        )
-
-    def test_youtube(self):
-        youtube.download(
-            'http://www.youtube.com/watch?v=pzKerr0JIPA', info_only=True
-        )
-        youtube.download('http://youtu.be/pzKerr0JIPA', info_only=True)
-        youtube.download(
-            'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
-            info_only=True
-        )
-        youtube.download(
-            'https://www.youtube.com/watch?v=Fpr4fQSh1cc', info_only=True
-        )
-
-    def test_acfun(self):
-        acfun.download('https://www.acfun.cn/v/ac11701912', info_only=True)
-
     def test_bilibil(self):
-        bilibili.download(
-            "https://www.bilibili.com/watchlater/#/BV1PE411q7mZ/p6", info_only=True
-        )
-        bilibili.download(
-            "https://www.bilibili.com/watchlater/#/av74906671/p6", info_only=True
-        )
-
-    def test_soundcloud(self):
-        ## single song
-        soundcloud.download(
-            'https://soundcloud.com/keiny-pham/impure-bird', info_only=True
-        )
-        ## playlist
-        #soundcloud.download(
-        #    'https://soundcloud.com/anthony-flieger/sets/cytus', info_only=True
-        #)
-
-    def tests_tiktok(self):
-        tiktok.download('https://www.tiktok.com/@nmb48_official/video/6850796940293164290', info_only=True)
-        tiktok.download('https://t.tiktok.com/i18n/share/video/6850796940293164290/', info_only=True)
-        tiktok.download('https://vt.tiktok.com/UGJR4R/', info_only=True)
+        bilibili.download("https://live.bilibili.com/record/R1qx411c7hJ", info_only=True)
 
 
 if __name__ == '__main__':

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,14 +3,7 @@
 import unittest
 
 from you_get.extractors import (
-    imgur,
-    magisto,
-    youtube,
-    missevan,
-    acfun,
-    bilibili,
-    soundcloud,
-    tiktok
+    bilibili
 )
 
 


### PR DESCRIPTION
you-get https://live.bilibili.com/record/R1qx411c7hJ --debug


[DEBUG] get_content: https://live.bilibili.com/record/R1qx411c7hJ
[DEBUG] get_content: https://api.live.bilibili.com/room/v1/Room/room_init?id=record
you-get: version 0.4.1456, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://live.bilibili.com/record/R1qx411c7hJ'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "a:\users\max\program files\python\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "a:\users\max\program files\python\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "A:\Users\Max\Program Files\Python\Scripts\you-get.exe\__main__.py", line 7, in <module>
  File "a:\users\max\program files\python\lib\site-packages\you_get\__main__.py", line 92, in main
    main(**kwargs)
  File "a:\users\max\program files\python\lib\site-packages\you_get\common.py", line 1784, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "a:\users\max\program files\python\lib\site-packages\you_get\common.py", line 1672, in script_main
    **extra
  File "a:\users\max\program files\python\lib\site-packages\you_get\common.py", line 1328, in download_main
    download(url, **kwargs)
  File "a:\users\max\program files\python\lib\site-packages\you_get\common.py", line 1775, in any_download
    m.download(url, **kwargs)
  File "a:\users\max\program files\python\lib\site-packages\you_get\extractor.py", line 48, in download_by_url
    self.prepare(**kwargs)
  File "a:\users\max\program files\python\lib\site-packages\you_get\extractors\bilibili.py", line 400, in prepare
    room_id = room_init_info['data']['room_id']
TypeError: list indices must be integers or slices, not str