### PR TITLE
Extremely slow download (~50KB/s) from YouTube

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -33,9 +33,9 @@ class YouGetTests(unittest.TestCase):
         #    'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
         #    info_only=True
         #)
-        #youtube.download(
-        #    'https://www.youtube.com/watch?v=Fpr4fQSh1cc', info_only=True
-        #)
+        youtube.download(
+            'https://www.youtube.com/watch?v=khGhZrYaEQ0&list=PLhFI5R_xInjdhtWuhgYlA8NZGXO-unnl4&index=1', info_only=True
+        )
 
     def test_acfun(self):
         acfun.download('https://www.acfun.cn/v/ac11701912', info_only=True)


### PR DESCRIPTION
Seemingly this is due to a new restriction imposed by YouTube. See https://github.com/ytdl-org/youtube-dl/issues/30102
The tool `yt-dlp` has a workaround for this.