### PR TITLE
weibo/miaopai video download failed. 微博/秒拍 视频下载失败

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -3,66 +3,18 @@
 import unittest
 
 from you_get.extractors import (
-    imgur,
-    magisto,
-    youtube,
-    missevan,
-    acfun,
     bilibili,
-    soundcloud,
-    tiktok
+    miaopai
 )
 
 
 class YouGetTests(unittest.TestCase):
-    def test_imgur(self):
-        imgur.download('http://imgur.com/WVLk5nD', info_only=True)
-
-    def test_magisto(self):
-        magisto.download(
-            'http://www.magisto.com/album/video/f3x9AAQORAkfDnIFDA',
-            info_only=True
-        )
-
-    def test_youtube(self):
-        youtube.download(
-            'http://www.youtube.com/watch?v=pzKerr0JIPA', info_only=True
-        )
-        youtube.download('http://youtu.be/pzKerr0JIPA', info_only=True)
-        youtube.download(
-            'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
-            info_only=True
-        )
-        #youtube.download(
-        #    'https://www.youtube.com/watch?v=Fpr4fQSh1cc', info_only=True
-        #)
-
-    def test_acfun(self):
-        acfun.download('https://www.acfun.cn/v/ac11701912', info_only=True)
-
     def test_bilibili(self):
         bilibili.download(
-            "https://www.bilibili.com/watchlater/#/BV1PE411q7mZ/p6", info_only=True
+            "https://www.bilibili.com/video/BV1xT4y1T7xA/", info_only=True
         )
-        bilibili.download(
-            "https://www.bilibili.com/watchlater/#/av74906671/p6", info_only=True
-        )
-
-    def test_soundcloud(self):
-        ## single song
-        soundcloud.download(
-            'https://soundcloud.com/keiny-pham/impure-bird', info_only=True
-        )
-        ## playlist
-        #soundcloud.download(
-        #    'https://soundcloud.com/anthony-flieger/sets/cytus', info_only=True
-        #)
-
-    #def tests_tiktok(self):
-    #    tiktok.download('https://www.tiktok.com/@nmb48_official/video/6850796940293164290', info_only=True)
-    #    tiktok.download('https://t.tiktok.com/i18n/share/video/6850796940293164290/', info_only=True)
-    #    tiktok.download('https://vt.tiktok.com/UGJR4R/', info_only=True)
-
+    def test_weibo(self):
+        miaopai.download('https://weibo.com/1748075785/K4VLHbVQB', info_only=True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
weibo/miaopai video download failed. 微博/秒拍 视频下载失败

you-get --version
```
you-get: version 0.4.1500, a tiny downloader that scrapes the web.

```

<details>
  <summary>cli output:</summary>

    $ you-get "https://weibo.com/1748075785/K4VLHbVQB" --debug
    [DEBUG] get_content: https://weibo.com/1748075785/K4VLHbVQB
    [DEBUG] get_content: http://video.weibo.com/show?fid=1034:4611434789928964&type=mp4
    you-get: version 0.4.1500, a tiny downloader that scrapes the web.
    you-get: Namespace(URL=['https://weibo.com/1748075785/K4VLHbVQB'], auto_rename=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir='.', output_filename=None, password=None, player=None, playlist=False, skip_existing_file_size_check=False, socks_proxy=None, stream=None, timeout=600, url=False, version=False)
    Traceback (most recent call last):
      File "/usr/lib/python3.8/urllib/request.py", line 1350, in do_open
        h.request(req.get_method(), req.selector, req.data, headers,
      File "/usr/lib/python3.8/http/client.py", line 1255, in request
        self._send_request(method, url, body, headers, encode_chunked)
      File "/usr/lib/python3.8/http/client.py", line 1301, in _send_request
        self.endheaders(body, encode_chunked=encode_chunked)
      File "/usr/lib/python3.8/http/client.py", line 1250, in endheaders
        self._send_output(message_body, encode_chunked=encode_chunked)
      File "/usr/lib/python3.8/http/client.py", line 1010, in _send_output
        self.send(msg)
      File "/usr/lib/python3.8/http/client.py", line 950, in send
        self.connect()
      File "/usr/lib/python3.8/http/client.py", line 921, in connect
        self.sock = self._create_connection(
      File "/usr/lib/python3.8/socket.py", line 808, in create_connection
        raise err
      File "/usr/lib/python3.8/socket.py", line 796, in create_connection
        sock.connect(sa)
    ConnectionRefusedError: [Errno 111] Connection refused
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/home/cat/.local/bin/you-get", line 8, in <module>
        sys.exit(main())
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/__main__.py", line 92, in main
        main(**kwargs)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/common.py", line 1798, in main
        script_main(any_download, any_download_playlist, **kwargs)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/common.py", line 1680, in script_main
        download_main(
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/common.py", line 1327, in download_main
        download(url, **kwargs)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/common.py", line 1789, in any_download
        m.download(url, **kwargs)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/extractors/miaopai.py", line 124, in miaopai_download
        miaopai_download(urllib.parse.unquote(escaped_url), output_dir=output_dir, merge=merge, info_only=info_only, **kwargs)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/extractors/miaopai.py", line 113, in miaopai_download
        miaopai_download_by_fid(fid, output_dir, merge, info_only)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/extractors/miaopai.py", line 24, in miaopai_download_by_fid
        mobile_page = get_content(page_url, headers=fake_headers_mobile)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/common.py", line 439, in get_content
        response = urlopen_with_retry(req)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/common.py", line 408, in urlopen_with_retry
        return request.urlopen(*args, **kwargs)
      File "/usr/lib/python3.8/urllib/request.py", line 222, in urlopen
        return opener.open(url, data, timeout)
      File "/usr/lib/python3.8/urllib/request.py", line 525, in open
        response = self._open(req, data)
      File "/usr/lib/python3.8/urllib/request.py", line 542, in _open
        result = self._call_chain(self.handle_open, protocol, protocol +
      File "/usr/lib/python3.8/urllib/request.py", line 502, in _call_chain
        result = func(*args)
      File "/usr/lib/python3.8/urllib/request.py", line 1379, in http_open
        return self.do_open(http.client.HTTPConnection, req)
      File "/usr/lib/python3.8/urllib/request.py", line 1353, in do_open
        raise URLError(err)
    urllib.error.URLError: <urlopen error [Errno 111] Connection refused>

</details>

<details>
  <summary>test case output:</summary>

    $ python3 test.py 
    site:                Bilibili
    title:               鬼知道我又看了几遍
    streams:             # Available quality and codecs
        [ DASH ] ____________________________________
        - format:        dash-flv720
          container:     mp4
          quality:       高清 720P
          size:          16.3 MiB (17040856 bytes)
        # download-with: you-get --format=dash-flv720 [URL]
    
        - format:        dash-flv480
          container:     mp4
          quality:       清晰 480P
          size:          9.4 MiB (9859692 bytes)
        # download-with: you-get --format=dash-flv480 [URL]
    
        - format:        dash-flv360
          container:     mp4
          quality:       流畅 360P
          size:          4.4 MiB (4608363 bytes)
        # download-with: you-get --format=dash-flv360 [URL]
    
        [ DEFAULT ] _________________________________
        - format:        flv480
          container:     flv
          quality:       清晰 480P
          size:          9.7 MiB (10151164 bytes)
        # download-with: you-get --format=flv480 [URL]
    
        - format:        flv360
          container:     flv
          quality:       流畅 360P
          size:          4.5 MiB (4672337 bytes)
        # download-with: you-get --format=flv360 [URL]
    
    .E
    ======================================================================
    ERROR: test_weibo (__main__.YouGetTests)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/usr/lib/python3.8/urllib/request.py", line 1350, in do_open
        h.request(req.get_method(), req.selector, req.data, headers,
      File "/usr/lib/python3.8/http/client.py", line 1255, in request
        self._send_request(method, url, body, headers, encode_chunked)
      File "/usr/lib/python3.8/http/client.py", line 1301, in _send_request
        self.endheaders(body, encode_chunked=encode_chunked)
      File "/usr/lib/python3.8/http/client.py", line 1250, in endheaders
        self._send_output(message_body, encode_chunked=encode_chunked)
      File "/usr/lib/python3.8/http/client.py", line 1010, in _send_output
        self.send(msg)
      File "/usr/lib/python3.8/http/client.py", line 950, in send
        self.connect()
      File "/usr/lib/python3.8/http/client.py", line 921, in connect
        self.sock = self._create_connection(
      File "/usr/lib/python3.8/socket.py", line 808, in create_connection
        raise err
      File "/usr/lib/python3.8/socket.py", line 796, in create_connection
        sock.connect(sa)
    ConnectionRefusedError: [Errno 111] Connection refused
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "test.py", line 21, in test_weibo
        miaopai.download('https://weibo.com/1748075785/K4VLHbVQB', info_only=True)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/extractors/miaopai.py", line 124, in miaopai_download
        miaopai_download(urllib.parse.unquote(escaped_url), output_dir=output_dir, merge=merge, info_only=info_only, **kwargs)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/extractors/miaopai.py", line 113, in miaopai_download
        miaopai_download_by_fid(fid, output_dir, merge, info_only)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/extractors/miaopai.py", line 24, in miaopai_download_by_fid
        mobile_page = get_content(page_url, headers=fake_headers_mobile)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/common.py", line 439, in get_content
        response = urlopen_with_retry(req)
      File "/home/cat/.local/lib/python3.8/site-packages/you_get/common.py", line 408, in urlopen_with_retry
        return request.urlopen(*args, **kwargs)
      File "/usr/lib/python3.8/urllib/request.py", line 222, in urlopen
        return opener.open(url, data, timeout)
      File "/usr/lib/python3.8/urllib/request.py", line 525, in open
        response = self._open(req, data)
      File "/usr/lib/python3.8/urllib/request.py", line 542, in _open
        result = self._call_chain(self.handle_open, protocol, protocol +
      File "/usr/lib/python3.8/urllib/request.py", line 502, in _call_chain
        result = func(*args)
      File "/usr/lib/python3.8/urllib/request.py", line 1379, in http_open
        return self.do_open(http.client.HTTPConnection, req)
      File "/usr/lib/python3.8/urllib/request.py", line 1353, in do_open
        raise URLError(err)
    urllib.error.URLError: <urlopen error [Errno 111] Connection refused>
    
    ----------------------------------------------------------------------
    Ran 2 tests in 9.931s
    
    FAILED (errors=1)

</details>