### PR TITLE
Update Youku ccode

### DIFF
--- a/src/you_get/extractors/youku.py
+++ b/src/you_get/extractors/youku.py
@@ -77,7 +77,7 @@ class Youku(VideoExtractor):
         self.api_error_code = None
         self.api_error_msg = None
 
-        self.ccode = '0564'
+        self.ccode = '0502'
         # Found in http://g.alicdn.com/player/ykplayer/0.5.64/youku-player.min.js
         # grep -oE '"[0-9a-zA-Z+/=]{256}"' youku-player.min.js
         self.ckey = 'DIl58SLFxFNndSV1GFNnMQVYkx1PP5tKe1siZu/86PR1u/Wh1Ptd+WOZsHHWxysSfAOhNJpdVWsdVJNsfJ8Sxd8WKVvNfAS8aS8fAOzYARzPyPc3JvtnPHjTdKfESTdnuTW6ZPvk2pNDh4uFzotgdMEFkzQ5wZVXl2Pf1/Y6hLK0OnCNxBj3+nb0v72gZ6b0td+WOZsHHWxysSo/0y9D2K42SaB8Y/+aD2K42SaB8Y/+ahU+WOZsHcrxysooUeND'
@@ -157,7 +157,8 @@ class Youku(VideoExtractor):
                     log.wtf('Cannot fetch vid')
 
         if kwargs.get('src') and kwargs['src'] == 'tudou':
-            self.ccode = '0512'
+            self.ccode = '0502'
+            # Found in https://g.alicdn.com/kplayer/kuplayer/4.1.61-xmedia/index.js
 
         if kwargs.get('password') and kwargs['password']:
             self.password_protected = True


### PR DESCRIPTION
The latest youku-ccode is 0502,

you can find it in <https://g.alicdn.com/kplayer/kuplayer/4.1.61-xmedia/index.js>.


the old ccode(0512) is preview ccode and part of the video cannot parse the full-length video using the preview ccode