### PR TITLE
QQ download fhd

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -467,7 +467,8 @@ def get_content(url, headers={}, decoded=True):
         # Here we add cookies to the request headers manually
         cookie_strings = []
         for cookie in list(cookies):
-            cookie_strings.append(cookie.name + '=' + cookie.value)
+            if cookie.domain in url and cookie.path in url:
+                cookie_strings.append(cookie.name + '=' + cookie.value)
         cookie_headers = {'Cookie': '; '.join(cookie_strings)}
         req.headers.update(cookie_headers)
 

--- a/src/you_get/extractors/qq.py
+++ b/src/you_get/extractors/qq.py
@@ -17,7 +17,7 @@ def qq_download_by_vid(vid, title, output_dir='.', merge=True, info_only=False):
     video_json = None
     platforms = [4100201, 11]
     for platform in platforms:
-        info_api = 'http://vv.video.qq.com/getinfo?otype=json&appver=3.2.19.333&platform={}&defnpayver=1&defn=shd&vid={}'.format(platform, vid)
+        info_api = 'http://vv.video.qq.com/getinfo?otype=json&appver=3.2.19.333&platform={}&defnpayver=1&defn=fhd&vid={}'.format(platform, vid)
         info = get_content(info_api, headers)
         video_json = json.loads(match1(info, r'QZOutputJson=(.*)')[:-1])
         if not video_json.get('msg')=='cannot play outside':


### PR DESCRIPTION
腾讯视频导入 cookie 后，下载 1080P 版本。

多个不同子域的同 key 不同值的 cookie，会互相覆盖导致认证失败，改为只加载同域 cookie。

修改前
```bash

you-get -i https://v.qq.com/x/cover/mzc00200mhgrghr/p00398zxwzu.html -c cookies.txt
Site:       QQ.com
Title:      能源_16
Type:       MPEG-4 video (video/mp4)
Size:       8.71 MiB (9135762 Bytes)
```

修改后
```
you-get -i https://v.qq.com/x/cover/mzc00200mhgrghr/p00398zxwzu.html -c cookies.txt
Site:       QQ.com
Title:      能源_16
Type:       MPEG-4 video (video/mp4)
Size:       70.1 MiB (73504132 Bytes)
```