### PR TITLE
YouTube failing

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -27,10 +27,10 @@ class YouGetTests(unittest.TestCase):
             info_only=True
         )
 
-    #def test_youtube(self):
-        #youtube.download(
-        #    'http://www.youtube.com/watch?v=pzKerr0JIPA', info_only=True
-        #)
+    def test_youtube(self):
+        youtube.download(
+            'https://www.youtube.com/watch/?v\=LNEOx_Dkdzo', info_only=True
+        )
         #youtube.download('http://youtu.be/pzKerr0JIPA', info_only=True)
         #youtube.download(
         #    'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa


### PR DESCRIPTION
```
$ you-get https://www.youtube.com/watch\?v\=LNEOx_Dkdzo
you-get: Server refused to provide video details. Returned status: LOGIN_REQUIRED. Reason: Sign in to confirm you’re not a bot This helps protect our community.
```