### PR TITLE
bandcamp download json error

### DIFF
--- a/src/you_get/extractors/bandcamp.py
+++ b/src/you_get/extractors/bandcamp.py
@@ -6,7 +6,7 @@ from ..common import *
 
 def bandcamp_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
     html = get_html(url)
-    trackinfo = json.loads(r1(r'(\[{"(video_poster_url|video_caption)".*}\]),', html))
+    trackinfo = json.loads(r1(r'(\[{"(video_poster_url|video_caption)".*}\]),', html)) #here is an issue that i can't fix
     for track in trackinfo:
         track_num = track['track_num']
         title = '%s. %s' % (track_num, track['title'])


### PR DESCRIPTION
tryed to download any bandcamp album, nothing works.
--debug:
```[DEBUG] get_response: https://4everfreebrony.bandcamp.com/album/fireside
you-get: version 0.4.1500, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://4everfreebrony.bandcamp.com/album/fireside'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "/usr/local/bin/you-get", line 8, in <module>
    sys.exit(main())
  File "/home/tombays/.local/lib/python3.8/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/home/tombays/.local/lib/python3.8/site-packages/you_get/common.py", line 1798, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/home/tombays/.local/lib/python3.8/site-packages/you_get/common.py", line 1680, in script_main
    download_main(
  File "/home/tombays/.local/lib/python3.8/site-packages/you_get/common.py", line 1327, in download_main
    download(url, **kwargs)
  File "/home/tombays/.local/lib/python3.8/site-packages/you_get/common.py", line 1789, in any_download
    m.download(url, **kwargs)
  File "/home/tombays/.local/lib/python3.8/site-packages/you_get/extractors/bandcamp.py", line 9, in bandcamp_download
    trackinfo = json.loads(r1(r'(\[{"(video_poster_url|video_caption)".*}\]),', html))
  File "/usr/lib/python3.8/json/__init__.py", line 341, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```