### PR TITLE
下载bilibili收藏夹时跳过无效视频 Skip invalid video when downloading bilibili favlist

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -710,12 +710,11 @@ class Bilibili(VideoExtractor):
         elif sort == 'space_favlist':
             m = re.match(r'https?://space\.?bilibili\.com/(\d+)/favlist\?.*fid=(\d+)', self.url)
             vmid, fid = m.group(1), m.group(2)
-            api_url = self.bilibili_space_favlist_api(fid)
+            page_size=20
+            api_url = self.bilibili_space_favlist_api(fid, ps=page_size)
             api_content = get_content(api_url, headers=self.bilibili_headers(referer=self.url))
             favlist_info = json.loads(api_content)
-            pc = favlist_info['data']['info']['media_count'] // len(favlist_info['data']['medias'])
-            if favlist_info['data']['info']['media_count'] % len(favlist_info['data']['medias']) != 0:
-                pc += 1
+            pc = int((favlist_info['data']['info']['media_count']+page_size-1) / page_size)
             for pn in range(1, pc + 1):
                 log.w('Extracting %s of %s pages ...' % (pn, pc))
                 api_url = self.bilibili_space_favlist_api(fid, pn=pn)
@@ -725,6 +724,9 @@ class Bilibili(VideoExtractor):
                 epn, i = len(favlist_info['data']['medias']), 0
                 for video in favlist_info['data']['medias']:
                     i += 1; log.w('Extracting %s of %s videos ...' % (i, epn))
+                    if self.is_video_invalid(video):
+                        log.w("{}:{} is invalid, skip".format(video['id'], video['title']))
+                        continue
                     url = 'https://www.bilibili.com/video/av%s' % video['id']
                     self.__class__().download_playlist_by_url(url, **kwargs)
 
@@ -762,6 +764,9 @@ class Bilibili(VideoExtractor):
                 url = 'https://www.bilibili.com/audio/au%s' % song['id']
                 self.__class__().download_by_url(url, **kwargs)
 
+    @staticmethod
+    def is_video_invalid(video_dict):
+        return not (video_dict["attr"] and video_dict["attr"] in (0, "0"))  # assume 0 is for all valid video
 
 site = Bilibili()
 download = site.download_by_url


### PR DESCRIPTION
程序在遇到无效视频时会因缺少aid跳出 The program would crash if encounter invalid videos in favlist due to missing "aid" keyword.