### PR TITLE
Can not download the youtube subtitles,无法下载油管字幕

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ _*
 
 .vscode
 
+#can not download the youtube captions

--- a/src/you_get/extractors/youtube.py
+++ b/src/you_get/extractors/youtube.py
@@ -203,8 +203,9 @@ class YouTube(VideoExtractor):
                 # Parse video page (for DASH)
                 video_page = get_content('https://www.youtube.com/watch?v=%s' % self.vid)
                 try:
+                    #Here is some thing wrong, but I dont konw how to fix it. json Error.
                     ytplayer_config = json.loads(re.search('ytplayer.config\s*=\s*([^\n]+?});', video_page).group(1))
-
+                    
                     # Workaround: get_video_info returns bad s. Why?
                     if 'url_encoded_fmt_stream_map' not in ytplayer_config['args']:
                         stream_list = json.loads(ytplayer_config['args']['player_response'])['streamingData']['formats']


### PR DESCRIPTION
升级0.4.15后，无法下载油管字幕，刚开始以为是视频没有字幕，所以没有下载。
后来使用之前已经下载过，且也下载了字幕的视频连接测试，也是没有下载到字幕。
请问字幕下载功能是否能恢复。

After upgrading to 0.4.15, the YouTube subtitles could not be downloaded. At first, I thought that the video did not have subtitles, so I didn't download it.
Later, I have used the video connection I download before for testing, it was downloaded the subtitles, but now it did not download the subtitles also.
Can the subtitle download function be restored?
