### PR TITLE
Unable to get data and download video in the same script（无法在同一个脚本中获取数据并下载视频）

### DIFF
--- a/src/you_get/test.py
+++ b/src/you_get/test.py
@@ -1,0 +1,59 @@
+import traceback
+import sys
+from you_get import common as you_get
+import io
+import os
+
+url = "https://www.bilibili.com/video/BV1GV411p7P9"
+path = os.path.dirname(os.path.realpath(__file__))
+
+def getJson(url):
+    from you_get import common as you
+    try:
+        __console__ = sys.stdout
+        f = io.StringIO()
+        sys.stdout = f
+        sys.argv = ['you-get', url, '--json']
+        you.main()
+        text = f.getvalue()
+        sys.stdout = __console__
+        print(text)
+    except:
+        traceback.print_exc()
+
+
+def getDefaultDownloadInfo(url):
+    try:
+        __console__ = sys.stdout
+        f = io.StringIO()
+        sys.stdout = f
+        sys.argv = ['you-get', url, '-u']
+        you_get.main()
+        text = f.getvalue()
+        sys.stdout = __console__
+        print(text)
+    except:
+        traceback.print_exc()
+
+
+def download(url, path):
+    try:
+        sys.argv = ['you-get', url, '-o', path, '--no-caption', '--debug']
+        you_get.main()
+    except:
+        traceback.print_exc()
+
+
+if __name__ == '__main__':
+    # only use one sentence, they all ok （使用如下的单条语句，都是可以正常打印的， 并且可以下载视频）
+    # both are cant download video with combine （但是将语句组合使用，打印出的结果就有问题了， 并且无法下载视频）
+
+    # use these lines, print double json text （使用如下语句，将会打印出两次 json 解析数据）
+    getDefaultDownloadInfo(url)
+    getJson(url)
+    download(url, path)
+
+    # or use these lines, print triple json text （使用如下语句，仅仅改变排序，将会打印出三次 json 解析数据）
+    # getJson(url)
+    # getDefaultDownloadInfo(url)
+    # download(url, "save path")


### PR DESCRIPTION
Q: Hello, developers, I have encountered a problem, I need use you-get three times to obtain the data. However, problems were found in the following code. After performing getjson and getDefaultDownloadInfo, execute Download, with redirect output, the text exception is obtained, and the download video will be invalid.
问题：你好，开发者，我遇到了一个问题，我需要通过三次调用you-get 方法来获取我想要的数据。但是，在如下代码中发现了问题。执行getJson和getDefaultDownloadInfo之后再执行download，重定向输出后，获取到的文本异常，并且下载视频将无效。