### PR TITLE
Test downloading youku videos with output_filename failed

### DIFF
--- a/test_youku_name.py
+++ b/test_youku_name.py
@@ -1,0 +1,4 @@
+from you_get.common import load_cookies,output_filename
+load_cookies('cookies_yk.txt')
+output_filename='1'
+youku.download('https://v.youku.com/v_show/id_XNTA1ODA3Njg0OA==.html?spm=a2hcb.12701310.app.5~5!2~5!3~5~5~5~5~5~5~A&s=afdc71a13720455baaa5',file='1',output_dir='./',merge=True)


### PR DESCRIPTION
Expect to pass filename to youku.download(), and output filename should be '1.mp4', but not work.
Result:
```
>>> from you_get.common import load_cookies,output_filename
>>> load_cookies('cookies_yk.txt')
>>> output_filename='1'
>>> youku.download('https://v.youku.com/v_show/id_XNTA1ODA3Njg0OA==.html?spm=a2hcb.12701310.app.5~5!2~5!3~5~5~5~5~5~5~A&s=afdc71a13720455baaa5',file='1',output_dir='./',merge=True)
site:                优酷 (Youku)
title:               紧急公关 01
stream:
    - format:        mp4hd3v2
      container:     mp4
      video-profile: 1080P
      size:          374.4 MiB (392589859 bytes)
      m3u8_url:      http://pl-ali.youku.com/playlist/m3u8?vid=XNTA1ODA3Njg0OA&type=mp4hd3v3&ups_client_netip=444f1482&utid=BcfiGC7jg3YCAURPFIIjlMlJ&ccode=0532&psid=e6482ff75e0d3740882f8fc71a04673d428ac&ups_userid=1638036821&ups_ytid=1638036821&duration=2725&expire=18000&drm_type=1&drm_device=0&hotvt=1&dyt=0&btf=&rid=200000001F8ED9F78335F062ACBF1F2DA795B56E02000000&ups_ts=1616632073&onOff=0&encr=0&ups_key=d6e619287d6299e8692dc5f82276bc3b
    # download-with: you-get --format=mp4hd3v2 [URL]

you-get: Skipping ./紧急公关 01.mp4: file already exists
```