### PR TITLE
[Bilibili] Fix HTTP 412 extraction and expose DASH audio formats

### DIFF
--- a/src/you_get/common.py
+++ b/src/you_get/common.py
@@ -555,17 +555,23 @@ def post_content(url, headers={}, post_data={}, decoded=True, **kwargs):
     return data
 
 
-def url_size(url, faker=False, headers={}):
+def url_size(url, faker=False, headers={}, timeout=None):
     if faker:
-        response = urlopen_with_retry(
-            request.Request(url, headers=fake_headers)
-        )
+        req = request.Request(url, headers=fake_headers)
     elif headers:
-        response = urlopen_with_retry(request.Request(url, headers=headers))
+        req = request.Request(url, headers=headers)
     else:
-        response = urlopen_with_retry(url)
+        req = url
 
-    size = response.headers['content-length']
+    if timeout is None:
+        response = urlopen_with_retry(req)
+    else:
+        response = urlopen_with_retry(req, timeout=timeout)
+
+    try:
+        size = response.headers['content-length']
+    finally:
+        response.close()
     return int(size) if size is not None else float('inf')
 
 

--- a/src/you_get/extractor.py
+++ b/src/you_get/extractor.py
@@ -224,7 +224,7 @@ class VideoExtractor():
                 ext = self.dash_streams[stream_id]['container']
                 total_size = self.dash_streams[stream_id]['size']
 
-            if ext == 'm3u8' or ext == 'm4a':
+            if ext == 'm3u8':
                 ext = 'mp4'
 
             if not urls:

--- a/src/you_get/extractors/bilibili.py
+++ b/src/you_get/extractors/bilibili.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from .. import common
 from ..common import *
 from ..extractor import VideoExtractor
 
@@ -40,6 +41,14 @@ class Bilibili(VideoExtractor):
         {'id': 'mp4', 'quality': 0},
 
         {'id': 'jpg', 'quality': 0},
+
+        # Standalone DASH audio formats, in descending quality order.
+        {'id': 'dash-audio-30280', 'quality': 30280,
+         'container': 'M4A', 'desc': '高音质音频'},
+        {'id': 'dash-audio-30232', 'quality': 30232,
+         'container': 'M4A', 'desc': '中音质音频'},
+        {'id': 'dash-audio-30216', 'quality': 30216,
+         'container': 'M4A', 'desc': '低音质音频'},
     ]
 
     codecids = {7: 'AVC', 12: 'HEVC', 13: 'AV1'}
@@ -61,8 +70,8 @@ class Bilibili(VideoExtractor):
 
     @staticmethod
     def bilibili_headers(referer=None, cookie=None):
-        # a reasonable UA
-        ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.84 Safari/537.36'
+        # Keep this in sync with the current browser UA used elsewhere in you-get.
+        ua = fake_headers['User-Agent']
         headers = {'Accept': '*/*', 'Accept-Language': 'en-US,en;q=0.5', 'User-Agent': ua}
         if referer is not None:
             headers.update({'Referer': referer})
@@ -73,6 +82,12 @@ class Bilibili(VideoExtractor):
     @staticmethod
     def bilibili_api(avid, cid, qn=0):
         return 'https://api.bilibili.com/x/player/playurl?avid=%s&cid=%s&qn=%s&type=&otype=json&fnver=0&fnval=4048&fourk=1' % (avid, cid, qn)
+
+    @staticmethod
+    def bilibili_view_api(video_id):
+        if video_id.lower().startswith('av'):
+            return 'https://api.bilibili.com/x/web-interface/view?aid=%s' % video_id[2:]
+        return 'https://api.bilibili.com/x/web-interface/view?bvid=%s' % video_id
 
     @staticmethod
     def bilibili_audio_api(sid):
@@ -144,35 +159,106 @@ class Bilibili(VideoExtractor):
         return 'https://api.vc.bilibili.com/link_draw/v1/doc/detail?doc_id=%s' % doc_id
 
     @staticmethod
+    def video_id_from_url(url):
+        match = re.search(r'/video/(av\d+|BV[0-9A-Za-z]+)', url, re.IGNORECASE)
+        return match.group(1) if match else None
+
+    def normalize_video_url(self):
+        match = re.match(
+            r'https?://(?:www\.)?bilibili\.com/watchlater/#/(av\d+|BV[0-9A-Za-z]+)/?',
+            self.url,
+            re.IGNORECASE,
+        )
+        if match:
+            page = int(match1(self.url, r'/p(\d+)') or '1')
+            self.url = 'https://www.bilibili.com/video/%s?p=%s' % (match.group(1), page)
+            return
+
+        if re.match(r'https?://(?:www\.)?bilibili\.com/festival/', self.url):
+            video_id = match1(self.url, r'[?&]bvid=([^&]+)')
+            if video_id:
+                self.url = 'https://www.bilibili.com/video/%s' % video_id
+
+    def get_video_info(self):
+        video_id = self.video_id_from_url(self.url)
+        if video_id is None:
+            log.wtf('[Failed] Unable to find a Bilibili video ID in the URL.')
+
+        api_url = self.bilibili_view_api(video_id)
+        api_content = get_content(api_url, headers=self.bilibili_headers(referer=self.url))
+        api_response = json.loads(api_content)
+        video_info = api_response.get('data')
+        if api_response.get('code') != 0 or not video_info:
+            message = api_response.get('message') or 'unknown API error'
+            log.wtf('[Failed] Unable to fetch Bilibili video metadata: %s' % message)
+        return video_info
+
+    @staticmethod
     def url_size(url, faker=False, headers={},err_value=0):
         try:
-            return url_size(url,faker,headers)
+            return url_size(url, faker, headers, timeout=5)
         except:
             return err_value
+
+    def add_dash_audio_streams(self, dash, audio_size_cache, requested_stream_id=None):
+        known_formats = {stream['id'] for stream in self.stream_types}
+        for audio in dash.get('audio') or []:
+            audio_id = int(audio['id'])
+            format_id = 'dash-audio-%s' % audio_id
+            if format_id not in known_formats:
+                continue
+            if requested_stream_id and format_id != requested_stream_id:
+                continue
+
+            audio_url = audio.get('baseUrl') or audio.get('base_url')
+            if not audio_url:
+                continue
+
+            if audio_id not in audio_size_cache:
+                audio_size_cache[audio_id] = self.url_size(
+                    audio_url,
+                    headers=self.bilibili_headers(referer=self.url),
+                )
+
+            codec = audio.get('codecs', 'unknown codec')
+            bandwidth = audio.get('bandwidth')
+            desc = '音频 %s' % codec
+            if bandwidth:
+                desc += ' %s kbps' % round(bandwidth / 1000)
+            self.streams[format_id] = {
+                'container': 'm4a',
+                'quality': desc,
+                'size': audio_size_cache[audio_id],
+                'src': [audio_url],
+            }
 
     def prepare(self, **kwargs):
         self.stream_qualities = {s['quality']: s for s in self.stream_types}
         self.streams.clear()
         self.dash_streams.clear()
 
-        try:
-            html_content = get_content(self.url, headers=self.bilibili_headers(referer=self.url))
-        except:
-            html_content = ''  # live always returns 400 (why?)
+        self.normalize_video_url()
+        video_info = None
+        if self.video_id_from_url(self.url):
+            video_info = self.get_video_info()
+            redirect_url = video_info.get('redirect_url')
+            if redirect_url and re.search(r'/bangumi/play/', redirect_url):
+                self.url = redirect_url
+                video_info = None
+
+        html_content = ''
+        if video_info is None:
+            try:
+                html_content = get_content(self.url, headers=self.bilibili_headers(referer=self.url))
+            except:
+                html_content = ''  # live always returns 400 (why?)
         #self.title = match1(html_content,
         #                    r'<h1 title="([^"]+)"')
 
-        # redirect: watchlater
-        if re.match(r'https?://(www\.)?bilibili\.com/watchlater/#/(av(\d+)|BV(\S+)/?)', self.url):
-            avid = match1(self.url, r'/(av\d+)') or match1(self.url, r'/(BV\w+)')
-            p = int(match1(self.url, r'/p(\d+)') or '1')
-            self.url = 'https://www.bilibili.com/video/%s?p=%s' % (avid, p)
-            html_content = get_content(self.url, headers=self.bilibili_headers())
-
         # redirect: bangumi/play/ss -> bangumi/play/ep
         # redirect: bangumi.bilibili.com/anime -> bangumi/play/ep
-        elif re.match(r'https?://(www\.)?bilibili\.com/bangumi/play/ss(\d+)', self.url) or \
-             re.match(r'https?://bangumi\.bilibili\.com/anime/(\d+)/play', self.url):
+        if re.match(r'https?://(www\.)?bilibili\.com/bangumi/play/ss(\d+)', self.url) or \
+           re.match(r'https?://bangumi\.bilibili\.com/anime/(\d+)/play', self.url):
             initial_state_text = match1(html_content, r'__INITIAL_STATE__=(.*?);\(function\(\)')  # FIXME
             initial_state = json.loads(initial_state_text)
             ep_id = initial_state['epList'][0]['id']
@@ -182,11 +268,6 @@ class Bilibili(VideoExtractor):
         # redirect: s
         elif re.match(r'https?://(www\.)?bilibili\.com/s/(.+)', self.url):
             self.url = 'https://www.bilibili.com/%s' % match1(self.url, r'/s/(.+)')
-            html_content = get_content(self.url, headers=self.bilibili_headers())
-
-        # redirect: festival
-        elif re.match(r'https?://(www\.)?bilibili\.com/festival/(.+)', self.url):
-            self.url = 'https://www.bilibili.com/video/%s' % match1(self.url, r'bvid=([^&]+)')
             html_content = get_content(self.url, headers=self.bilibili_headers())
 
         # sort it out
@@ -210,52 +291,59 @@ class Bilibili(VideoExtractor):
 
         # regular video
         if sort == 'video':
-            initial_state_text = match1(html_content, r'__INITIAL_STATE__=(.*?);\(function\(\)')  # FIXME
-            initial_state = json.loads(initial_state_text)
+            playinfo, playinfo_ = None, None
+            if video_info is not None:
+                pages = video_info.get('pages') or []
+                if not pages:
+                    log.wtf('[Failed] Bilibili returned no video pages.')
 
-            playinfo_text = match1(html_content, r'__playinfo__=(.*?)</script><script>')  # FIXME
-            playinfo = json.loads(playinfo_text) if playinfo_text else None
-            playinfo = playinfo if playinfo and playinfo.get('code') == 0 else None
+                pn = video_info.get('videos') or len(pages)
+                p = int(match1(self.url, r'[\?&]p=(\d+)') or match1(self.url, r'/index_(\d+)') or '1')
+                if p < 1 or p > len(pages):
+                    log.wtf('[Failed] Bilibili video page %s is out of range.' % p)
 
-            html_content_ = get_content(self.url, headers=self.bilibili_headers(cookie='CURRENT_FNVAL=16'))
-            playinfo_text_ = match1(html_content_, r'__playinfo__=(.*?)</script><script>')  # FIXME
-            playinfo_ = json.loads(playinfo_text_) if playinfo_text_ else None
-            playinfo_ = playinfo_ if playinfo_ and playinfo_.get('code') == 0 else None
-
-            if 'videoData' in initial_state:
-                # (standard video)
-
-                # warn if cookies are not loaded
-                if cookies is None:
-                    log.w('You will need login cookies for 720p formats or above. (use --cookies to load cookies.txt.)')
-
-                # warn if it is a multi-part video
-                pn = initial_state['videoData']['videos']
-                if pn > 1 and not kwargs.get('playlist'):
-                    log.w('This is a multipart video. (use --playlist to download all parts.)')
-
-                # set video title
-                self.title = initial_state['videoData']['title']
-                # refine title for a specific part, if it is a multi-part video
-                p = int(match1(self.url, r'[\?&]p=(\d+)') or match1(self.url, r'/index_(\d+)') or
-                        '1')  # use URL to decide p-number, not initial_state['p']
+                self.title = video_info['title']
                 if pn > 1:
-                    part = initial_state['videoData']['pages'][p - 1]['part']
-                    self.title = '%s (P%s. %s)' % (self.title, p, part)
+                    if not kwargs.get('playlist'):
+                        log.w('This is a multipart video. (use --playlist to download all parts.)')
+                    self.title = '%s (P%s. %s)' % (self.title, p, pages[p - 1]['part'])
 
-                # construct playinfos
-                avid = initial_state['aid']
-                cid = initial_state['videoData']['pages'][p - 1]['cid']  # use p-number, not initial_state['videoData']['cid']
+                avid = video_info['aid']
+                cid = pages[p - 1]['cid']
             else:
-                # (festival video)
+                initial_state_text = match1(html_content, r'__INITIAL_STATE__=(.*?);\(function\(\)')  # FIXME
+                if not initial_state_text:
+                    log.wtf('[Failed] Unable to extract Bilibili video metadata.')
+                initial_state = json.loads(initial_state_text)
 
-                # set video title
-                self.title = initial_state['videoInfo']['title']
+                playinfo_text = match1(html_content, r'__playinfo__=(.*?)</script><script>')  # FIXME
+                playinfo = json.loads(playinfo_text) if playinfo_text else None
+                playinfo = playinfo if playinfo and playinfo.get('code') == 0 else None
 
-                # construct playinfos
-                avid = initial_state['videoInfo']['aid']
-                cid = initial_state['videoInfo']['cid']
+                html_content_ = get_content(self.url, headers=self.bilibili_headers(cookie='CURRENT_FNVAL=16'))
+                playinfo_text_ = match1(html_content_, r'__playinfo__=(.*?)</script><script>')  # FIXME
+                playinfo_ = json.loads(playinfo_text_) if playinfo_text_ else None
+                playinfo_ = playinfo_ if playinfo_ and playinfo_.get('code') == 0 else None
 
+                video_data = initial_state.get('videoData') or initial_state.get('videoInfo')
+                pages = video_data.get('pages') or [video_data]
+                pn = video_data.get('videos') or len(pages)
+                p = int(match1(self.url, r'[\?&]p=(\d+)') or match1(self.url, r'/index_(\d+)') or '1')
+                self.title = video_data['title']
+                if pn > 1:
+                    if not kwargs.get('playlist'):
+                        log.w('This is a multipart video. (use --playlist to download all parts.)')
+                    self.title = '%s (P%s. %s)' % (self.title, p, pages[p - 1]['part'])
+                avid = initial_state.get('aid') or video_data['aid']
+                cid = pages[p - 1]['cid']
+
+            if common.cookies is None:
+                log.w('You will need login cookies for 720p formats or above. (use --cookies to load cookies.txt.)')
+
+            requested_stream_id = kwargs.get('stream_id')
+            audio_only_requested = (
+                requested_stream_id and requested_stream_id.startswith('dash-audio-')
+            )
             current_quality, best_quality = None, None
             if playinfo is not None:
                 current_quality = playinfo['data']['quality'] or None  # 0 indicates an error, fallback to None
@@ -267,18 +355,22 @@ class Bilibili(VideoExtractor):
             if playinfo_ is not None:
                 playinfos.append(playinfo_)
             # get alternative formats from API
-            for qn in [120, 112, 80, 64, 32, 16]:
+            message = 'No supported streams were returned.'
+            quality_levels = [120] if audio_only_requested else [120, 112, 80, 64, 32, 16]
+            for qn in quality_levels:
                 # automatic format for durl: qn=0
                 # for dash, qn does not matter
                 if current_quality is None or qn < current_quality:
                     api_url = self.bilibili_api(avid, cid, qn=qn)
                     api_content = get_content(api_url, headers=self.bilibili_headers(referer=self.url))
                     api_playinfo = json.loads(api_content)
-                    if api_playinfo['code'] == 0:  # success
+                    if api_playinfo.get('code') == 0:  # success
                         playinfos.append(api_playinfo)
                     else:
-                        message = api_playinfo['data']['message']
-                if best_quality is None or qn <= best_quality:
+                        api_data = api_playinfo.get('data') or {}
+                        message = api_playinfo.get('message') or api_data.get('message') or message
+                if (not requested_stream_id or not requested_stream_id.startswith('dash-')) and \
+                   (best_quality is None or qn <= best_quality):
                     api_url = self.bilibili_interface_api(cid, qn=qn)
                     api_content = get_content(api_url, headers=self.bilibili_headers(referer=self.url))
                     api_playinfo_data = json.loads(api_content)
@@ -292,39 +384,65 @@ class Bilibili(VideoExtractor):
                 self.streams['flv480'] = {'container': container, 'size': size, 'src': [url]}
                 return
 
+            audio_size_cache = {}
             for playinfo in playinfos:
-                quality = playinfo['data']['quality']
-                format_id = self.stream_qualities[quality]['id']
-                container = self.stream_qualities[quality]['container'].lower()
-                desc = self.stream_qualities[quality]['desc']
+                playinfo_data = playinfo.get('data') or {}
 
-                if 'durl' in playinfo['data']:
-                    src, size = [], 0
-                    for durl in playinfo['data']['durl']:
-                        src.append(durl['url'])
-                        size += durl['size']
-                    self.streams[format_id] = {'container': container, 'quality': desc, 'size': size, 'src': src}
+                if 'durl' in playinfo_data:
+                    quality = playinfo_data['quality']
+                    stream_quality = self.stream_qualities.get(quality)
+                    if stream_quality is not None:
+                        format_id = stream_quality['id']
+                        if not requested_stream_id or format_id == requested_stream_id:
+                            container = stream_quality['container'].lower()
+                            desc = stream_quality['desc']
+                            src, size = [], 0
+                            for durl in playinfo_data['durl']:
+                                src.append(durl['url'])
+                                size += durl['size']
+                            self.streams[format_id] = {
+                                'container': container,
+                                'quality': desc,
+                                'size': size,
+                                'src': src,
+                            }
 
                 # DASH formats
-                if 'dash' in playinfo['data']:
-                    audio_size_cache = {}
-                    for video in playinfo['data']['dash']['video']:
-                        s = self.stream_qualities[video['id']]
-                        format_id = f"dash-{s['id']}-{self.codecids[video['codecid']]}"  # prefix
+                if 'dash' in playinfo_data:
+                    dash = playinfo_data['dash']
+                    if not requested_stream_id or audio_only_requested:
+                        self.add_dash_audio_streams(
+                            dash,
+                            audio_size_cache,
+                            requested_stream_id=requested_stream_id,
+                        )
+                    audio_tracks = dash.get('audio') or []
+                    if audio_only_requested:
+                        continue
+                    for video in dash.get('video') or []:
+                        s = self.stream_qualities.get(video['id'])
+                        if s is None:
+                            continue
+                        codec = self.codecids.get(video.get('codecid'), str(video.get('codecid', 'unknown')))
+                        format_id = f"dash-{s['id']}-{codec}"  # prefix
+                        if requested_stream_id and format_id != requested_stream_id:
+                            continue
                         container = 'mp4'  # enforce MP4 container
                         desc = s['desc'] + ' ' + video['codecs']
                         audio_quality = s['audio_quality']
-                        baseurl = video['baseUrl']
+                        baseurl = video.get('baseUrl') or video.get('base_url')
+                        if not baseurl:
+                            continue
                         size = self.url_size(baseurl, headers=self.bilibili_headers(referer=self.url))
 
                         # find matching audio track
-                        if playinfo['data']['dash']['audio']:
-                            audio_baseurl = playinfo['data']['dash']['audio'][0]['baseUrl']
-                            for audio in playinfo['data']['dash']['audio']:
+                        if audio_tracks:
+                            audio_baseurl = audio_tracks[0].get('baseUrl') or audio_tracks[0].get('base_url')
+                            for audio in audio_tracks:
                                 if int(audio['id']) == audio_quality:
-                                    audio_baseurl = audio['baseUrl']
+                                    audio_baseurl = audio.get('baseUrl') or audio.get('base_url')
                                     break
-                            if not audio_size_cache.get(audio_quality, False):
+                            if audio_quality not in audio_size_cache:
                                 audio_size_cache[audio_quality] = self.url_size(audio_baseurl, headers=self.bilibili_headers(referer=self.url))
                             size += audio_size_cache[audio_quality]
 

--- a/tests/test_bilibili.py
+++ b/tests/test_bilibili.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+
+import copy
+import json
+import unittest
+from unittest.mock import patch
+
+from you_get.extractors import bilibili
+
+
+class TestBilibili(unittest.TestCase):
+    video_url = 'https://www.bilibili.com/video/BV1TestVideo/'
+
+    @staticmethod
+    def video_info(pages=None):
+        pages = pages or [
+            {'cid': 456, 'page': 1, 'part': 'Part 1', 'duration': 60},
+        ]
+        return {
+            'aid': 123,
+            'bvid': 'BV1TestVideo',
+            'title': 'API metadata title',
+            'videos': len(pages),
+            'pages': pages,
+        }
+
+    @staticmethod
+    def playinfo():
+        return {
+            'code': 0,
+            'message': '0',
+            'data': {
+                'quality': 112,
+                'accept_quality': [112, 80, 64, 32, 16],
+                'dash': {
+                    'video': [
+                        {
+                            'id': 112,
+                            'codecid': 7,
+                            'codecs': 'avc1.640032',
+                            'baseUrl': 'https://cdn.example/video-112.m4s',
+                        },
+                        {
+                            'id': 16,
+                            'codecid': 7,
+                            'codecs': 'avc1.64001e',
+                            'baseUrl': 'https://cdn.example/video-16.m4s',
+                        },
+                    ],
+                    'audio': [
+                        {
+                            'id': 30216,
+                            'bandwidth': 66147,
+                            'codecs': 'mp4a.40.2',
+                            'baseUrl': 'https://cdn.example/audio-30216.m4s',
+                        },
+                        {
+                            'id': 30280,
+                            'bandwidth': 200388,
+                            'codecs': 'mp4a.40.2',
+                            'baseUrl': 'https://cdn.example/audio-30280.m4s',
+                        },
+                        {
+                            'id': 30232,
+                            'bandwidth': 116896,
+                            'codecs': 'mp4a.40.2',
+                            'baseUrl': 'https://cdn.example/audio-30232.m4s',
+                        },
+                    ],
+                },
+            },
+        }
+
+    def make_get_content(self, video_info=None):
+        video_info = video_info or self.video_info()
+
+        def get_content(url, **kwargs):
+            if '/x/web-interface/view?' in url:
+                return json.dumps({'code': 0, 'message': 'OK', 'data': video_info})
+            if '/x/player/playurl?' in url:
+                return json.dumps(copy.deepcopy(self.playinfo()))
+            if '/x/player/wbi/v2?' in url:
+                return json.dumps({'code': -400, 'message': 'request error'})
+            if url.startswith('https://comment.bilibili.com/'):
+                return '<i></i>'
+            if url.startswith(self.video_url):
+                raise AssertionError('the standard video webpage must not be requested')
+            raise AssertionError('unexpected URL: %s' % url)
+
+        return get_content
+
+    @staticmethod
+    def url_size(url, **kwargs):
+        sizes = {
+            'https://cdn.example/video-112.m4s': 1000,
+            'https://cdn.example/video-16.m4s': 500,
+            'https://cdn.example/audio-30280.m4s': 300,
+            'https://cdn.example/audio-30232.m4s': 200,
+            'https://cdn.example/audio-30216.m4s': 100,
+        }
+        return sizes[url]
+
+    def test_standard_video_uses_api_and_exposes_audio_only_formats(self):
+        extractor = bilibili.Bilibili(self.video_url)
+        with patch.object(bilibili, 'get_content', side_effect=self.make_get_content()), \
+             patch.object(bilibili.common, 'cookies', object()), \
+             patch.object(bilibili.Bilibili, 'url_size', side_effect=self.url_size):
+            extractor.prepare()
+
+        self.assertEqual(extractor.title, 'API metadata title')
+        self.assertEqual(extractor.danmaku, '<i></i>')
+        self.assertEqual(
+            extractor.dash_streams['dash-hdflv2-AVC']['src'],
+            [
+                ['https://cdn.example/video-112.m4s'],
+                ['https://cdn.example/audio-30280.m4s'],
+            ],
+        )
+        self.assertEqual(
+            extractor.dash_streams['dash-flv360-AVC']['src'],
+            [
+                ['https://cdn.example/video-16.m4s'],
+                ['https://cdn.example/audio-30216.m4s'],
+            ],
+        )
+        self.assertEqual(extractor.streams['dash-audio-30280']['container'], 'm4a')
+        self.assertEqual(extractor.streams['dash-audio-30280']['size'], 300)
+        self.assertEqual(
+            extractor.streams['dash-audio-30280']['src'],
+            ['https://cdn.example/audio-30280.m4s'],
+        )
+        self.assertEqual(extractor.streams['dash-audio-30232']['size'], 200)
+        self.assertEqual(extractor.streams['dash-audio-30216']['size'], 100)
+
+    def test_requested_multipart_page_uses_api_page_cid(self):
+        pages = [
+            {'cid': 111, 'page': 1, 'part': 'First', 'duration': 60},
+            {'cid': 222, 'page': 2, 'part': 'Second', 'duration': 60},
+        ]
+        calls = []
+        get_content = self.make_get_content(self.video_info(pages))
+
+        def record_get_content(url, **kwargs):
+            calls.append(url)
+            return get_content(url, **kwargs)
+
+        extractor = bilibili.Bilibili(self.video_url + '?p=2')
+        with patch.object(bilibili, 'get_content', side_effect=record_get_content), \
+             patch.object(bilibili.common, 'cookies', object()), \
+             patch.object(bilibili.Bilibili, 'url_size', side_effect=self.url_size):
+            extractor.prepare()
+
+        self.assertEqual(extractor.title, 'API metadata title (P2. Second)')
+        playurl_calls = [url for url in calls if '/x/player/playurl?' in url]
+        self.assertTrue(playurl_calls)
+        self.assertTrue(all('cid=222' in url for url in playurl_calls))
+
+    def test_requested_audio_skips_unrelated_video_size_probes(self):
+        content_calls = []
+        size_calls = []
+        get_content = self.make_get_content()
+
+        def record_get_content(url, **kwargs):
+            content_calls.append(url)
+            return get_content(url, **kwargs)
+
+        def record_url_size(url, **kwargs):
+            size_calls.append(url)
+            return self.url_size(url, **kwargs)
+
+        extractor = bilibili.Bilibili(self.video_url)
+        with patch.object(bilibili, 'get_content', side_effect=record_get_content), \
+             patch.object(bilibili.common, 'cookies', object()), \
+             patch.object(bilibili.Bilibili, 'url_size', side_effect=record_url_size):
+            extractor.prepare(stream_id='dash-audio-30280')
+
+        playurl_calls = [url for url in content_calls if '/x/player/playurl?' in url]
+        interface_calls = [url for url in content_calls if '/x/player/wbi/v2?' in url]
+        self.assertEqual(len(playurl_calls), 1)
+        self.assertEqual(interface_calls, [])
+        self.assertEqual(size_calls, ['https://cdn.example/audio-30280.m4s'])
+        self.assertEqual(set(extractor.streams), {'dash-audio-30280'})
+        self.assertEqual(extractor.dash_streams, {})
+
+    def test_metadata_api_error_is_reported_without_none_json_crash(self):
+        response = json.dumps({'code': -404, 'message': 'not found', 'data': None})
+        extractor = bilibili.Bilibili(self.video_url)
+        with patch.object(bilibili, 'get_content', return_value=response):
+            with self.assertRaises(SystemExit) as raised:
+                extractor.prepare()
+        self.assertEqual(raised.exception.code, 1)
+
+    def test_video_url_helpers(self):
+        self.assertEqual(
+            bilibili.Bilibili.bilibili_view_api('av123'),
+            'https://api.bilibili.com/x/web-interface/view?aid=123',
+        )
+        self.assertEqual(
+            bilibili.Bilibili.bilibili_view_api('BV1AbCd'),
+            'https://api.bilibili.com/x/web-interface/view?bvid=BV1AbCd',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
 import unittest
+from unittest.mock import Mock, patch
 
+import you_get.common as common
 from you_get.common import *
 
 class TestCommon(unittest.TestCase):
@@ -9,3 +11,11 @@ class TestCommon(unittest.TestCase):
     def test_match1(self):
         self.assertEqual(match1('http://youtu.be/1234567890A', r'youtu.be/([^/]+)'), '1234567890A')
         self.assertEqual(match1('http://youtu.be/1234567890A', r'youtu.be/([^/]+)', r'youtu.(\w+)'), ['1234567890A', 'be'])
+
+    def test_url_size_passes_timeout_and_closes_response(self):
+        response = Mock()
+        response.headers = {'content-length': '123'}
+        with patch.object(common, 'urlopen_with_retry', return_value=response) as urlopen:
+            self.assertEqual(common.url_size('https://example.com/file', timeout=5), 123)
+        self.assertEqual(urlopen.call_args.kwargs, {'timeout': 5})
+        response.close.assert_called_once_with()

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import unittest
+from unittest.mock import patch
+
+from you_get.extractor import VideoExtractor
+
+
+class TestVideoExtractor(unittest.TestCase):
+    def test_m4a_container_is_preserved_for_audio_only_stream(self):
+        extractor = VideoExtractor('https://example.com/audio')
+        extractor.title = 'Audio only'
+        extractor.streams = {
+            'audio': {
+                'container': 'm4a',
+                'quality': 'audio',
+                'size': 123,
+                'src': ['https://cdn.example/audio.m4s'],
+            },
+        }
+        extractor.streams_sorted = [{'id': 'audio'}]
+
+        with patch.object(extractor, 'p'), \
+             patch('you_get.extractor.download_urls') as download_urls:
+            extractor.download(
+                stream_id='audio',
+                output_dir='.',
+                merge=True,
+                caption=False,
+                keep_obj=True,
+            )
+
+        self.assertEqual(download_urls.call_args.args[2], 'm4a')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

Ordinary Bilibili `av`/`BV` extraction relied on the page's embedded
`__INITIAL_STATE__`. The initial page request can now return HTTP 412, leaving
the state empty and eventually failing with:

```text
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```

This can be reproduced with:

```console
you-get -i https://www.bilibili.com/video/BV1nmRcBrEzv/
```

In addition, DASH audio tracks were only associated with video formats. They
could not be listed or selected directly with `-F`, and selecting an audio-only
format still triggered irrelevant video URL size probes.

## Changes

- Fetch metadata for ordinary `av`/`BV` videos from
  `/x/web-interface/view`, while preserving the existing bangumi and special
  URL flows.
- Validate Bilibili API responses, report useful errors, and select the correct
  `cid` for multipart videos.
- Use the current shared cookie state and a modern browser user agent for
  Bilibili requests.
- Expose DASH audio qualities `30280`, `30232`, and `30216` as standalone
  `dash-audio-*` formats and preserve their `.m4a` extension.
- Skip video size probes for explicitly selected audio-only formats, and bound
  and close HTTP size-probe requests.
- Add focused unit coverage for API metadata, multipart selection, API errors,
  cookie handling, audio stream selection, and extension handling.

## Tests

```console
PYTHONPATH=src uv run --with dukpy python -m unittest discover -s tests -p 'test_bilibili.py'
PYTHONPATH=src uv run --with dukpy python -m unittest discover -s tests -p 'test_common.py'
PYTHONPATH=src uv run --with dukpy python -m unittest discover -s tests -p 'test_extractor.py'
uvx flake8 src tests --count --select=E9,F63,F7,F82 --ignore=F824 --show-source --statistics
uv build
```

The related unit tests pass (8 tests), the fatal flake8 check reports 0 errors,
and both the sdist and wheel build successfully. Live checks also confirmed that
format listing works for the reproducer and that a selected `dash-audio-*`
format downloads as an audio-only M4A file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/3057)
<!-- Reviewable:end -->
