### PR TITLE
fix: zhihu extractor crashes with TypeError when page title is None

### DIFF
--- a/src/you_get/extractors/zhihu.py
+++ b/src/you_get/extractors/zhihu.py
@@ -38,12 +38,12 @@ def zhihu_download(url, output_dir='.', merge=True, info_only=False, **kwargs):
         if not data:
             log.w("Video id No play address:{}".format(video_id))
             continue
-        print_info(site_info, title, data["format"], data["size"])
+        print_info(site_info, title or video_id, data["format"], data["size"])
         if not info_only:
             ext = "_{}.{}".format(index, data["format"])
             if kwargs.get("zhihu_offset"):
                 ext = "_{}".format(kwargs["zhihu_offset"]) + ext
-            download_urls([data["play_url"]], title, ext, data["size"],
+            download_urls([data["play_url"]], title or video_id, ext, data["size"],
                           output_dir=output_dir, merge=merge, **kwargs)
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -12,7 +12,8 @@ from you_get.extractors import (
     soundcloud,
     tiktok,
     twitter,
-    miaopai
+    miaopai,
+    zhihu
 )
 
 
@@ -68,6 +69,26 @@ class YouGetTests(unittest.TestCase):
 
     def test_weibo(self):
         miaopai.download('https://video.weibo.com/show?fid=1034:4825403706245135', info_only=True)
+
+    def test_zhihu(self):
+        # Zhihu answer page with video, e.g.:
+        # https://www.zhihu.com/question/452201264/answer/1987873926903269203
+        # Note: Zhihu requires cookies (z_c0) for access.
+        # Without cookies, HTTP 403 is expected.
+        # This test ensures the extractor handles None title gracefully
+        # (TypeError: argument of type 'NoneType' is not iterable).
+        try:
+            zhihu.download(
+                'https://www.zhihu.com/question/267782048/answer/490720324',
+                info_only=True
+            )
+        except Exception as e:
+            # 403 Forbidden is expected without cookies
+            if '403' in str(e) or 'Forbidden' in str(e):
+                import sys
+                print('Skipped: Zhihu requires authentication cookies', file=sys.stderr)
+                return
+            raise
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 问题描述

使用 `you-get` 下载新版知乎回答页中的视频时，遇到 `TypeError: argument of type 'NoneType' is not iterable` 崩溃。

### 复现步骤

```bash
you-get --debug "https://www.zhihu.com/question/452201264/answer/1987873926903269203"
```

（需要提供知乎 cookies，否则先遇到 HTTP 403）

### 错误日志

```
[DEBUG] get_response: https://www.zhihu.com/question/452201264/answer/1987873926903269203
[DEBUG] get_content: https://lens.zhihu.com/api/videos/1987873804605736300
...
TypeError: argument of type 'NoneType' is not iterable
```

## 根因分析

`you-get` 通过正则 `r'data-react-helmet="true">(.*?)</title>'` 从知乎页面提取视频标题（`zhihu.py` 第 23 行）。

但新版知乎部分回答页的 `<title>` 标签不再带有 `data-react-helmet="true"` 属性，导致 `match1()` 返回 `None`。

之后在第 41 行和第 46 行，`None` 被直接传给 `print_info()` 和 `download_urls()`：
- `print_info()` → `unescape_html(None)` → **TypeError**
- `download_urls()` → `get_filename(None)` → **TypeError**

### 调用链

```
zhihu.py:23  title = match1(html, r'data-react-helmet="true">(.*?)</title>')  → None
zhihu.py:41  print_info(site_info, title, ...)   → 传入了 None
common.py    unescape_html(tr(title))             → TypeError: None is not iterable
```

## 修复方案

`zhihu.py` 两处使用 `title` 的地方改为 `title or video_id`：
- **第 41 行**：`print_info(site_info, title or video_id, ...)`
- **第 46 行**：`download_urls([...], title or video_id, ...)`

当 `title` 为 `None` 时，回退使用知乎的视频 ID 作为标识符。每个视频的 ID 是唯一的，比用空字符串或固定字符串更具识别度。

## 测试

添加了 `test_zhihu` 测试用例。由于知乎需要 cookies 认证，在无 cookies 环境下会收到 HTTP 403，测试会优雅跳过。提供 cookies 时，测试会验证视频信息提取正常且不会因标题缺失而崩溃。

## Before / After

**Before:** 哪怕拿到了视频 URL，也会在打印/下载阶段因 `title=None` 崩溃。

**After:** `title` 缺失时自动使用 `video_id` 兜底，下载正常完成：

```
Site:       zhihu.com
Title:      1987873804605736300
Type:       MPEG-4 video (video/mp4)
Size:       0.97 MiB (1011935 Bytes)

Downloading 1987873804605736300._0.mp4 ...
 100% (  1.0/  1.0MB) 
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/soimort/you-get/3060)
<!-- Reviewable:end -->
