### PR TITLE
Bilibili: fix "真彩 HDR" video_resolution

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -13,7 +13,7 @@ class Bilibili(VideoExtractor):
     # Bilibili media encoding options, in descending quality order.
     stream_types = [
         {'id': 'hdflv2', 'quality': 125, 'audio_quality': 30280,
-         'container': 'FLV', 'video_resolution': '3840p', 'desc': '真彩 HDR'},
+         'container': 'FLV', 'video_resolution': '2160p', 'desc': '真彩 HDR'},
         {'id': 'hdflv2_4k', 'quality': 120, 'audio_quality': 30280,
          'container': 'FLV', 'video_resolution': '2160p', 'desc': '超清 4K'},
         {'id': 'flv_p60', 'quality': 116, 'audio_quality': 30280,


### PR DESCRIPTION
Video resolution of Bilibili "真彩 HDR" is 2160p (3840x2160), not 3840p.