### PR TITLE
cannot find 1080p+ format for some videos

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -47,6 +47,10 @@ class YouGetTests(unittest.TestCase):
         bilibili.download(
             "https://www.bilibili.com/watchlater/#/av74906671/p6", info_only=True
         )
+        # for 1080p+
+        bilibili.download(
+            "https://www.bilibili.com/video/BV1Z4411A7Ye", info_only=True
+        )
 
     def test_soundcloud(self):
         ## single song


### PR DESCRIPTION
Searched with cookie(b站大会员) enable. Cannot find the "1080P+ 高码率" stream type. Bilibili now adding support about 1080P+高码率 for some old videos that initially only support 1080P, and you-get cannot detect them. But only [some] of videos cannot be detected. (Another example that cannot detect 1080P+: https://www.bilibili.com/video/BV1ns411H7sJ). New videos and some other old videos that have the 1080P+高码率 format nowadays can be detected in you-get. 