### PR TITLE
[新片场] fix regex to match new vid for Xinpianchang

### DIFF
--- a/src/you_get/extractors/xinpianchang.py
+++ b/src/you_get/extractors/xinpianchang.py
@@ -20,7 +20,7 @@ class Xinpianchang(VideoExtractor):
     def prepare(self, **kwargs):
         # find key
         page_content = get_content(self.url)
-        match_rule = r"vid: \"(.+?)\","
+        match_rule = r"vid = \"(.+?)\";"
         key = re.findall(match_rule, page_content)[0]
 
         # get videos info


### PR DESCRIPTION
之前提取 vid 的 regex 坏了，修一下

测试
```
you-get -i https://www.xinpianchang.com/a10673220
```
```console
site:                xinpianchang
title:               疫情
streams:             # Available quality and codecs
    [ DEFAULT ] _________________________________
    - format:        1080
      container:     mp4
      quality:       高清 1080P
      size:          8.3 MiB (8730005 bytes)
    # download-with: you-get --format=1080 [URL]

    - format:        720
      container:     mp4
      quality:       高清 720P
      size:          3.9 MiB (4108878 bytes)
    # download-with: you-get --format=720 [URL]

    - format:        540
      container:     mp4
      quality:       清晰 540P
      size:          2.5 MiB (2634093 bytes)
    # download-with: you-get --format=540 [URL]

    - format:        360
      container:     mp4
      quality:       流畅 360P
      size:          0.5 MiB (537062 bytes)
    # download-with: you-get --format=360 [URL]
```