### PR TITLE
新片场画质选项有4K的视频下载报错

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -10,7 +10,8 @@ from you_get.extractors import (
     acfun,
     bilibili,
     soundcloud,
-    tiktok
+    tiktok,
+    xinpianchang
 )
 
 
@@ -33,9 +34,9 @@ class YouGetTests(unittest.TestCase):
             'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
             info_only=True
         )
-        #youtube.download(
+        # youtube.download(
         #    'https://www.youtube.com/watch?v=Fpr4fQSh1cc', info_only=True
-        #)
+        # )
 
     def test_acfun(self):
         acfun.download('https://www.acfun.cn/v/ac11701912', info_only=True)
@@ -53,12 +54,18 @@ class YouGetTests(unittest.TestCase):
         soundcloud.download(
             'https://soundcloud.com/keiny-pham/impure-bird', info_only=True
         )
-        ## playlist
-        #soundcloud.download(
-        #    'https://soundcloud.com/anthony-flieger/sets/cytus', info_only=True
-        #)
 
-    #def tests_tiktok(self):
+    def test_xinpianchang(self):
+        ## 4K
+        xinpianchang.download('https://www.xinpianchang.com/a11029357?from=ArticleList', info_only=True)
+        xinpianchang.download('https://www.xinpianchang.com/a10791486?from=ArticleList', info_only=True)
+        xinpianchang.download('https://www.xinpianchang.com/a10296109?from=ArticleList', info_only=True)
+        ## playlist
+        # soundcloud.download(
+        #    'https://soundcloud.com/anthony-flieger/sets/cytus', info_only=True
+        # )
+
+    # def tests_tiktok(self):
     #    tiktok.download('https://www.tiktok.com/@nmb48_official/video/6850796940293164290', info_only=True)
     #    tiktok.download('https://t.tiktok.com/i18n/share/video/6850796940293164290/', info_only=True)
     #    tiktok.download('https://vt.tiktok.com/UGJR4R/', info_only=True)


### PR DESCRIPTION
今天下载新片场的视频，发现画质选项2K以下（包括2K）下载是没有问题的。但是下载画质选项有4K的视频会报错。
报错信息如下：
```
H-goal@H-goaldeiMac ~ % you-get -i 'https://www.xinpianchang.com/a11029357?from=ArticleList' --debug
[DEBUG] get_content: https://www.xinpianchang.com/a11029357?from=ArticleList
[DEBUG] get_content: https://openapi-vtom.vmovier.com/v3/video/YgyDjwovzoo7xv1q?expand=resource
you-get: version 0.4.1488, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.xinpianchang.com/a11029357?from=ArticleList'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=True, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "/usr/local/bin/you-get", line 10, in <module>
    sys.exit(main())
  File "/Library/Python/3.8/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/Library/Python/3.8/site-packages/you_get/common.py", line 1799, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/Library/Python/3.8/site-packages/you_get/common.py", line 1681, in script_main
    download_main(
  File "/Library/Python/3.8/site-packages/you_get/common.py", line 1328, in download_main
    download(url, **kwargs)
  File "/Library/Python/3.8/site-packages/you_get/common.py", line 1790, in any_download
    m.download(url, **kwargs)
  File "/Library/Python/3.8/site-packages/you_get/extractor.py", line 48, in download_by_url
    self.prepare(**kwargs)
  File "/Library/Python/3.8/site-packages/you_get/extractors/xinpianchang.py", line 29, in prepare
    self.title = data["data"]["video"]["title"]
TypeError: 'NoneType' object is not subscriptable
```