### PR TITLE
[YouTube] Fix 403 error and throttling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
 
     entry_points = {'console_scripts': proj_info['console_scripts']},
 
-    extras_require={
+    install_requires = ['dukpy'],
+    extras_require = {
         'socks': ['PySocks'],
     }
 )

--- a/src/you_get/extractors/youtube.py
+++ b/src/you_get/extractors/youtube.py
@@ -190,8 +190,6 @@ class YouTube(VideoExtractor):
             jsUrl = re.search('([^"]*/base\.js)"', video_page).group(1)
         except:
             log.wtf('[Failed] Unable to find base.js on the video page')
-        # FIXME: do we still need this?
-        jsUrl = jsUrl.replace('\/', '/')  # unescape URL (for age-restricted videos)
         self.html5player = 'https://www.youtube.com' + jsUrl
         logging.debug('Retrieving the player code...')
         self.js = get_content(self.html5player).replace('\n', ' ')
@@ -201,6 +199,14 @@ class YouTube(VideoExtractor):
 
         # Get the video title
         self.title = ytInitialPlayerResponse["videoDetails"]["title"]
+
+        # Check the status
+        playabilityStatus = ytInitialPlayerResponse['playabilityStatus']
+        status = playabilityStatus['status']
+        logging.debug('status: %s' % status)
+        if status != 'OK':
+            # If cookies are loaded, status should be OK
+            log.wtf('[Failed] %s (use --cookies to load cookies)' % playabilityStatus['reason'])
 
         stream_list = ytInitialPlayerResponse['streamingData']['formats']
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -36,9 +36,9 @@ class YouGetTests(unittest.TestCase):
         #    'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
         #    info_only=True
         #)
-        #youtube.download(
-        #    'https://www.youtube.com/watch?v=Fpr4fQSh1cc', info_only=True
-        #)
+        youtube.download(
+            'https://www.youtube.com/watch?v=oRdxUFDoQe0', info_only=True
+        )
 
     def test_acfun(self):
         acfun.download('https://www.acfun.cn/v/ac44560432', info_only=True)


### PR DESCRIPTION
Decrypting `signatureCipher` to fix the recent 403 error, as well as to solve the long-standing download speed throttling issue (#2950). This was made possible thanks to the lightweight JavaScript interpreter [dukpy](https://pypi.org/project/dukpy/).
