### PR TITLE
fix: instagram media_id bug

### DIFF
--- a/src/you_get/extractors/instagram.py
+++ b/src/you_get/extractors/instagram.py
@@ -19,7 +19,7 @@ def instagram_download(url, output_dir='.', merge=True, info_only=False, **kwarg
     title = "{} [{}]".format(description.replace("\n", " "), vid)
 
     appId = r1(r'"appId":"(\d+)"', cont)
-    media_id = r1(r'"media_id":"(\d+)"', cont)
+    media_id = r1(r'"media_id":"([\d\_]+)"', cont)
     logging.debug('appId: %s' % appId)
     logging.debug('media_id: %s' % media_id)
 


### PR DESCRIPTION
URL: https://www.instagram.com/reels/DDUhuObPELi/
media_id = 3518585521003315938_60017471874
![微信图片_20250107154516](https://github.com/user-attachments/assets/0a3df872-f263-4efb-a88d-53b461e635fb)
