### PR TITLE
[bilibili] fix 'NoneType' object is not subscriptable

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -193,10 +193,12 @@ class Bilibili(VideoExtractor):
 
             playinfo_text = match1(html_content, r'__playinfo__=(.*?)</script><script>')  # FIXME
             playinfo = json.loads(playinfo_text) if playinfo_text else None
+            playinfo = playinfo if playinfo['code'] == 0 else None
 
             html_content_ = get_content(self.url, headers=self.bilibili_headers(cookie='CURRENT_FNVAL=16'))
             playinfo_text_ = match1(html_content_, r'__playinfo__=(.*?)</script><script>')  # FIXME
             playinfo_ = json.loads(playinfo_text_) if playinfo_text_ else None
+            playinfo_ = playinfo_ if playinfo_['code'] == 0 else None
 
             # warn if it is a multi-part video
             pn = initial_state['videoData']['videos']


### PR DESCRIPTION
```console
$ ./you-get -i --debug https://www.bilibili.com/video/BV1ex411c7jX
[DEBUG] get_content: https://www.bilibili.com/video/BV1ex411c7jX
[DEBUG] get_content: https://www.bilibili.com/video/BV1ex411c7jX
you-get: version 0.4.1545, a tiny downloader that scrapes the web.
you-get: Namespace(version=False, help=False, info=True, url=False, json=False, no_merge=False, no_caption=False, force=False, skip_existing_file_size_check=False, format=None, output_filename=None, output_dir='.', player=None, cookies=None, timeout=600, debug=True, input_file=None, password=None, playlist=False, first=None, last=None, size=None, auto_rename=False, insecure=False, http_proxy=None, extractor_proxy=None, no_proxy=False, socks_proxy=None, stream=None, itag=None, URL=['https://www.bilibili.com/video/BV1ex411c7jX'])
Traceback (most recent call last):
  File "/home/chuang/Documents/you-get/./you-get", line 11, in <module>
    you_get.main(repo_path=_filepath)
  File "/home/chuang/Documents/you-get/src/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/home/chuang/Documents/you-get/src/you_get/common.py", line 1831, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/home/chuang/Documents/you-get/src/you_get/common.py", line 1713, in script_main
    download_main(
  File "/home/chuang/Documents/you-get/src/you_get/common.py", line 1345, in download_main
    download(url, **kwargs)
  File "/home/chuang/Documents/you-get/src/you_get/common.py", line 1822, in any_download
    m.download(url, **kwargs)
  File "/home/chuang/Documents/you-get/src/you_get/extractor.py", line 48, in download_by_url
    self.prepare(**kwargs)
  File "/home/chuang/Documents/you-get/src/you_get/extractors/bilibili.py", line 220, in prepare
    current_quality = playinfo['data']['quality'] or None  # 0 indicates an error, fallback to None
KeyError: 'data'
```

It seems that bilibili messed up something in the front end, causing that the `__playinfo__` variable in HTML is a failed API request.

```console
$ curl --compressed https://www.bilibili.com/video/BV1ex411c7jX -H 'User-Agent: Firefox/93.0' | grep __playinfo__
...cript> <script>window.__playinfo__={"code":-404,"message":"啥都木有","ttl":1,"session":"c0e4280b0f64033865e990f1490c9a07"}</script><s...
```

In this PR I added two simple checks to make sure the embedded `__playinfo__` is a valid one.