### PR TITLE
fix the outdated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,18 @@ You may either download the [stable](https://github.com/soimort/you-get/archive/
 Alternatively, run
 
 ```
-$ [sudo] python3 setup.py install
+$ cd path/to/you-get
+$ [sudo] python -m pip install .
 ```
 
 Or
 
 ```
-$ python3 setup.py install --user
+$ cd path/to/you-get
+$ python -m pip install . --user
 ```
 
-to install `you-get` to a permanent path.
+to install `you-get` to a permanent path. (And don't omit the dot `.` representing the current directory)
 
 You can also use the [pipenv](https://pipenv.pypa.io/en/latest) to install the `you-get` in the Python virtual environment.
 
@@ -107,7 +109,7 @@ This is the recommended way for all developers, even if you don't often code in 
 $ git clone git://github.com/soimort/you-get.git
 ```
 
-Then put the cloned directory into your `PATH`, or run `./setup.py install` to install `you-get` to a permanent path.
+Then put the cloned directory into your `PATH`, or run `python -m pip install path/to/you-get` to install `you-get` to a permanent path.
 
 ### Option 5: Homebrew (Mac only)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,20 @@ PACKAGE_NAME = 'you_get'
 
 PROJ_METADATA = '%s.json' % PROJ_NAME
 
-import os, json, imp
+import importlib.util
+import importlib.machinery
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
+
+import os, json
 here = os.path.abspath(os.path.dirname(__file__))
 proj_info = json.loads(open(os.path.join(here, PROJ_METADATA), encoding='utf-8').read())
 try:
@@ -13,7 +26,7 @@ try:
 except:
     README = ""
 CHANGELOG = open(os.path.join(here, 'CHANGELOG.rst'), encoding='utf-8').read()
-VERSION = imp.load_source('version', os.path.join(here, 'src/%s/version.py' % PACKAGE_NAME)).__version__
+VERSION = load_source('version', os.path.join(here, 'src/%s/version.py' % PACKAGE_NAME)).__version__
 
 from setuptools import setup, find_packages
 setup(


### PR DESCRIPTION
The README.md installation instructions failed for two reasons:
1. python 3.12 has removed the `imp` module and has replaced it by the `importlib` module. [1](https://docs.python.org/3/whatsnew/3.12.html#imp)
2. the use of setup.py as in the command `python setup.py install` is deprecated and should be replaced by the recommended way of `python -m pip install path/to/project`. [2](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/)

BTW, the reason why I changed `python3` to `python` is because (1) this should be the mainstream nowadays, and (2) I don't know since when win10 has one `python3.exe` under `%APPDATA%\Local\Microsoft\WindowsApps\` which is non-functional. (At the same time the python 3.12 official release no longer comes with a `python3.exe`.) (Thus calling `python3` will have no effect.)