### PR TITLE
Add workflow test on python 3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', pypy-3.8, pypy-3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11', '3.12', pypy-3.8, pypy-3.9]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8

--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,21 @@ PACKAGE_NAME = 'you_get'
 
 PROJ_METADATA = '%s.json' % PROJ_NAME
 
-import importlib.util
-import importlib.machinery
-
-def load_source(modname, filename):
-    loader = importlib.machinery.SourceFileLoader(modname, filename)
-    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
-    module = importlib.util.module_from_spec(spec)
-    # The module is always executed and not cached in sys.modules.
-    # Uncomment the following line to cache the module.
-    # sys.modules[module.__name__] = module
-    loader.exec_module(module)
-    return module
+import sys
+if (sys.version_info >= (3, 12)):
+    import importlib.util
+    import importlib.machinery
+    def load_source(modname, filename):
+        loader = importlib.machinery.SourceFileLoader(modname, filename)
+        spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+        module = importlib.util.module_from_spec(spec)
+        # The module is always executed and not cached in sys.modules.
+        # Uncomment the following line to cache the module.
+        # sys.modules[module.__name__] = module
+        loader.exec_module(module)
+        return module
+else:
+    from imp import load_source
 
 import os, json
 here = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -5,21 +5,18 @@ PACKAGE_NAME = 'you_get'
 
 PROJ_METADATA = '%s.json' % PROJ_NAME
 
-import sys
-if (sys.version_info >= (3, 12)):
-    import importlib.util
-    import importlib.machinery
-    def load_source(modname, filename):
-        loader = importlib.machinery.SourceFileLoader(modname, filename)
-        spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
-        module = importlib.util.module_from_spec(spec)
-        # The module is always executed and not cached in sys.modules.
-        # Uncomment the following line to cache the module.
-        # sys.modules[module.__name__] = module
-        loader.exec_module(module)
-        return module
-else:
-    from imp import load_source
+import importlib.util
+import importlib.machinery
+
+def load_source(modname, filename):
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module
 
 import os, json
 here = os.path.abspath(os.path.dirname(__file__))

--- a/you-get.json
+++ b/you-get.json
@@ -22,6 +22,8 @@
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Internet",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Multimedia",


### PR DESCRIPTION
should pass the checks now... setuptools needs to be upgraded for python 3.12 test to find the module

edit:
still cannot pass unittest... but anyway, failures seemed to be merely network issues...

plus, one may consider migrate from `make test` `python3 setup.py test` unittest to the modern way `pytest tests` (start by having two ways of test in workflow yaml), see [1](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#what-about-other-commands), [2](https://docs.pytest.org/en/latest/how-to/unittest.html)