### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/you_get/extractors/flickr.py
+++ b/src/you_get/extractors/flickr.py
@@ -73,7 +73,7 @@ def get_api_key(page):
     match = match1(page, pattern_inline_api_key)
     # this happens only when the url points to a gallery page
     # that contains no inline api_key(and never makes xhr api calls)
-    # in fact this might be a better approch for getting a temporary api key
+    # in fact this might be a better approach for getting a temporary api key
     # since there's no place for a user to add custom information that may
     # misguide the regex in the homepage
     if not match:

--- a/src/you_get/extractors/mtv81.py
+++ b/src/you_get/extractors/mtv81.py
@@ -28,7 +28,7 @@ def mtv81_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
     #
     # rtmpdump  -r 'rtmpe://cp30865.edgefcs.net/ondemand/mtviestor/_!/intlod/MTVInternational/MBUS/GeoLocals/00JP/VIAMTVI/PYC/201304/7122HVAQ4/00JPVIAMTVIPYC7122HVAQ4_640x_360_1200_m30.mp4' -o "title.mp4" --swfVfy http://media.mtvnservices.com/player/prime/mediaplayerprime.1.10.8.swf
     #
-    # because rtmpdump is unstable,may try serveral times
+    # because rtmpdump is unstable,may try several times
     #
     if not info_only:
         # import pdb

--- a/src/you_get/extractors/qingting.py
+++ b/src/you_get/extractors/qingting.py
@@ -10,7 +10,7 @@ __all__ = ['qingting_download_by_url']
 
 class Qingting(VideoExtractor):
     # every resource is described by its channel id and program id
-    # so vid is tuple (chaanel_id, program_id)
+    # so vid is tuple (channel_id, program_id)
 
     name = 'Qingting'
     stream_types = [


### PR DESCRIPTION
There are small typos in:
- src/you_get/extractors/flickr.py
- src/you_get/extractors/mtv81.py
- src/you_get/extractors/qingting.py

Fixes:
- Should read `several` rather than `serveral`.
- Should read `channel` rather than `chaanel`.
- Should read `approach` rather than `approch`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md