### PR TITLE
Add new option "--postfix" to postfix downloaded files

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -137,6 +137,7 @@ output_filename = None
 auto_rename = False
 insecure = False
 m3u8 = False
+postfix = False
 
 fake_headers = {
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',  # noqa
@@ -984,6 +985,8 @@ def download_urls(
             pass
 
     title = tr(get_filename(title))
+    if postfix and 'vid' in kwargs:
+        title = "%s [%s]" % (title, kwargs['vid'])
     output_filename = get_output_filename(urls, title, ext, output_dir, merge)
     output_filepath = os.path.join(output_dir, output_filename)
 
@@ -1533,6 +1536,10 @@ def script_main(download, download_playlist, **kwargs):
         help='Do not download captions (subtitles, lyrics, danmaku, ...)'
     )
     download_grp.add_argument(
+        '--postfix', action='store_true', default=False,
+        help='Postfix downloaded files with unique identifiers'
+    )
+    download_grp.add_argument(
         '-f', '--force', action='store_true', default=False,
         help='Force overwriting existing files'
     )
@@ -1654,6 +1661,7 @@ def script_main(download, download_playlist, **kwargs):
     global auto_rename
     global insecure
     global m3u8
+    global postfix
     output_filename = args.output_filename
     extractor_proxy = args.extractor_proxy
 
@@ -1690,6 +1698,7 @@ def script_main(download, download_playlist, **kwargs):
         # ignore ssl
         insecure = True
 
+    postfix = args.postfix
 
     if args.no_proxy:
         set_http_proxy('')

--- a/src/you_get/extractor.py
+++ b/src/you_get/extractor.py
@@ -238,7 +238,8 @@ class VideoExtractor():
             download_urls(urls, self.title, ext, total_size, headers=headers,
                           output_dir=kwargs['output_dir'],
                           merge=kwargs['merge'],
-                          av=stream_id in self.dash_streams)
+                          av=stream_id in self.dash_streams,
+                          vid=self.vid)
 
             if 'caption' not in kwargs or not kwargs['caption']:
                 print('Skipping captions or danmaku.')


### PR DESCRIPTION
Different videos might have the same title. This option `--postfix` postfixes downloaded videos with their unique identifiers to guarantee that they do not get overwritten accidentally.

Currently this option only works for YouTube.