### PR TITLE
Add darkibox extractor

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -38,6 +38,7 @@ SITES = {
     'cbs'              : 'cbs',
     'coub'             : 'coub',
     'dailymotion'      : 'dailymotion',
+    'darkibox'         : 'darkibox',
     'douban'           : 'douban',
     'douyin'           : 'douyin',
     'douyu'            : 'douyutv',

--- a/src/you_get/extractors/__init__.py
+++ b/src/you_get/extractors/__init__.py
@@ -13,6 +13,7 @@ from .ckplayer import *
 from .cntv import *
 from .coub import *
 from .dailymotion import *
+from .darkibox import *
 from .douban import *
 from .douyin import *
 from .douyutv import *

--- a/src/you_get/extractors/darkibox.py
+++ b/src/you_get/extractors/darkibox.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+__all__ = ['darkibox_download']
+
+from ..common import *
+import re
+
+
+def _unpack_js(packed):
+    """Unpack Dean Edwards' packed JavaScript.
+
+    Handles eval(function(p,a,c,k,e,d){...}) patterns.
+    """
+    # Extract the arguments to the inner function
+    m = re.search(
+        r"eval\(function\(p,a,c,k,e,[dr]\)\{.*?\}\('(.+)',(\d+),(\d+),'([^']+)'",
+        packed, re.DOTALL
+    )
+    if not m:
+        return packed
+    payload, radix, count, keywords = m.group(1), int(m.group(2)), int(m.group(3)), m.group(4).split('|')
+
+    def _base_n(num, base):
+        digits = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+        if num < 0:
+            return '-' + _base_n(-num, base)
+        result = ''
+        while num:
+            result = digits[num % base] + result
+            num //= base
+        return result or '0'
+
+    def _lookup(match):
+        word = match.group(0)
+        n = _base_n(int(word, 36), radix) if radix <= 36 else word
+        try:
+            idx = int(word, 36)
+        except ValueError:
+            idx = int(word)
+        return keywords[idx] if idx < len(keywords) and keywords[idx] else word
+
+    # Replace each word token with its keyword
+    unpacked = re.sub(r'\b\w+\b', _lookup, payload)
+    return unpacked
+
+
+def _extract_file_code(url):
+    """Extract the file code from various darkibox URL patterns.
+
+    Supports:
+        darkibox.com/FILECODE
+        darkibox.com/d/FILECODE
+        darkibox.com/embed-FILECODE.html
+    """
+    file_code = match1(url, r'darkibox\.com/embed-([a-zA-Z0-9]+)') or \
+                match1(url, r'darkibox\.com/d/([a-zA-Z0-9]+)') or \
+                match1(url, r'darkibox\.com/([a-zA-Z0-9]+)')
+    return file_code
+
+
+def darkibox_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
+    """Download videos from darkibox.com."""
+
+    file_code = _extract_file_code(url)
+    if not file_code:
+        raise ValueError('Cannot extract file code from URL: ' + url)
+
+    embed_url = 'https://darkibox.com/embed-{}.html'.format(file_code)
+
+    # GET the embed page first (sets cookies, gets any tokens)
+    embed_page = get_content(embed_url)
+    title = match1(embed_page, r'<title>([^<]+)</title>') or file_code
+    # Clean up title
+    title = title.replace(' - DarkiBox', '').strip()
+    if not title:
+        title = file_code
+
+    # POST to the download endpoint
+    post_data = {
+        'op': 'embed',
+        'file_code': file_code,
+        'auto': '1',
+    }
+    response = post_content(
+        'https://darkibox.com/dl',
+        post_data=post_data,
+        headers={'Referer': embed_url}
+    )
+
+    # Response contains packed JS; unpack it
+    unpacked = _unpack_js(response)
+
+    # Extract video URL from the unpacked JS
+    # PlayerJS format: file:"URL"
+    video_url = match1(unpacked, r'file:\s*"([^"]+)"') or \
+                match1(unpacked, r'src:\s*"([^"]+)"') or \
+                match1(unpacked, r'"file"\s*:\s*"([^"]+)"')
+
+    if not video_url:
+        raise ValueError('Cannot extract video URL from darkibox response')
+
+    mime, ext, size = url_info(video_url, headers={'Referer': embed_url})
+
+    print_info(site_info, title, mime, size)
+    if not info_only:
+        download_urls(
+            [video_url], title, ext, size,
+            output_dir=output_dir, merge=merge,
+            headers={'Referer': embed_url}
+        )
+
+
+site_info = "DarkiBox"
+download = darkibox_download
+download_playlist = playlist_not_supported('darkibox')


### PR DESCRIPTION
## Summary
- Add extractor for [darkibox.com](https://darkibox.com/), an XFileSharing-based video hosting platform

## How it works
1. Parses file code from URL
2. Fetches embed page, POSTs to `/dl` with `op=embed&file_code=ID&auto=1`
3. Unpacks Dean Edwards packed JavaScript
4. Extracts video URL from PlayerJS `file:` parameter

## Supported URLs
- `https://darkibox.com/FILECODE`
- `https://darkibox.com/d/FILECODE`
- `https://darkibox.com/embed-FILECODE.html`

## Files
- `src/you_get/extractors/darkibox.py` - Extractor
- `src/you_get/extractors/__init__.py` - Registration
- `src/you_get/common.py` - Site entry in SITES dict

## Test plan
- [x] All 3 files compile (`py_compile`)
- [x] Module imports correctly
- [x] All URL patterns route to darkibox module

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/3054)
<!-- Reviewable:end -->
