### PR TITLE
Download speed limited

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -28,8 +28,11 @@ class YouGetTests(unittest.TestCase):
 
     def test_youtube(self):
         youtube.download(
-            'http://www.youtube.com/watch?v=pzKerr0JIPA', info_only=True
+            'https://www.youtube.com/watch?v=sgxhyzPBY3s', info_only=True
         )
+        # youtube.download(
+        #     'http://www.youtube.com/watch?v=pzKerr0JIPA', info_only=True
+        # )
         #youtube.download('http://youtu.be/pzKerr0JIPA', info_only=True)
         #youtube.download(
         #    'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa


### PR DESCRIPTION
Watching videos through a proxy in a browser is fast, but downloading through you-get is slow.

<img width="559" alt="1688355566072" src="https://github.com/soimort/you-get/assets/18117854/aa604738-5a79-417b-89b5-4e156e12f0ea">
<img width="443" alt="1688355566064" src="https://github.com/soimort/you-get/assets/18117854/987ee803-5ba6-4a92-b864-dc81d10288ff">
