### PR TITLE
Facebook download video

### DIFF
--- a/src/you_get/extractors/qq.py
+++ b/src/you_get/extractors/qq.py
@@ -35,6 +35,7 @@ def qq_download_by_vid(vid, title, output_dir='.', merge=True, info_only=False):
 
     part_urls= []
     total_size = 0
+    ext = None
     for part in range(1, seg_cnt+1):
         if fc_cnt == 0:
             # fix json parsing error

--- a/src/you_get/extractors/universal.py
+++ b/src/you_get/extractors/universal.py
@@ -70,12 +70,13 @@ def universal_download(url, output_dir='.', merge=True, info_only=False, **kwarg
                       '[-_][6-9]\d\dx1\d\d\d\.jpe?g',
                       '[-_][6-9]\d\dx[6-9]\d\d\.jpe?g',
                       's1600/[\w%]+\.jpe?g', # blogger
+                      'blogger\.googleusercontent\.com/img/a/\w*', # blogger
                       'img[6-9]\d\d/[\w%]+\.jpe?g' # oricon?
         ]
 
         urls = []
         for i in media_exts:
-            urls += re.findall(r'(https?://[^ ;&"\'\\<>]+' + i + r'[^ ;&"\'\\<>]*)', page)
+            urls += re.findall(r'(https?://[^ ;&"\'\\<>]*' + i + r'[^ ;&"\'\\<>]*)', page)
 
             p_urls = re.findall(r'(https?%3A%2F%2F[^;&"]+' + i + r'[^;&"]*)', page)
             urls += [parse.unquote(url) for url in p_urls]


### PR DESCRIPTION
[DEBUG] get_response: https://facebook.com/100017203925039/videos/391306875996747/
you-get: version 0.4.1545, a tiny downloader that scrapes the web.
you-get: Namespace(version=False, help=False, info=False, url=False, json=False, no_merge=False, no_caption=False, force=False, skip_existing_file_size_check=False, format=None, output_filename=None, output_dir='.', player=None, cookies=None, timeout=600, debug=True, input_file=None, password=None, playlist=False, first=None, last=None, size=None, auto_rename=False, insecure=False, http_proxy=None, extractor_proxy=None, no_proxy=False, socks_proxy=None, stream=None, itag=None, URL=['https://www.facebook.com/100017203925039/videos/391306875996747/'])
Traceback (most recent call last):
  File "/usr/local/bin/you-get", line 33, in <module>
    sys.exit(load_entry_point('you-get==0.4.1545', 'console_scripts', 'you-get')())
  File "/usr/local/Cellar/you-get/0.4.1545/libexec/lib/python3.9/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/usr/local/Cellar/you-get/0.4.1545/libexec/lib/python3.9/site-packages/you_get/common.py", line 1831, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/usr/local/Cellar/you-get/0.4.1545/libexec/lib/python3.9/site-packages/you_get/common.py", line 1713, in script_main
    download_main(
  File "/usr/local/Cellar/you-get/0.4.1545/libexec/lib/python3.9/site-packages/you_get/common.py", line 1345, in download_main
    download(url, **kwargs)
  File "/usr/local/Cellar/you-get/0.4.1545/libexec/lib/python3.9/site-packages/you_get/common.py", line 1822, in any_download
    m.download(url, **kwargs)
  File "/usr/local/Cellar/you-get/0.4.1545/libexec/lib/python3.9/site-packages/you_get/extractors/facebook.py", line 27, in facebook_download
    type, ext, size = url_info(urls[0], True)
IndexError: list index out of range