### PR TITLE
Bilibili video list with a long title download with duplicate file error

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -15,54 +15,10 @@ from you_get.extractors import (
 
 
 class YouGetTests(unittest.TestCase):
-    def test_imgur(self):
-        imgur.download('http://imgur.com/WVLk5nD', info_only=True)
-
-    def test_magisto(self):
-        magisto.download(
-            'http://www.magisto.com/album/video/f3x9AAQORAkfDnIFDA',
-            info_only=True
-        )
-
-    def test_youtube(self):
-        youtube.download(
-            'http://www.youtube.com/watch?v=pzKerr0JIPA', info_only=True
-        )
-        youtube.download('http://youtu.be/pzKerr0JIPA', info_only=True)
-        youtube.download(
-            'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
-            info_only=True
-        )
-        youtube.download(
-            'https://www.youtube.com/watch?v=Fpr4fQSh1cc', info_only=True
-        )
-
-    def test_acfun(self):
-        acfun.download('https://www.acfun.cn/v/ac11701912', info_only=True)
-
     def test_bilibil(self):
-        bilibili.download(
-            "https://www.bilibili.com/watchlater/#/BV1PE411q7mZ/p6", info_only=True
+        bilibili.download_playlist(
+            "https://www.bilibili.com/video/av755179663", playlist=True, info_only=False, output_dir="./tmp", merge=True
         )
-        bilibili.download(
-            "https://www.bilibili.com/watchlater/#/av74906671/p6", info_only=True
-        )
-
-    def test_soundcloud(self):
-        ## single song
-        soundcloud.download(
-            'https://soundcloud.com/keiny-pham/impure-bird', info_only=True
-        )
-        ## playlist
-        #soundcloud.download(
-        #    'https://soundcloud.com/anthony-flieger/sets/cytus', info_only=True
-        #)
-
-    def tests_tiktok(self):
-        tiktok.download('https://www.tiktok.com/@nmb48_official/video/6850796940293164290', info_only=True)
-        tiktok.download('https://t.tiktok.com/i18n/share/video/6850796940293164290/', info_only=True)
-        tiktok.download('https://vt.tiktok.com/UGJR4R/', info_only=True)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
当视频title过长的时候，下载视频列表会因文件重复而失败（）

测试环境：Ubuntu 20.04

比如 https://www.bilibili.com/video/av755179663，文件名称全部被缩成了 `'【本气黑猫】明日方舟第八章攻略合集（更新突袭与隐藏 大骑士领郊外高配堵门速刷 R8-6 R8-8 M8-6 R8-11 M8-8 JT8-2 JT8-3） (P.mp4'` 于是后面的分P下载全部失败