### PR TITLE
fix: [extractors.bilibili] add headers when requesting for danmaku

### DIFF
--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -335,7 +335,7 @@ class Bilibili(VideoExtractor):
                                                             'src': [[baseurl]], 'size': size}
 
             # get danmaku
-            self.danmaku = get_content('http://comment.bilibili.com/%s.xml' % cid)
+            self.danmaku = get_content('http://comment.bilibili.com/%s.xml' % cid, headers=self.bilibili_headers(referer=self.url))
 
         # bangumi
         elif sort == 'bangumi':
@@ -414,7 +414,7 @@ class Bilibili(VideoExtractor):
                                                         'src': [[baseurl], [audio_baseurl]], 'size': size}
 
             # get danmaku
-            self.danmaku = get_content('http://comment.bilibili.com/%s.xml' % cid)
+            self.danmaku = get_content('http://comment.bilibili.com/%s.xml' % cid, headers=self.bilibili_headers(referer=self.url))
 
         # vc video
         elif sort == 'vc':
@@ -596,7 +596,7 @@ class Bilibili(VideoExtractor):
                                                         'src': [[baseurl]], 'size': size}
 
         # get danmaku
-        self.danmaku = get_content('http://comment.bilibili.com/%s.xml' % cid)
+        self.danmaku = get_content('http://comment.bilibili.com/%s.xml' % cid, headers=self.bilibili_headers(referer=self.url))
 
     def extract(self, **kwargs):
         # set UA and referer for downloading


### PR DESCRIPTION
Hi! Looks like `comment.bilibili.com` requires headers now. I encountered a problem like this:

```
$ you-get --debug -c /app/cookies.txt -l -i https://www.bilibili.com/video/BV1gt421A7Mz/
[DEBUG] get_content: https://www.bilibili.com/video/BV1gt421A7Mz/
[DEBUG] get_content: https://www.bilibili.com/video/av1753632765?p=1
[DEBUG] get_content: https://www.bilibili.com/video/av1753632765?p=1
[DEBUG] get_content: https://api.bilibili.com/x/player/playurl?avid=1753632765&cid=1517599397&qn=64&type=&otype=json&fnver=0&fnval=16&fourk=1
[DEBUG] get_content: https://api.bilibili.com/x/player/playurl?avid=1753632765&cid=1517599397&qn=32&type=&otype=json&fnver=0&fnval=16&fourk=1
[DEBUG] get_content: https://api.bilibili.com/x/player/playurl?avid=1753632765&cid=1517599397&qn=16&type=&otype=json&fnver=0&fnval=16&fourk=1
[DEBUG] get_content: http://comment.bilibili.com/1517599397.xml
[DEBUG] HTTP Error with code412
[DEBUG] HTTP Error with code412
[DEBUG] HTTP Error with code412
you-get: version 0.4.1650, a tiny downloader that scrapes the web.
you-get: Namespace(version=False, help=False, info=True, url=False, json=False, no_merge=False, no_caption=False, postfix=False, force=False, skip_existing_file_size_check=False, format=None, output_filename=None, output_dir='.', player=None, cookies='/app/cookies.txt', timeout=600, debug=True, input_file=None, password=None, playlist=True, first=None, last=None, size=None, auto_rename=False, insecure=False, http_proxy=None, extractor_proxy=None, no_proxy=False, socks_proxy=None, stream=None, itag=None, m3u8=False, URL=['https://www.bilibili.com/video/BV1gt421A7Mz/'])
Traceback (most recent call last):
  File "/usr/local/bin/you-get", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/you_get/__main__.py", line 92, in main
    main(**kwargs)
  File "/usr/local/lib/python3.10/site-packages/you_get/common.py", line 1870, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/you_get/common.py", line 1762, in script_main
    download_main(
  File "/usr/local/lib/python3.10/site-packages/you_get/common.py", line 1380, in download_main
    download_playlist(url, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/you_get/common.py", line 1866, in any_download_playlist
    m.download_playlist(url, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/you_get/extractors/bilibili.py", line 658, in download_playlist_by_url
    self.__class__().download_by_url(purl, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/you_get/extractor.py", line 48, in download_by_url
    self.prepare(**kwargs)
  File "/usr/local/lib/python3.10/site-packages/you_get/extractors/bilibili.py", line 332, in prepare
    self.danmaku = get_content('http://comment.bilibili.com/%s.xml' % cid)
  File "/usr/local/lib/python3.10/site-packages/you_get/common.py", line 477, in get_content
    response = urlopen_with_retry(req)
  File "/usr/local/lib/python3.10/site-packages/you_get/common.py", line 446, in urlopen_with_retry
    raise http_error
  File "/usr/local/lib/python3.10/site-packages/you_get/common.py", line 437, in urlopen_with_retry
    return request.urlopen(*args, **kwargs)
  File "/usr/local/lib/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/local/lib/python3.10/urllib/request.py", line 525, in open
    response = meth(req, response)
  File "/usr/local/lib/python3.10/urllib/request.py", line 634, in http_response
    response = self.parent.error(
  File "/usr/local/lib/python3.10/urllib/request.py", line 557, in error
    result = self._call_chain(*args)
  File "/usr/local/lib/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/usr/local/lib/python3.10/urllib/request.py", line 749, in http_error_302
    return self.parent.open(new, timeout=req.timeout)
  File "/usr/local/lib/python3.10/urllib/request.py", line 525, in open
    response = meth(req, response)
  File "/usr/local/lib/python3.10/urllib/request.py", line 634, in http_response
    response = self.parent.error(
  File "/usr/local/lib/python3.10/urllib/request.py", line 563, in error
    return self._call_chain(*args)
  File "/usr/local/lib/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/usr/local/lib/python3.10/urllib/request.py", line 643, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 412: Precondition Failed
```

After adding headers to the request method like what diff shows, the problem is solved.
I'm new with github's PR and not sure if my PR meets your requirements.
If modification  or more information is needed, I'm more than happy to provide that.

Thx for you fantastic tool for helping me a lot in downloading interesting videos!