### PR TITLE
解决 up 主个人主页 URL 变化及其他问题 Solve URL Changes and Other Error Issues on Up - master's Personal Homepage

### DIFF
--- a/src/you_get/extractor.py
+++ b/src/you_get/extractor.py
@@ -208,6 +208,8 @@ class VideoExtractor():
                                    key=lambda i: -self.dash_streams[i]['size'])
                     stream_id = itags[0]
                 else:
+                    if not self.streams_sorted:
+                        return
                     stream_id = self.streams_sorted[0]['id'] if 'id' in self.streams_sorted[0] else self.streams_sorted[0]['itag']
 
             if 'index' not in kwargs:

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -229,6 +229,8 @@ class Bilibili(VideoExtractor):
         # self.title = match1(html_content,
         #                    r'<h1 title="([^"]+)"')
 
+        self.url = self.url.strip("/")
+
         # redirect: watchlater
         if re.match(r'https?://(www\.)?bilibili\.com/watchlater/#/(av(\d+)|BV(\S+)/?)', self.url):
             avid = match1(self.url, r'/(av\d+)') or match1(self.url, r'/(BV\w+)')
@@ -900,7 +902,6 @@ class Bilibili(VideoExtractor):
                 kwargs['output_dir'] = os.path.join(output_dir, name)
                 self.__class__().download_playlist_by_url(url, **kwargs)
 
-            sys.exit(0)  # finish
             # channel_info = json.loads(api_content)
             # # TBD: channel of more than 100 videos
             #

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -736,6 +736,8 @@ class Bilibili(VideoExtractor):
             sort = 'space_favlist'
         elif re.match(r'https?://(www\.)?bilibili\.com/audio/am(\d+)', self.url):
             sort = 'audio_menu'
+        elif re.match(r'https?://(www\.)?bilibili\.com/cheese/play/ss(\d+)', self.url):  # 课堂
+            sort = 'cheese'
         else:
             log.e('[Error] Unsupported URL pattern.')
             exit(1)
@@ -744,6 +746,9 @@ class Bilibili(VideoExtractor):
         if sort == 'video':
             initial_state_text = match1(html_content, r'__INITIAL_STATE__=(.*?);\(function\(\)')  # FIXME
             initial_state = json.loads(initial_state_text)
+            error = initial_state['error']
+            if error:
+                raise Exception
             aid = initial_state['videoData']['aid']
             pn = initial_state['videoData']['videos']
 
@@ -929,9 +934,14 @@ class Bilibili(VideoExtractor):
                 i += 1;
                 log.w('Extracting %s of %s videos ...' % (i, epn))
                 url = 'https://www.bilibili.com/video/av%s' % video['aid']
-                self.__class__().download_playlist_by_url(url, **kwargs)
+                try:
+                    self.__class__().download_playlist_by_url(url, **kwargs)
+                except:
+                    title = video['title']
+                    log.e(f"{title} 下载出错啦！🤔")
+                    log.e(f"{title} 下载出错啦！🤔")
+                    log.e(f"{title} 下载出错啦！🤔")
 
-            sys.exit(0)  # finish
 
 
         elif sort == 'space_video':
@@ -939,8 +949,9 @@ class Bilibili(VideoExtractor):
                 log.e("You have to login cookies for downloading. (use --cookies to load cookies.txt.)")
                 log.e("你需要登录来下载up主的所有视频。（使用 --cookies 加载 cookies.txt）")
                 sys.exit(0)
+
             mid = match1(self.url, r'com/(\d+)/upload')
-            w_webid = self.get_w_webid(html_content)
+            # w_webid = self.get_w_webid(html_content)
             videos_list = []
             for pn in count(1):
                 api_url = self.bilibili_space_video_api(mid, pn=pn)
@@ -954,10 +965,16 @@ class Bilibili(VideoExtractor):
             videos_nums = len(videos_list)
             for i, video in enumerate(videos_list, 1):
                 log.w('Extracting %s of %s videos ...' % (i, videos_nums))
-                url = 'https://www.bilibili.com/video/av%s' % video['aid']
-                self.__class__().download_playlist_by_url(url, **kwargs)
+                aid, jump_url = video['aid'], video['jump_url']
+                url = f'https://www.bilibili.com/video/av{aid}' if not jump_url else jump_url
+                try:
+                    self.__class__().download_playlist_by_url(url, **kwargs)
+                except:
+                    title = video['title']
+                    log.e(f"{title} 下载出错啦！🤔")
+                    log.e(f"{title} 下载出错啦！🤔")
+                    log.e(f"{title} 下载出错啦！🤔")
 
-            sys.exit(0)  # finish
         elif sort == 'audio_menu':
             m = re.match(r'https?://(?:www\.)?bilibili\.com/audio/am(\d+)', self.url)
             sid = m.group(1)
@@ -973,6 +990,12 @@ class Bilibili(VideoExtractor):
                 log.w('Extracting %s of %s songs ...' % (i, epn))
                 url = 'https://www.bilibili.com/audio/au%s' % song['id']
                 self.__class__().download_by_url(url, **kwargs)
+
+        elif sort == "cheese":
+            # TODO
+            print()
+            log.w("you-get 还下载不了这种视频呢...You-Get can't download this kind of videos yet ...😗");
+            print()
 
 
 site = Bilibili()

--- a/tests/test.py
+++ b/tests/test.py
@@ -14,7 +14,8 @@ from you_get.extractors import (
     twitter,
     miaopai
 )
-
+from you_get.common import main
+import sys
 
 class YouGetTests(unittest.TestCase):
     def test_imgur(self):
@@ -43,8 +44,24 @@ class YouGetTests(unittest.TestCase):
     def test_acfun(self):
         acfun.download('https://www.acfun.cn/v/ac44560432', info_only=True)
 
-    #def test_bilibili(self):
-        #bilibili.download('https://www.bilibili.com/video/BV1sL4y177sC', info_only=True)
+    def test_bilibili(self):
+        urls = [
+            'https://space.bilibili.com/357665034/',#主页
+            'https://space.bilibili.com/357665034/upload/video',#投稿视频
+            'https://space.bilibili.com/357665034/lists',#合集列表
+            'https://space.bilibili.com/357665034/lists/2663548?type=season',#合集
+            'https://space.bilibili.com/22179951/lists/297776?type=series',#视频列表
+            # redirect
+            'https://space.bilibili.com/8047632/video',
+            'https://space.bilibili.com/8047632/channel/series',
+            'https://space.bilibili.com/8047632/channel/collectiondetail?sid=1308605',
+            'https://space.bilibili.com/8047632/channel/seriesdetail?sid=60488',
+        ]
+        for i,url in enumerate(urls):
+            sys.argv = ['', url, '-o', f'E:/you-get-download/{i}', '--cookie', 'E:/cookies.txt', '--']
+            main()
+
+        # bilibili.download('https://space.bilibili.com/8047632/channel/series', info_only=True)
 
     #def test_soundcloud(self):
         ## single song

--- a/tests/test.py
+++ b/tests/test.py
@@ -14,8 +14,7 @@ from you_get.extractors import (
     twitter,
     miaopai
 )
-from you_get.common import main
-import sys
+
 
 class YouGetTests(unittest.TestCase):
     def test_imgur(self):

--- a/tests/test_bilibili.py
+++ b/tests/test_bilibili.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+
+import unittest
+from unittest.mock import patch
+import os
+import time
+from http import cookiejar
+
+from you_get.util import log, term
+from you_get.extractors import bilibili
+
+
+def load_cookies(cookiefile):
+    cookies = None
+    if cookiefile.endswith('.txt'):
+        # MozillaCookieJar treats prefix '#HttpOnly_' as comments incorrectly!
+        # do not use its load()
+        # see also:
+        #   - https://docs.python.org/3/library/http.cookiejar.html#http.cookiejar.MozillaCookieJar
+        #   - https://github.com/python/cpython/blob/4b219ce/Lib/http/cookiejar.py#L2014
+        #   - https://curl.haxx.se/libcurl/c/CURLOPT_COOKIELIST.html#EXAMPLE
+        # cookies = cookiejar.MozillaCookieJar(cookiefile)
+        # cookies.load()
+        from http.cookiejar import Cookie
+        cookies = cookiejar.MozillaCookieJar()
+        now = time.time()
+        ignore_discard, ignore_expires = False, False
+        with open(cookiefile, 'r', encoding='utf-8') as f:
+            for line in f:
+                # last field may be absent, so keep any trailing tab
+                if line.endswith("\n"): line = line[:-1]
+
+                # skip comments and blank lines XXX what is $ for?
+                if (line.strip().startswith(("#", "$")) or
+                        line.strip() == ""):
+                    if not line.strip().startswith('#HttpOnly_'):  # skip for #HttpOnly_
+                        continue
+
+                domain, domain_specified, path, secure, expires, name, value = \
+                    line.split("\t")
+                secure = (secure == "TRUE")
+                domain_specified = (domain_specified == "TRUE")
+                if name == "":
+                    # cookies.txt regards 'Set-Cookie: foo' as a cookie
+                    # with no name, whereas http.cookiejar regards it as a
+                    # cookie with no value.
+                    name = value
+                    value = None
+
+                initial_dot = domain.startswith(".")
+                if not line.strip().startswith('#HttpOnly_'):  # skip for #HttpOnly_
+                    assert domain_specified == initial_dot
+
+                discard = False
+                if expires == "":
+                    expires = None
+                    discard = True
+
+                # assume path_specified is false
+                c = Cookie(0, name, value,
+                           None, False,
+                           domain, domain_specified, initial_dot,
+                           path, False,
+                           secure,
+                           expires,
+                           discard,
+                           None,
+                           None,
+                           {})
+                if not ignore_discard and c.discard:
+                    continue
+                if not ignore_expires and c.is_expired(now):
+                    continue
+                cookies.set_cookie(c)
+
+    elif cookiefile.endswith(('.sqlite', '.sqlite3')):
+        import sqlite3, shutil, tempfile
+        temp_dir = tempfile.gettempdir()
+        temp_cookiefile = os.path.join(temp_dir, 'temp_cookiefile.sqlite')
+        shutil.copy2(cookiefile, temp_cookiefile)
+
+        cookies = cookiejar.MozillaCookieJar()
+        con = sqlite3.connect(temp_cookiefile)
+        cur = con.cursor()
+        cur.execute("""SELECT host, path, isSecure, expiry, name, value
+        FROM moz_cookies""")
+        for item in cur.fetchall():
+            c = cookiejar.Cookie(
+                0, item[4], item[5], None, False, item[0],
+                item[0].startswith('.'), item[0].startswith('.'),
+                item[1], False, item[2], item[3], item[3] == '', None,
+                None, {},
+            )
+            cookies.set_cookie(c)
+
+    else:
+        log.e('[error] unsupported cookies format')
+        # TODO: Chromium Cookies
+        # SELECT host_key, path, secure, expires_utc, name, encrypted_value
+        # FROM cookies
+        # http://n8henrie.com/2013/11/use-chromes-cookies-for-easier-downloading-with-python-requests/
+
+    return cookies
+
+
+class Bilibiliests(unittest.TestCase):
+    @patch('you_get.extractors.bilibili.cookies', None)
+    def test_space_upload_video_no_cookie(self):
+        bilibili.download('https://space.bilibili.com/357665034/', info_only=True)
+
+    @patch('you_get.extractors.bilibili.cookies', load_cookies('E:/cookies.txt'))
+    @patch('you_get.common.cookies', load_cookies('E:/cookies.txt'))
+    def test_space_home(self):
+        bilibili.download('https://space.bilibili.com/8047632/', info_only=True)
+
+    @patch('you_get.extractors.bilibili.cookies', load_cookies('E:/cookies.txt'))
+    @patch('you_get.common.cookies', load_cookies('E:/cookies.txt'))
+    def test_space_upload_video(self):
+        bilibili.download('https://space.bilibili.com/357665034/upload/video', info_only=True)
+
+    @patch('you_get.extractors.bilibili.cookies', load_cookies('E:/cookies.txt'))
+    @patch('you_get.common.cookies', load_cookies('E:/cookies.txt'))
+    def test_space_upload_video_old(self):
+        # bilibili.download('https://space.bilibili.com/8047632/video', info_only=True)
+        bilibili.download('https://space.bilibili.com/347691691/video', info_only=True)
+
+    def Stest_space_lists(self):
+        bilibili.download('https://space.bilibili.com/254463269/lists', info_only=True, output_dir='.')
+
+    def test_space_lists_old(self):
+        bilibili.download('https://space.bilibili.com/254463269/channel/series', info_only=True, output_dir='.')
+
+    def test_space_lists_series(self):
+        bilibili.download('https://space.bilibili.com/8047632/lists/60489?type=series', info_only=True)
+
+    def test_space_lists_series_old(self):
+        bilibili.download('https://space.bilibili.com/8047632/channel/seriesdetail?sid=60489', info_only=True)
+
+    def test_space_lists_season(self):
+        bilibili.download('https://space.bilibili.com/8047632/lists/1308605?type=season', info_only=True)
+
+    def test_space_lists_season_old(self):
+        bilibili.download('https://space.bilibili.com/8047632/channel/collectiondetail?sid=1308605', info_only=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 问题描述
### 1. URL 变化问题
也许是由于 B 站更新，部分页面的 URL 发生了改变。在我的电脑上，Chrome 和 Edge 浏览器显示的 URL 存在新旧差异。具体变化如下表所示：

| 页面                    | 之前                                                                         | 变化后 |
|-----------------------|----------------------------------------------------------------------------| --- |
| 合集列表（之前叫“TA 的合集和视频列表”） | `https://space.bilibili.com/22179951/channel/series`                       | `https://space.bilibili.com/22179951/lists` |
| `id=3152230` 的合集       | `https://space.bilibili.com/22179951/channel/collectiondetail?sid=3152230` | `https://space.bilibili.com/22179951/lists/3152230?type=season` |
| `id=485635` 的视频列表      | `https://space.bilibili.com/22179951/channel/seriesdetail?sid=485635`      | `https://space.bilibili.com/22179951/lists/485635?type=series` |
| up 主的所有视频              | `https://space.bilibili.com/22179951/video`                                | `https://space.bilibili.com/22179951/upload/video` |

新的 URL 无法被 you-get 匹配，会报错 `you-get: [Error] Unsupported URL pattern.`。旧的 URL 也存在部分无法匹配和报错的情况。

报错示例如下：

```bash
(you-get) E:\you-get-download\2>you-get "https://space.bilibili.com/22179951/channel/series" -d
[DEBUG] get_content: https://space.bilibili.com/22179951/channel/series
[DEBUG] get_content: https://space.bilibili.com/22179951/channel/series
you-get: [Error] Unsupported URL pattern.
```

```bash
(you-get) E:\you-get-download\3>you-get -d https://space.bilibili.com/22179951/video
[DEBUG] get_content: https://space.bilibili.com/22179951/video
[DEBUG] get_content: https://space.bilibili.com/22179951/video
[DEBUG] get_content: https://api.bilibili.com/x/space/arc/search?mid=22179951&pn=1&ps=50&tid=0&keyword=&order=pubdate&jsonp=jsonp
you-get: version 0.4.1743, a tiny downloader that scrapes the web.
you-get: Namespace(version=False, help=False, info=False, url=False, json=False, no_merge=False, no_caption=False, postfix=False, prefix=None, force=False, skip_existing_file_size_check=False, format=None, output_filename=None, output_dir='.', player=None, cookies=None, timeout=600, debug=True, input_file=None, password=None, playlist=False, first=None, last=None, size=None, auto_rename=False, insecure=False, http_proxy=None, extractor_proxy=None, no_proxy=False, socks_proxy=None, stream=None, itag=None, m3u8=False, URL=['https://space.bilibili.com/22179951/video'])
Traceback (most recent call last):
  File "\\?\C:\Users\11200\anaconda3\envs\you-get\Scripts\you-get-script.py", line 33, in <module>
    sys.exit(load_entry_point('you-get', 'console_scripts', 'you-get')())
  File "e:\cs\you-get\src\you_get\__main__.py", line 92, in main
    main(**kwargs)
  File "e:\cs\you-get\src\you_get\common.py", line 1883, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "e:\cs\you-get\src\you_get\common.py", line 1772, in script_main
    download_main(
  File "e:\cs\you-get\src\you_get\common.py", line 1386, in download_main
    download(url, **kwargs)
  File "e:\cs\you-get\src\you_get\common.py", line 1874, in any_download
    m.download(url, **kwargs)
  File "e:\cs\you-get\src\you_get\extractor.py", line 48, in download_by_url
    self.prepare(**kwargs)
  File "e:\cs\you-get\src\you_get\extractors\bilibili.py", line 208, in prepare
    self.download_playlist_by_url(self.url, **kwargs)
  File "e:\cs\you-get\src\you_get\extractors\bilibili.py", line 823, in download_playlist_by_url
    pc = math.ceil(videos_info['data']['page']['count'] / videos_info['data']['page']['ps'])
KeyError: 'data'
```

### 2. `playlist` 下载结束问题
在 `playlist` 下载结束后，由于仍会在`download_by_url`函数中执行`self.extract(**kwargs)`和`self.download(**kwargs)`，会导致
  1. 由于`self.stream_sorted` 为空，在 `stream_id = self.streams_sorted[0]['id'] if 'id' in self.streams_sorted[0] else self.streams_sorted[0]['itag']`（位于 `download` 函数中）导致 `IndexError: list index out of range` 错误。
  2. 输出不必要的信息。如下：
  ``` bash
  site:                Bilibili
  title:               None
  streams:             # Available quality and codecs
  ```

### 3. 视频跳转和缺失问题
在下载所有视频（或合集等）时，会遇到部分视频跳转到课程页面，或者视频已不存在但仍在合集里显示的情况，进而导致程序出错。

## 解决方案
### 1. URL 重定向与 API 更新
如果输入的是旧的 URL，将其重定向到对应的新 URL。并更新部分 API。

### 2. 空列表判断
加入判断 `if not self.streams_sorted: return`，避免因 `self.stream_sorted` 为空而引发错误。

### 3. 异常处理
使用 `try...except...` 语句暂时处理视频缺失问题，将课程下载标记为 TODO。

## 待解决问题
### 1. 下载速度问题
下载速度较慢，不理解 `skip_existing_file_size_check` 参数的作用。代码中多处存在类似 `file_size == os.path.getsize(filepath) or skip_existing_file_size_check` 语句，感觉在使用该参数时仍需检查文件大小，没有体现出 “跳过” 的作用。

### 2. 下载结果反馈问题
建议在下载结束时列出哪些视频下载成功、哪些视频下载失败，以便用户了解下载情况。

---


## Problem Description
### 1. URL Changes
Perhaps due to the update of Bilibili, the URLs of some pages have changed. On my computer, there are differences between the old and new URLs displayed in Chrome and Edge browsers. The specific changes are as shown in the table above:

The new URLs cannot be matched by the program, resulting in the error `you-get: [Error] Unsupported URL pattern.`. Some of the old URLs also cannot be matched and will cause errors.

Examples of error reports can be found above.

### 2. Issue after `playlist` Download Completion
After the `playlist` download is completed, since `self.extract(**kwargs)` and `self.download(**kwargs)` will still be executed in the `download_by_url` function, it will lead to the following problems:
  1. As `self.stream_sorted` is empty, in the statement `stream_id = self.streams_sorted[0]['id'] if 'id' in self.streams_sorted[0] else self.streams_sorted[0]['itag']` (located in the `download` function), it will result in an `IndexError: list index out of range` error.
  2. Unnecessary information will be output. 

### 3. Video Redirection and Missing Issues
When downloading all videos (or collections, etc.), some videos may jump to course pages, or some videos may no longer exist but are still displayed in the list, causing the program to error.

## Solutions
### 1. URL Redirection and API Update
If an old URL is entered, redirect it to the corresponding new URL and update some APIs.

### 2. Empty List Check
Add the check `if not self.streams_sorted: return` to the relevant code to avoid errors caused by an empty `self.stream_sorted` list.

### 3. Exception Handling
Use `try...except...` statements to temporarily handle video redirection and missing issues. Mark course downloads as TODO.

## Outstanding Issues
### 1. Download Speed Issue
The download speed is slow, and I don't understand the function of the `skip_existing_file_size_check` parameter. There are many statements like `file_size == os.path.getsize(filepath) or skip_existing_file_size_check` in the code. It seems that the file size still needs to be checked when using this parameter, and the "skip" function is not reflected.

### 2. Download Result Feedback Issue
It is recommended to list which videos were downloaded successfully and which failed at the end of the download so that users can understand the download status.