### PR TITLE
Updated google search back up to correctly handle non-url parameters

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -1782,10 +1782,10 @@ def script_main(download, download_playlist, **kwargs):
 
 def google_search(url):
     keywords = r1(r'https?://(.*)', url)
-    url = 'https://www.google.com/search?tbm=vid&q=%s' % parse.quote(keywords)
+    url = 'https://www.google.com/search?tbm=vid&q=%s' % parse.quote(str(keywords))
     page = get_content(url, headers=fake_headers)
     videos = re.findall(
-        r'<a href="(https?://[^"]+)" onmousedown="[^"]+"><h3 class="[^"]*">([^<]+)<', page
+        r'<a href="(https?://www.youtube[^"]+)"', page
     )
     vdurs = re.findall(r'<span class="vdur[^"]*">([^<]+)<', page)
     durs = [r1(r'(\d+:\d+)', unescape_html(dur)) for dur in vdurs]
@@ -1798,7 +1798,7 @@ def google_search(url):
         print('# you-get %s' % log.sprint(v[0][0], log.UNDERLINE))
         print()
     print('Best matched result:')
-    return(videos[0][0])
+    return(videos[0])
 
 
 def url_to_module(url):
@@ -1807,9 +1807,12 @@ def url_to_module(url):
         video_url = r1(r'https?://[^/]+(.*)', url)
         assert video_host and video_url
     except AssertionError:
-        url = google_search(url)
-        video_host = r1(r'https?://([^/]+)/', url)
-        video_url = r1(r'https?://[^/]+(.*)', url)
+        try:
+            url = google_search(url)
+            video_host = r1(r'https?://([^/]+)/', url)
+            video_url = r1(r'https?://[^/]+(.*)', url)
+        except IndexError:
+            print("Google Search Backup failed, please enter a supported url")
 
     if video_host.endswith('.com.cn') or video_host.endswith('.ac.cn'):
         video_host = video_host[:-3]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
+from typing import Any
 import unittest
+from unittest import mock
 
 from you_get.common import *
 
@@ -9,3 +11,11 @@ class TestCommon(unittest.TestCase):
     def test_match1(self):
         self.assertEqual(match1('http://youtu.be/1234567890A', r'youtu.be/([^/]+)'), '1234567890A')
         self.assertEqual(match1('http://youtu.be/1234567890A', r'youtu.be/([^/]+)', r'youtu.(\w+)'), ['1234567890A', 'be'])
+
+#Ensure google_search backup essentailly work 
+    def test_google_search(self):
+        self.assertIsNotNone(google_search('anyString'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As noted in this [PR](https://github.com/soimort/you-get/pull/2924), the google search back up feature of you-get was not working. 

I have identified and updated the google_search method to correctly handle non-url parameters and correctly return the first youtube video found via the google search of the parameter. Before, the method was causing any non-url param passed into you-get to cause an exception. 

I have also written and added a unit test to the test_common.py file that shows the google search method can correctly return a url when passed in a non-url string.  