### PR TITLE
missing files when downloading bilibili's playlist cause the title was too long

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -210,7 +210,10 @@ class Bilibili(VideoExtractor):
                     '1')  # use URL to decide p-number, not initial_state['p']
             if pn > 1:
                 part = initial_state['videoData']['pages'][p - 1]['part']
-                self.title = '%s (P%s. %s)' % (self.title, p, part)
+                """
+                title's length is limited max 80 characters defined in `utils.fs.legitimize`.
+                """
+                self.title = 'P%s. %s' % (p, part)
 
             # construct playinfos
             avid = initial_state['aid']

--- a/tests/test.py
+++ b/tests/test.py
@@ -40,6 +40,10 @@ class YouGetTests(unittest.TestCase):
     def test_acfun(self):
         acfun.download('https://www.acfun.cn/v/ac11701912', info_only=True)
 
+    def test_bilibili(self):
+        bilibili.download_playlist('https://www.bilibili.com/video/BV1Zv411G7ty', output_dir='.', playlist=True,
+                                   merge=True, is_only=True)
+
     #def test_soundcloud(self):
         ## single song
         #soundcloud.download(


### PR DESCRIPTION
1. the title will be truncated by `utils.fs.legitimize` to 80 characters
2. the title was too long than `80` characters