### PR TITLE
[douyin] remove video watermark

### DIFF
--- a/src/you_get/extractors/douyin.py
+++ b/src/you_get/extractors/douyin.py
@@ -53,7 +53,7 @@ def douyin_download_by_url(url, **kwargs):
     title = get_value(video_info, ['item_list', 0, 'desc'])
 
     # get video play url
-    video_url = "https://aweme.snssdk.com/aweme/v1/playwm/?ratio=720p&line=0&video_id={}".format(video_id)
+    video_url = "https://aweme.snssdk.com/aweme/v1/play/?ratio=720p&line=0&video_id={}".format(video_id)
     video_format = 'mp4'
     size = url_size(video_url, faker=True)
     print_info(


### PR DESCRIPTION
Watermark is removed from videos at both left-top corner and the end of video.