### PR TITLE
CCTV videos are downloaded completely but failed to merge

### DIFF
--- a/src/you_get/extractors/missevan.py
+++ b/src/you_get/extractors/missevan.py
@@ -75,17 +75,13 @@ class _Dispatcher(object):
         raise _NoMatchException()
 
 missevan_stream_types = [
-    {'id': 'source', 'quality': '源文件', 'url_json_key': 'soundurl',
-     'resource_url_fmt': 'sound/{resource_url}'},
-    {'id': '320', 'quality': '320 Kbps', 'url_json_key': 'soundurl_64'},
+    {'id': 'source', 'quality': '源文件', 'url_json_key': 'soundurl'},
     {'id': '128', 'quality': '128 Kbps', 'url_json_key': 'soundurl_128'},
-    {'id': '32', 'quality': '32 Kbps', 'url_json_key': 'soundurl_32'},
     {'id': 'covers', 'desc': '封面图', 'url_json_key': 'cover_image',
      'default_src': 'covers/nocover.png',
      'resource_url_fmt': 'covers/{resource_url}'},
-    {'id': 'coversmini', 'desc': '封面缩略图', 'url_json_key': 'cover_image',
-     'default_src': 'coversmini/nocover.png',
-     'resource_url_fmt': 'coversmini/{resource_url}'}
+    {'id': 'coversmini', 'desc': '封面缩略图', 'url_json_key': 'front_cover',
+     'default_src': 'coversmini/nocover.png'}
 ]
 
 def _get_resource_uri(data, stream_type):

--- a/src/you_get/extractors/missevan.py
+++ b/src/you_get/extractors/missevan.py
@@ -353,7 +353,7 @@ class MissEvan(VideoExtractor):
 
     @staticmethod
     def url_resource(uri):
-        return 'https://static.missevan.com/' + uri
+        return uri if re.match(r'^https?:/{2}\w.+$', uri) else 'https://static.missevan.com/' + uri
 
 site = MissEvan()
 site_info = 'MissEvan.com'


### PR DESCRIPTION

D:\youget>you-get --format=4 https://tv.cctv.com/2021/06/15/VIDE83NJC5ppHghK78SSbkMO210615.shtml?spm=C55853485115.PbyFRuU7DWZS.0.0
site:                CNTV.com
title:               《叛逆者》 第11集
stream:
    - format:        4
      container:     mp4
      video-profile: 480x270_450kb/s
    # download-with: you-get --format=4 [URL]

Downloading 《叛逆者》 第11集.mp4 ...
 100% (135.5/135.5MB) ├████████████████████████████████████████┤[9/9]   38 kB/syou-get: [error] oops, someth
ing went wrong.
you-get: don't panic, c'est la vie. please try the following steps:
you-get:   (1) Rule out any network problem.
you-get:   (2) Make sure you-get is up-to-date.
you-get:   (3) Check if the issue is already known, on
you-get:         https://github.com/soimort/you-get/wiki/Known-Bugs
you-get:         https://github.com/soimort/you-get/issues
you-get:   (4) Run the command with '--debug' option,
you-get:       and report this issue with the full output.

Merging video parts...
.\《叛逆者》 第11集[00].mp4