### PR TITLE
Add Flox as an installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ You can install `you-get` easily via:
 # pkg install you-get
 ```
 
+### Option 7: Flox (Mac, Linux, and Windows WSL)
+
+You can install `you-get` easily via:
+
+```
+$ flox install you-get
+```
+
 ### Shell completion
 
 Completion definitions for Bash, Fish and Zsh can be found in [`contrib/completion`](https://github.com/soimort/you-get/tree/develop/contrib/completion). Please consult your shell's manual for how to take advantage of them.


### PR DESCRIPTION
`you-get` is available and working on Flox today.
I tested it out as follows.

```console
$ flox init
✨ Created environment 'tmp.nmbKH8f71c' (aarch64-darwin)

Next:
  $ flox search <package>    <- Search for a package
  $ flox install <package>   <- Install a package into an environment
  $ flox activate            <- Enter the environment
  $ flox edit                <- Add environment variables and shell hooks

$ flox install you-get
✅ 'you-get' installed to environment 'tmp.nmbKH8f71c'
$ flox activate -- you-get --version
you-get: version 0.4.1700, a tiny downloader that scrapes the web.
```