### PR TITLE
QQ download cuts outro

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -11,7 +11,8 @@ from you_get.extractors import (
     bilibili,
     soundcloud,
     tiktok,
-    twitter
+    twitter,
+    qq
 )
 
 
@@ -22,6 +23,12 @@ class YouGetTests(unittest.TestCase):
     def test_magisto(self):
         magisto.download(
             'http://www.magisto.com/album/video/f3x9AAQORAkfDnIFDA',
+            info_only=True
+        )
+
+    def test_qq(self):
+        qq.download(
+            'https://v.qq.com/x/cover/awnia0n2erqryf3/n0033ecmh8f.html',
             info_only=True
         )
 


### PR DESCRIPTION
The downloaded file has the video outro cut

Download:
![image](https://user-images.githubusercontent.com/50285552/187011371-e433a45b-1718-4a6d-b8ac-a840a399c2db.png)

Expected:
![image](https://user-images.githubusercontent.com/50285552/187011380-667a9cbe-0298-4e4c-b2b8-099731de524d.png)
