### PR TITLE
clear stream info

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -141,6 +141,8 @@ class Bilibili(VideoExtractor):
 
     def prepare(self, **kwargs):
         self.stream_qualities = {s['quality']: s for s in self.stream_types}
+        self.streams.clear()
+        self.dash_streams.clear()
 
         try:
             html_content = get_content(self.url, headers=self.bilibili_headers(referer=self.url))


### PR DESCRIPTION
When download video consecutively, like ```you-get -I download.txt ...```, previous stream info is not clear, may cause download wrong video.
连续下载，例如使用-I模式时，前一个视频的信息未被清除，导致下载视频错误