### PR TITLE
[ixigua] fix 'string indices must be integers'

### DIFF
--- a/src/you_get/extractors/ixigua.py
+++ b/src/you_get/extractors/ixigua.py
@@ -95,6 +95,8 @@ def ixigua_download(url, output_dir='.', merge=True, info_only=False, stream_id=
 
 def convertStreams(video_list, audio_url):
     streams = []
+    if type(video_list) == dict:
+        video_list = video_list.values()
     for dynamic_video in video_list:
         streams.append({
             'file_id': dynamic_video['file_hash'],


### PR DESCRIPTION
`you-get -i --debug "https://www.ixigua.com/7114608501724283407?app=video_article&timestamp=1663582546&utm_medium=android&utm_campaign=client_share&utm_source=wechat_friend&test_group=v1"`
will traceback:
```
Traceback (most recent call last):
  File "d:\setup\you-get\you-get", line 11, in <module>
    you_get.main(repo_path=_filepath)
  File "D:\setup\you-get/src\you_get\__main__.py", line 92, in main
    main(**kwargs)
  File "D:\setup\you-get/src\you_get\common.py", line 1867, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "D:\setup\you-get/src\you_get\common.py", line 1759, in script_main
    download_main(
  File "D:\setup\you-get/src\you_get\common.py", line 1379, in download_main
    download(url, **kwargs)
  File "D:\setup\you-get/src\you_get\common.py", line 1858, in any_download
    m.download(url, **kwargs)
  File "D:\setup\you-get/src\you_get\extractors\ixigua.py", line 69, in ixigua_download
    streams = convertStreams(dynamic_video_list, "")
  File "D:\setup\you-get/src\you_get\extractors\ixigua.py", line 103, in convertStreams
    'file_id': dynamic_video['file_hash'],
TypeError: string indices must be integers
```